### PR TITLE
recalculation endpoint

### DIFF
--- a/backend/src/routes/risk-score.ts
+++ b/backend/src/routes/risk-score.ts
@@ -6,6 +6,7 @@ import express, { Response } from 'express';
 import { riskDetectionService } from '../services/risk-detection/risk-detection-service';
 import { riskNotificationService } from '../services/risk-detection/risk-notification-service';
 import { authenticate, AuthenticatedRequest } from '../middleware/auth';
+import { adminAuth } from '../middleware/admin';
 import logger from '../config/logger';
 
 const router = express.Router();
@@ -155,8 +156,10 @@ router.get('/', async (req: AuthenticatedRequest, res: Response) => {
  *         description: Recalculation result
  *       401:
  *         description: Unauthorized
+ *       403:
+ *         description: Forbidden - Admin access required
  */
-router.post('/recalculate', async (req: AuthenticatedRequest, res: Response) => {
+router.post('/recalculate', adminAuth, async (req: AuthenticatedRequest, res: Response) => {
   try {
     const userId = req.user?.id;
 
@@ -166,9 +169,6 @@ router.post('/recalculate', async (req: AuthenticatedRequest, res: Response) => 
         error: 'Unauthorized',
       });
     }
-
-    // TODO: Add admin check
-    // For now, allow any authenticated user to trigger recalculation
 
     logger.info('Manual risk recalculation triggered', { user_id: userId });
 


### PR DESCRIPTION
## Description

Adds `adminAuth` middleware to the `POST /api/risk-score/recalculate` endpoint, restricting batch risk recalculation to admin users only. Previously, any authenticated user could trigger a full recalculation across all subscriptions, creating a denial-of-service risk.

---

## Related Issue

Closes #119

---

## Changes

- Imported `adminAuth` from `../middleware/admin` into `risk-score.ts`
- Applied `adminAuth` middleware to the `/recalculate` route handler
- Updated OpenAPI docs to include `403 Forbidden` response
- Removed stale `// TODO: Add admin check` comment

---

## Test Plan

- [ ] Tested locally
- [ ] Non-admin user receives `403` when calling `POST /api/risk-score/recalculate`
- [ ] Admin user can still trigger recalculation successfully
- [ ] Other risk-score endpoints (`GET /`, `GET /:subscriptionId`, `POST /:subscriptionId/calculate`) remain accessible to all authenticated users
- [ ] No regressions introduced

---

## Screenshots (if applicable)

N/A

---

## Checklist

- [x] Code builds successfully
- [x] Follows project conventions
- [x] No sensitive data exposed
- [ ] Tests pass

