### PR TITLE
feat: add validation utilities for subscription and gift card inputs

### DIFF
--- a/client/lib/client-validators.ts
+++ b/client/lib/client-validators.ts
@@ -1,0 +1,200 @@
+/**
+ * Client-Side Validation Utilities
+ *
+ * Zod-based validators that run BEFORE any API request from the client layer,
+ * ensuring invalid payloads never reach the backend. These complement the
+ * existing `validateSubscriptionData` form-level validation in `validation.ts`
+ * and provide stricter, schema-based validation at the service boundary.
+ */
+
+import { z } from "zod";
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+const VALID_STATUSES = ["active", "paused", "cancelled", "expired", "expiring"] as const;
+
+const VALID_BILLING_CYCLES = [
+    "monthly",
+    "quarterly",
+    "semi-annual",
+    "annual",
+    "lifetime",
+] as const;
+
+const VALID_PRICING_TYPES = ["fixed", "usage", "tiered"] as const;
+
+const MAX_NAME_LENGTH = 100;
+const MAX_PRICE = 10_000;
+const MAX_RENEWS_IN_DAYS = 365;
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+const GIFT_CARD_HASH_REGEX = /^[0-9a-f]{64}$/;
+
+// ─── Zod Schemas ─────────────────────────────────────────────────────
+
+export const SubscriptionCreateSchema = z.object({
+    name: z
+        .string({ required_error: "Subscription name is required." })
+        .min(1, "Subscription name must not be empty.")
+        .max(MAX_NAME_LENGTH, `Subscription name must be at most ${MAX_NAME_LENGTH} characters.`),
+
+    category: z
+        .string({ required_error: "Category is required." })
+        .min(1, "Category must not be empty."),
+
+    price: z
+        .number({
+            required_error: "Price is required.",
+            invalid_type_error: "Price must be a number.",
+        })
+        .positive("Price must be greater than 0.")
+        .max(MAX_PRICE, `Price must not exceed $${MAX_PRICE.toLocaleString()}.`),
+
+    status: z.enum(VALID_STATUSES).optional().default("active"),
+
+    billing_cycle: z.enum(VALID_BILLING_CYCLES).optional().default("monthly"),
+
+    renews_in: z
+        .number()
+        .int("Renewal days must be a whole number.")
+        .min(0, "Renewal days must be 0 or greater.")
+        .max(MAX_RENEWS_IN_DAYS, `Renewal days must not exceed ${MAX_RENEWS_IN_DAYS}.`)
+        .nullable()
+        .optional(),
+
+    // Also accept camelCase from client forms
+    renewsIn: z
+        .number()
+        .int("Renewal days must be a whole number.")
+        .min(0, "Renewal days must be 0 or greater.")
+        .max(MAX_RENEWS_IN_DAYS, `Renewal days must not exceed ${MAX_RENEWS_IN_DAYS}.`)
+        .optional(),
+
+    icon: z.string().optional().default("🔗"),
+
+    color: z
+        .string()
+        .regex(HEX_COLOR_REGEX, "Color must be a valid hex code (e.g. #FF5733).")
+        .optional()
+        .default("#000000"),
+
+    renewal_url: z.string().url("Renewal URL must be a valid URL.").nullable().optional(),
+    renewalUrl: z.string().url("Renewal URL must be a valid URL.").nullable().optional(),
+
+    tags: z
+        .array(
+            z.string().min(1, "Tag must not be empty.").max(MAX_TAG_LENGTH, `Tag must be at most ${MAX_TAG_LENGTH} characters.`)
+        )
+        .max(MAX_TAGS, `A maximum of ${MAX_TAGS} tags is allowed.`)
+        .optional()
+        .default([]),
+
+    pricing_type: z.enum(VALID_PRICING_TYPES).optional().default("fixed"),
+    pricingType: z.enum(VALID_PRICING_TYPES).optional(),
+
+    is_trial: z.boolean().optional().default(false),
+    isTrial: z.boolean().optional(),
+
+    trial_ends_at: z.string().datetime("trial_ends_at must be a valid ISO 8601 datetime.").nullable().optional(),
+    trialEndsAt: z.string().datetime("trialEndsAt must be a valid ISO 8601 datetime.").nullable().optional(),
+
+    price_after_trial: z
+        .number()
+        .positive("Price after trial must be greater than 0.")
+        .max(MAX_PRICE, `Price after trial must not exceed $${MAX_PRICE.toLocaleString()}.`)
+        .nullable()
+        .optional(),
+    priceAfterTrial: z
+        .number()
+        .positive("Price after trial must be greater than 0.")
+        .nullable()
+        .optional(),
+
+    userId: z.string().optional(),
+    billingCycle: z.enum(VALID_BILLING_CYCLES).optional(),
+}).passthrough(); // Allow additional fields to pass through for flexibility
+
+export const SubscriptionUpdateSchema = SubscriptionCreateSchema.partial().refine(
+    (data) => Object.keys(data).length > 0,
+    { message: "At least one field must be provided for update." }
+);
+
+export const GiftCardHashSchema = z
+    .string({
+        required_error: "Gift card hash is required.",
+        invalid_type_error: "Gift card hash must be a string.",
+    })
+    .min(1, "Gift card hash must not be empty.")
+    .length(64, "Gift card hash must be exactly 64 characters (SHA-256).")
+    .regex(GIFT_CARD_HASH_REGEX, "Gift card hash must be a lowercase hexadecimal string.");
+
+// ─── Public Validation Functions ─────────────────────────────────────
+
+/**
+ * Validate subscription creation payload before network call.
+ * @throws {Error} with descriptive message listing all validation failures.
+ */
+export function validateSubscriptionCreateInput(input: unknown): z.infer<typeof SubscriptionCreateSchema> {
+    if (input === null || input === undefined) {
+        throw new Error("Validation failed: Subscription create payload must be a non-null object.");
+    }
+    if (typeof input !== "object" || Array.isArray(input)) {
+        throw new Error("Validation failed: Subscription create payload must be a plain object.");
+    }
+
+    const result = SubscriptionCreateSchema.safeParse(input);
+    if (!result.success) {
+        const messages = result.error.issues.map(
+            (issue) => `${issue.path.join(".")}: ${issue.message}`
+        );
+        throw new Error(`Validation failed: ${messages.join(" | ")}`);
+    }
+    return result.data;
+}
+
+/**
+ * Validate subscription update payload before network call.
+ * @throws {Error} with descriptive message listing all validation failures.
+ */
+export function validateSubscriptionUpdateInput(input: unknown): z.infer<typeof SubscriptionUpdateSchema> {
+    if (input === null || input === undefined) {
+        throw new Error("Validation failed: Subscription update payload must be a non-null object.");
+    }
+    if (typeof input !== "object" || Array.isArray(input)) {
+        throw new Error("Validation failed: Subscription update payload must be a plain object.");
+    }
+    if (Object.keys(input as object).length === 0) {
+        throw new Error("Validation failed: At least one field must be provided for update.");
+    }
+
+    const result = SubscriptionUpdateSchema.safeParse(input);
+    if (!result.success) {
+        const messages = result.error.issues.map(
+            (issue) => issue.path.length > 0 ? `${issue.path.join(".")}: ${issue.message}` : issue.message
+        );
+        throw new Error(`Validation failed: ${messages.join(" | ")}`);
+    }
+    return result.data;
+}
+
+/**
+ * Validate a gift card hash (SHA-256 hex digest) before network call.
+ * @throws {Error} with descriptive message if validation fails.
+ */
+export function validateGiftCardHash(input: unknown): string {
+    if (input === null || input === undefined) {
+        throw new Error("Validation failed: Gift card hash is required.");
+    }
+    if (typeof input !== "string") {
+        throw new Error("Validation failed: Gift card hash must be a string.");
+    }
+
+    const result = GiftCardHashSchema.safeParse(input);
+    if (!result.success) {
+        const messages = result.error.issues.map((issue) => issue.message);
+        throw new Error(`Validation failed: ${messages.join(" | ")}`);
+    }
+    return result.data;
+}

--- a/client/lib/subscription-service.ts
+++ b/client/lib/subscription-service.ts
@@ -12,6 +12,10 @@ export interface Subscription {
 }
 
 import { apiGet, apiPost, apiDelete, apiPatch } from "./api";
+import {
+  validateSubscriptionCreateInput,
+  validateSubscriptionUpdateInput,
+} from "./client-validators";
 
 export class SubscriptionService {
   async getSubscriptions(userId: string): Promise<Subscription[]> {
@@ -22,6 +26,8 @@ export class SubscriptionService {
   async createSubscription(
     subscription: Omit<Subscription, "id" | "createdAt">
   ): Promise<Subscription> {
+    // Fail fast: validate before network call
+    validateSubscriptionCreateInput(subscription);
     const data = await apiPost("/api/subscriptions", subscription);
     return data.subscription;
   }
@@ -34,6 +40,8 @@ export class SubscriptionService {
     id: number,
     updates: Partial<Subscription>
   ): Promise<Subscription> {
+    // Fail fast: validate before network call
+    validateSubscriptionUpdateInput(updates);
     const data = await apiPatch(`/api/subscriptions/${id}`, updates);
     return data.subscription;
   }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,14 +5,15 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "axios": "^1.13.5",
-    "events": "^3.3.0"
+    "events": "^3.3.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,11 @@
 import axios, { type AxiosInstance } from "axios";
 import { EventEmitter } from "node:events";
 import type { GiftCardEvent, GiftCardEventType } from "./types";
+import {
+  validateSubscriptionCreateInput,
+  validateSubscriptionUpdateInput,
+  validateGiftCardHash,
+} from "./validators.js";
 
 export interface Subscription {
   id: string;
@@ -225,6 +230,86 @@ export class SyncroSDK extends EventEmitter {
     }
     return null;
   }
+
+  /**
+   * Create a subscription with pre-flight validation.
+   * Invalid payloads are rejected before any network request.
+   */
+  async createSubscription(
+    input: unknown,
+  ): Promise<Subscription> {
+    const validated = validateSubscriptionCreateInput(input);
+
+    this.emit("creating", validated);
+
+    const response = await this.client.post("/subscriptions", validated);
+    const subscription = this.normalizeSubscription(response.data.data);
+
+    this.emit("created", subscription);
+    return subscription;
+  }
+
+  /**
+   * Update a subscription with pre-flight validation.
+   * Invalid payloads are rejected before any network request.
+   */
+  async updateSubscription(
+    subscriptionId: string,
+    input: unknown,
+  ): Promise<Subscription> {
+    if (!subscriptionId || typeof subscriptionId !== "string") {
+      throw new Error("Validation failed: subscriptionId must be a non-empty string.");
+    }
+
+    const validated = validateSubscriptionUpdateInput(input);
+
+    this.emit("updating", { subscriptionId, updates: validated });
+
+    const response = await this.client.patch(
+      `/subscriptions/${subscriptionId}`,
+      validated,
+    );
+    const subscription = this.normalizeSubscription(response.data.data);
+
+    this.emit("updated", subscription);
+    return subscription;
+  }
+
+  /**
+   * Attach a gift card to a subscription with hash validation.
+   * Invalid hashes are rejected before any network request.
+   */
+  async attachGiftCard(
+    subscriptionId: string,
+    giftCardHash: unknown,
+    provider?: string,
+  ): Promise<GiftCardEvent> {
+    if (!subscriptionId || typeof subscriptionId !== "string") {
+      throw new Error("Validation failed: subscriptionId must be a non-empty string.");
+    }
+
+    const validatedHash = validateGiftCardHash(giftCardHash);
+
+    const payload = { giftCardHash: validatedHash, provider };
+
+    this.emit("giftcard:attaching", { subscriptionId, ...payload });
+
+    const response = await this.client.post(
+      `/subscriptions/${subscriptionId}/giftcard`,
+      payload,
+    );
+
+    const event: GiftCardEvent = {
+      type: "attached",
+      subscriptionId,
+      giftCardHash: validatedHash,
+      provider,
+      data: response.data.data,
+    };
+
+    this.emit("giftcard:attached", event);
+    return event;
+  }
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -327,3 +412,16 @@ export function init(config: SyncroSDKInitConfig): SyncroSDK {
 
 export default SyncroSDK;
 export type { GiftCardEvent, GiftCardEventType } from "./types";
+export {
+  validateSubscriptionCreateInput,
+  validateSubscriptionUpdateInput,
+  validateGiftCardHash,
+  SubscriptionCreateSchema,
+  SubscriptionUpdateSchema,
+  GiftCardHashSchema,
+} from "./validators.js";
+export type {
+  ValidationResult,
+  ValidationSuccess,
+  ValidationFailure,
+} from "./validators.js";

--- a/sdk/src/validators.test.ts
+++ b/sdk/src/validators.test.ts
@@ -1,0 +1,583 @@
+import { describe, it, expect } from "@jest/globals";
+
+// Dynamic import is required for ESM compatibility with ts-jest preset
+const {
+    validateSubscriptionCreateInput,
+    validateSubscriptionUpdateInput,
+    validateGiftCardHash,
+} = await import("./validators.js");
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Shorthand: assert a function call throws with a specific message substring. */
+function expectThrow(fn: () => unknown, messageSubstring: string) {
+    expect(fn).toThrow(messageSubstring);
+}
+
+/** A valid SHA-256 hex hash (64 lowercase hex chars). */
+const VALID_HASH =
+    "a3f1b2c4d5e6f7890123456789abcdef0123456789abcdef0123456789abcdef";
+
+// ─── validateSubscriptionCreateInput ─────────────────────────────────
+
+describe("validateSubscriptionCreateInput", () => {
+    const validPayload = {
+        name: "Netflix",
+        category: "Streaming",
+        price: 15.99,
+    };
+
+    // ── Success paths ──────────────────────────────────────────────────
+
+    it("accepts a valid minimal payload and fills defaults", () => {
+        const result = validateSubscriptionCreateInput(validPayload);
+        expect(result.name).toBe("Netflix");
+        expect(result.category).toBe("Streaming");
+        expect(result.price).toBe(15.99);
+        expect(result.status).toBe("active");
+        expect(result.billing_cycle).toBe("monthly");
+        expect(result.icon).toBe("🔗");
+        expect(result.color).toBe("#000000");
+        expect(result.tags).toEqual([]);
+        expect(result.pricing_type).toBe("fixed");
+        expect(result.is_trial).toBe(false);
+    });
+
+    it("accepts a fully populated payload", () => {
+        const full = {
+            name: "Spotify Premium",
+            category: "Music",
+            price: 9.99,
+            status: "active" as const,
+            billing_cycle: "monthly" as const,
+            renews_in: 30,
+            icon: "🎵",
+            color: "#1DB954",
+            renewal_url: "https://spotify.com/account",
+            tags: ["music", "entertainment"],
+            pricing_type: "fixed" as const,
+            is_trial: true,
+            trial_ends_at: "2026-03-15T00:00:00Z",
+            price_after_trial: 12.99,
+        };
+        const result = validateSubscriptionCreateInput(full);
+        expect(result.name).toBe("Spotify Premium");
+        expect(result.is_trial).toBe(true);
+        expect(result.price_after_trial).toBe(12.99);
+    });
+
+    // ── Null / undefined / non-object ──────────────────────────────────
+
+    it("throws when input is null", () => {
+        expectThrow(
+            () => validateSubscriptionCreateInput(null),
+            "non-null object",
+        );
+    });
+
+    it("throws when input is undefined", () => {
+        expectThrow(
+            () => validateSubscriptionCreateInput(undefined),
+            "non-null object",
+        );
+    });
+
+    it("throws when input is a string", () => {
+        expectThrow(
+            () => validateSubscriptionCreateInput("hello"),
+            "plain object",
+        );
+    });
+
+    it("throws when input is an array", () => {
+        expectThrow(
+            () => validateSubscriptionCreateInput([]),
+            "plain object",
+        );
+    });
+
+    it("throws when input is a number", () => {
+        expectThrow(
+            () => validateSubscriptionCreateInput(42),
+            "plain object",
+        );
+    });
+
+    // ── Name validation ────────────────────────────────────────────────
+
+    it("throws when name is missing", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({ category: "A", price: 10 }),
+            "name",
+        );
+    });
+
+    it("throws when name is empty string", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "",
+                    category: "A",
+                    price: 10,
+                }),
+            "must not be empty",
+        );
+    });
+
+    it("throws when name exceeds 100 characters", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "x".repeat(101),
+                    category: "A",
+                    price: 10,
+                }),
+            "at most 100",
+        );
+    });
+
+    // ── Category validation ────────────────────────────────────────────
+
+    it("throws when category is missing", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({ name: "Netflix", price: 10 }),
+            "category",
+        );
+    });
+
+    it("throws when category is empty string", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "",
+                    price: 10,
+                }),
+            "must not be empty",
+        );
+    });
+
+    // ── Price validation ───────────────────────────────────────────────
+
+    it("throws when price is missing", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "Streaming",
+                }),
+            "price",
+        );
+    });
+
+    it("throws when price is zero", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "Streaming",
+                    price: 0,
+                }),
+            "greater than 0",
+        );
+    });
+
+    it("throws when price is negative", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "Streaming",
+                    price: -5,
+                }),
+            "greater than 0",
+        );
+    });
+
+    it("throws when price exceeds $10,000", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "Streaming",
+                    price: 10_001,
+                }),
+            "10,000",
+        );
+    });
+
+    it("throws when price is not a number", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    name: "Netflix",
+                    category: "Streaming",
+                    price: "free",
+                }),
+            "Invalid input",
+        );
+    });
+
+    // ── Status validation ──────────────────────────────────────────────
+
+    it("throws when status is invalid", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    status: "bogus",
+                }),
+            "Invalid option",
+        );
+    });
+
+    // ── Billing cycle validation ───────────────────────────────────────
+
+    it("throws when billing_cycle is invalid", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    billing_cycle: "bi-weekly",
+                }),
+            "Invalid option",
+        );
+    });
+
+    // ── Color validation ───────────────────────────────────────────────
+
+    it("throws when color is not a valid hex code", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    color: "red",
+                }),
+            "valid hex code",
+        );
+    });
+
+    it("throws for hex color with wrong length", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    color: "#FFF",
+                }),
+            "valid hex code",
+        );
+    });
+
+    // ── URL validation ─────────────────────────────────────────────────
+
+    it("throws when renewal_url is not a valid URL", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    renewal_url: "not-a-url",
+                }),
+            "valid URL",
+        );
+    });
+
+    // ── Tags validation ────────────────────────────────────────────────
+
+    it("throws when tags contains an empty string", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    tags: ["valid", ""],
+                }),
+            "must not be empty",
+        );
+    });
+
+    it("throws when tags exceed max count (20)", () => {
+        const manyTags = Array.from({ length: 21 }, (_, i) => `tag${i}`);
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    tags: manyTags,
+                }),
+            "maximum of 20",
+        );
+    });
+
+    it("throws when a tag exceeds 50 characters", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    tags: ["x".repeat(51)],
+                }),
+            "at most 50",
+        );
+    });
+
+    // ── Renewal days validation ────────────────────────────────────────
+
+    it("throws when renews_in is negative", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    renews_in: -1,
+                }),
+            "0 or greater",
+        );
+    });
+
+    it("throws when renews_in exceeds 365", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    renews_in: 366,
+                }),
+            "365",
+        );
+    });
+
+    it("throws when renews_in is a float", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    renews_in: 10.5,
+                }),
+            "whole number",
+        );
+    });
+
+    // ── Trial fields validation ────────────────────────────────────────
+
+    it("throws when trial_ends_at is not a valid datetime", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    trial_ends_at: "next-tuesday",
+                }),
+            "ISO 8601",
+        );
+    });
+
+    it("throws when price_after_trial is zero", () => {
+        expectThrow(
+            () =>
+                validateSubscriptionCreateInput({
+                    ...validPayload,
+                    price_after_trial: 0,
+                }),
+            "greater than 0",
+        );
+    });
+
+    // ── Multiple-error aggregation ─────────────────────────────────────
+
+    it("aggregates multiple errors separated by ' | '", () => {
+        try {
+            validateSubscriptionCreateInput({});
+            throw new Error("Should have thrown");
+        } catch (e: any) {
+            expect(e.message).toContain("|");
+            expect(e.message).toContain("name");
+            expect(e.message).toContain("category");
+            expect(e.message).toContain("price");
+        }
+    });
+});
+
+// ─── validateSubscriptionUpdateInput ─────────────────────────────────
+
+describe("validateSubscriptionUpdateInput", () => {
+    // ── Success paths ──────────────────────────────────────────────────
+
+    it("accepts a single valid field update", () => {
+        const result = validateSubscriptionUpdateInput({ price: 19.99 });
+        expect(result.price).toBe(19.99);
+    });
+
+    it("accepts multiple valid field updates", () => {
+        const result = validateSubscriptionUpdateInput({
+            name: "Netflix Premium",
+            status: "paused",
+        });
+        expect(result.name).toBe("Netflix Premium");
+        expect(result.status).toBe("paused");
+    });
+
+    // ── Null / undefined / non-object ──────────────────────────────────
+
+    it("throws when input is null", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput(null),
+            "non-null object",
+        );
+    });
+
+    it("throws when input is undefined", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput(undefined),
+            "non-null object",
+        );
+    });
+
+    it("throws when input is a string", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput("hello"),
+            "plain object",
+        );
+    });
+
+    it("throws when input is an array", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput([]),
+            "plain object",
+        );
+    });
+
+    // ── Empty object ───────────────────────────────────────────────────
+
+    it("throws when input is an empty object", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({}),
+            "At least one field",
+        );
+    });
+
+    // ── Invalid field values ───────────────────────────────────────────
+
+    it("throws when name is empty string on update", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({ name: "" }),
+            "must not be empty",
+        );
+    });
+
+    it("throws when price is negative on update", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({ price: -10 }),
+            "greater than 0",
+        );
+    });
+
+    it("throws when status is invalid on update", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({ status: "destroyed" }),
+            "Invalid option",
+        );
+    });
+
+    it("throws when color is invalid on update", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({ color: "purple" }),
+            "valid hex code",
+        );
+    });
+
+    it("throws when renewal_url is invalid on update", () => {
+        expectThrow(
+            () => validateSubscriptionUpdateInput({ renewal_url: "bad" }),
+            "valid URL",
+        );
+    });
+});
+
+// ─── validateGiftCardHash ────────────────────────────────────────────
+
+describe("validateGiftCardHash", () => {
+    // ── Success path ───────────────────────────────────────────────────
+
+    it("accepts a valid 64-char lowercase hex hash", () => {
+        const result = validateGiftCardHash(VALID_HASH);
+        expect(result).toBe(VALID_HASH);
+    });
+
+    // ── Null / undefined ───────────────────────────────────────────────
+
+    it("throws when input is null", () => {
+        expectThrow(() => validateGiftCardHash(null), "required");
+    });
+
+    it("throws when input is undefined", () => {
+        expectThrow(() => validateGiftCardHash(undefined), "required");
+    });
+
+    // ── Non-string types ───────────────────────────────────────────────
+
+    it("throws when input is a number", () => {
+        expectThrow(() => validateGiftCardHash(42), "must be a string");
+    });
+
+    it("throws when input is a boolean", () => {
+        expectThrow(() => validateGiftCardHash(true), "must be a string");
+    });
+
+    it("throws when input is an object", () => {
+        expectThrow(() => validateGiftCardHash({}), "must be a string");
+    });
+
+    it("throws when input is an array", () => {
+        expectThrow(() => validateGiftCardHash([]), "must be a string");
+    });
+
+    // ── Empty string ───────────────────────────────────────────────────
+
+    it("throws when input is empty string", () => {
+        expectThrow(() => validateGiftCardHash(""), "must not be empty");
+    });
+
+    // ── Wrong length ───────────────────────────────────────────────────
+
+    it("throws when hash is too short (63 chars)", () => {
+        expectThrow(
+            () => validateGiftCardHash(VALID_HASH.slice(0, 63)),
+            "exactly 64 characters",
+        );
+    });
+
+    it("throws when hash is too long (65 chars)", () => {
+        expectThrow(
+            () => validateGiftCardHash(VALID_HASH + "a"),
+            "exactly 64 characters",
+        );
+    });
+
+    // ── Invalid characters ─────────────────────────────────────────────
+
+    it("throws when hash contains uppercase letters", () => {
+        const upper = VALID_HASH.slice(0, 63) + "A";
+        expectThrow(
+            () => validateGiftCardHash(upper),
+            "lowercase hexadecimal",
+        );
+    });
+
+    it("throws when hash contains non-hex characters", () => {
+        const bad = VALID_HASH.slice(0, 63) + "g";
+        expectThrow(
+            () => validateGiftCardHash(bad),
+            "lowercase hexadecimal",
+        );
+    });
+
+    it("throws when hash contains spaces", () => {
+        const spaced = " " + VALID_HASH.slice(1);
+        expectThrow(() => validateGiftCardHash(spaced), "lowercase hexadecimal");
+    });
+
+    // ── Partial hash ───────────────────────────────────────────────────
+
+    it("throws for a 32-char hex string (MD5 length)", () => {
+        expectThrow(
+            () => validateGiftCardHash("a".repeat(32)),
+            "exactly 64 characters",
+        );
+    });
+});

--- a/sdk/src/validators.ts
+++ b/sdk/src/validators.ts
@@ -1,0 +1,311 @@
+/**
+ * SDK Input Validators
+ *
+ * Zod-based validation utilities that run BEFORE any Axios request,
+ * ensuring invalid payloads never reach the backend (fail-fast).
+ */
+
+import { z } from "zod";
+
+// ─── Shared Constants ────────────────────────────────────────────────
+
+const VALID_STATUSES = ["active", "paused", "cancelled", "expired"] as const;
+
+const VALID_BILLING_CYCLES = [
+    "monthly",
+    "quarterly",
+    "semi-annual",
+    "annual",
+    "lifetime",
+] as const;
+
+const VALID_PRICING_TYPES = ["fixed", "usage", "tiered"] as const;
+
+const MAX_NAME_LENGTH = 100;
+const MAX_PRICE = 10_000;
+const MAX_RENEWS_IN_DAYS = 365;
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
+/**
+ * Hex colour: 7-char string starting with #, followed by exactly 6 hex digits.
+ */
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Gift-card hash: 64-character lowercase hex string (SHA-256 digest).
+ */
+const GIFT_CARD_HASH_REGEX = /^[0-9a-f]{64}$/;
+
+// ─── Zod Schemas ─────────────────────────────────────────────────────
+
+/**
+ * Schema for creating a new subscription.
+ * All required fields are enforced; optional fields have sensible defaults.
+ */
+export const SubscriptionCreateSchema = z.object({
+    name: z
+        .string({ required_error: "Subscription name is required." })
+        .min(1, "Subscription name must not be empty.")
+        .max(
+            MAX_NAME_LENGTH,
+            `Subscription name must be at most ${MAX_NAME_LENGTH} characters.`,
+        ),
+
+    category: z
+        .string({ required_error: "Category is required." })
+        .min(1, "Category must not be empty."),
+
+    price: z
+        .number({
+            required_error: "Price is required.",
+            invalid_type_error: "Price must be a number.",
+        })
+        .positive("Price must be greater than 0.")
+        .max(MAX_PRICE, `Price must not exceed $${MAX_PRICE.toLocaleString()}.`),
+
+    status: z
+        .enum(VALID_STATUSES, {
+            errorMap: () => ({
+                message: `Status must be one of: ${VALID_STATUSES.join(", ")}.`,
+            }),
+        })
+        .default("active"),
+
+    billing_cycle: z
+        .enum(VALID_BILLING_CYCLES, {
+            errorMap: () => ({
+                message: `Billing cycle must be one of: ${VALID_BILLING_CYCLES.join(", ")}.`,
+            }),
+        })
+        .default("monthly"),
+
+    renews_in: z
+        .number()
+        .int("Renewal days must be a whole number.")
+        .min(0, "Renewal days must be 0 or greater.")
+        .max(
+            MAX_RENEWS_IN_DAYS,
+            `Renewal days must not exceed ${MAX_RENEWS_IN_DAYS}.`,
+        )
+        .nullable()
+        .optional(),
+
+    icon: z.string().optional().default("🔗"),
+
+    color: z
+        .string()
+        .regex(HEX_COLOR_REGEX, "Color must be a valid hex code (e.g. #FF5733).")
+        .optional()
+        .default("#000000"),
+
+    renewal_url: z
+        .string()
+        .url("Renewal URL must be a valid URL.")
+        .nullable()
+        .optional(),
+
+    tags: z
+        .array(
+            z
+                .string()
+                .min(1, "Tag must not be empty.")
+                .max(MAX_TAG_LENGTH, `Tag must be at most ${MAX_TAG_LENGTH} characters.`),
+        )
+        .max(MAX_TAGS, `A maximum of ${MAX_TAGS} tags is allowed.`)
+        .optional()
+        .default([]),
+
+    pricing_type: z
+        .enum(VALID_PRICING_TYPES, {
+            errorMap: () => ({
+                message: `Pricing type must be one of: ${VALID_PRICING_TYPES.join(", ")}.`,
+            }),
+        })
+        .optional()
+        .default("fixed"),
+
+    is_trial: z.boolean().optional().default(false),
+
+    trial_ends_at: z
+        .string()
+        .datetime("trial_ends_at must be a valid ISO 8601 datetime.")
+        .nullable()
+        .optional(),
+
+    price_after_trial: z
+        .number()
+        .positive("Price after trial must be greater than 0.")
+        .max(
+            MAX_PRICE,
+            `Price after trial must not exceed $${MAX_PRICE.toLocaleString()}.`,
+        )
+        .nullable()
+        .optional(),
+});
+
+/**
+ * Schema for updating an existing subscription.
+ * All fields are optional — at least one must be present.
+ */
+export const SubscriptionUpdateSchema = SubscriptionCreateSchema.partial()
+    .refine(
+        (data) => Object.keys(data).length > 0,
+        { message: "At least one field must be provided for update." },
+    );
+
+/**
+ * Schema for a gift-card hash (SHA-256 hex digest).
+ */
+export const GiftCardHashSchema = z
+    .string({
+        required_error: "Gift card hash is required.",
+        invalid_type_error: "Gift card hash must be a string.",
+    })
+    .min(1, "Gift card hash must not be empty.")
+    .length(64, "Gift card hash must be exactly 64 characters (SHA-256).")
+    .regex(
+        GIFT_CARD_HASH_REGEX,
+        "Gift card hash must be a lowercase hexadecimal string.",
+    );
+
+// ─── Validation Result Types ─────────────────────────────────────────
+
+export interface ValidationSuccess<T> {
+    success: true;
+    data: T;
+}
+
+export interface ValidationFailure {
+    success: false;
+    errors: string[];
+}
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+// ─── Public Validation Functions ─────────────────────────────────────
+
+/**
+ * Validate subscription creation payload.
+ *
+ * @throws {Error} with a descriptive message listing all validation failures.
+ *
+ * @example
+ * ```ts
+ * const validated = validateSubscriptionCreateInput({
+ *   name: "Netflix",
+ *   category: "Streaming",
+ *   price: 15.99,
+ * });
+ * // validated is now a type-safe, validated object ready to send.
+ * ```
+ */
+export function validateSubscriptionCreateInput(
+    input: unknown,
+): z.infer<typeof SubscriptionCreateSchema> {
+    if (input === null || input === undefined) {
+        throw new Error(
+            "Validation failed: Subscription create payload must be a non-null object.",
+        );
+    }
+
+    if (typeof input !== "object" || Array.isArray(input)) {
+        throw new Error(
+            "Validation failed: Subscription create payload must be a plain object.",
+        );
+    }
+
+    const result = SubscriptionCreateSchema.safeParse(input);
+
+    if (!result.success) {
+        const messages = result.error.issues.map(
+            (issue) => `${issue.path.join(".")}: ${issue.message}`,
+        );
+        throw new Error(
+            `Validation failed: ${messages.join(" | ")}`,
+        );
+    }
+
+    return result.data;
+}
+
+/**
+ * Validate subscription update payload.
+ *
+ * @throws {Error} with a descriptive message listing all validation failures.
+ *
+ * @example
+ * ```ts
+ * const validated = validateSubscriptionUpdateInput({ price: 19.99 });
+ * ```
+ */
+export function validateSubscriptionUpdateInput(
+    input: unknown,
+): z.infer<typeof SubscriptionUpdateSchema> {
+    if (input === null || input === undefined) {
+        throw new Error(
+            "Validation failed: Subscription update payload must be a non-null object.",
+        );
+    }
+
+    if (typeof input !== "object" || Array.isArray(input)) {
+        throw new Error(
+            "Validation failed: Subscription update payload must be a plain object.",
+        );
+    }
+
+    if (Object.keys(input as object).length === 0) {
+        throw new Error(
+            "Validation failed: At least one field must be provided for update.",
+        );
+    }
+
+    const result = SubscriptionUpdateSchema.safeParse(input);
+
+    if (!result.success) {
+        const messages = result.error.issues.map(
+            (issue) =>
+                issue.path.length > 0
+                    ? `${issue.path.join(".")}: ${issue.message}`
+                    : issue.message,
+        );
+        throw new Error(
+            `Validation failed: ${messages.join(" | ")}`,
+        );
+    }
+
+    return result.data;
+}
+
+/**
+ * Validate a gift card hash.
+ *
+ * @throws {Error} with a descriptive message if validation fails.
+ *
+ * @example
+ * ```ts
+ * const hash = validateGiftCardHash("a1b2c3d4...");
+ * ```
+ */
+export function validateGiftCardHash(input: unknown): string {
+    if (input === null || input === undefined) {
+        throw new Error("Validation failed: Gift card hash is required.");
+    }
+
+    if (typeof input !== "string") {
+        throw new Error(
+            "Validation failed: Gift card hash must be a string.",
+        );
+    }
+
+    const result = GiftCardHashSchema.safeParse(input);
+
+    if (!result.success) {
+        const messages = result.error.issues.map((issue) => issue.message);
+        throw new Error(
+            `Validation failed: ${messages.join(" | ")}`,
+        );
+    }
+
+    return result.data;
+}


### PR DESCRIPTION
Closes #90

---

- Implement validateSubscriptionCreateInput with Zod schema validation
- Implement validateSubscriptionUpdateInput for partial update payloads
- Implement validateGiftCardHash for SHA-256 hex digest validation
- Integrate validators into SyncroSDK (createSubscription, updateSubscription, attachGiftCard)
- Integrate validators into client SubscriptionService (fail fast before API calls)
- Add 57 unit tests covering all validation failure scenarios
- Add zod dependency to SDK, fix test script for ESM support