### PR TITLE
Add Winston log rotation to prevent unbounded log file growth in production

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,9 @@ PORT=3001
 NODE_ENV=development
 FRONTEND_URL=http://localhost:3000
 
+# Logging
+LOG_LEVEL=info
+
 # Database
 DATABASE_URL=postgresql://user:password@localhost:5432/synchro
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,6 +3,7 @@ dist/
 .env
 .env.local
 *.log
+logs/
 .DS_Store
 coverage/
 .nyc_output/

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "uuid": "^13.0.0",
     "web-push": "^3.6.7",
     "winston": "^3.14.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/backend/src/config/logger.ts
+++ b/backend/src/config/logger.ts
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
 import { requestContextStorage } from '../middleware/requestContext';
 
 /**
@@ -27,8 +28,21 @@ const logger = winston.createLogger({
   ),
   defaultMeta: { service: 'synchro-backend' },
   transports: [
-    new winston.transports.File({ filename: 'error.log', level: 'error' }),
-    new winston.transports.File({ filename: 'combined.log' }),
+    new DailyRotateFile({
+      filename: 'logs/error-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '10m',
+      maxFiles: '30d',
+      level: 'error',
+    }),
+    new DailyRotateFile({
+      filename: 'logs/combined-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+    }),
   ],
 });
 


### PR DESCRIPTION
Closes #153

---

## Description
Add Winston log rotation to prevent unbounded log file growth in production
Briefly describe what this PR does.
Added Winston log rotation to prevent unbounded log file growth in production
---

## Related Issue

Closes #
#153 
---

## Test Plan

- [x] Tested locally
- [x] Verified expected behavior
- [x] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [x] Code builds successfully
- [x] Tests pass
- [x] Follows project conventions
- [x] No sensitive data exposed
