### PR TITLE
Privacy-Preserving Email Content Filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Validate client environment variables
         env:
@@ -64,16 +64,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: client/package-lock.json
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: client/pnpm-lock.yaml
 
       - name: Install client dependencies
         working-directory: client
-        run: npm ci
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build client
         working-directory: client
@@ -84,7 +89,7 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
-        run: npm run build
+        run: pnpm run build
 
   # ──────────────────────────────────────────────
   # Job 3: Run backend tests
@@ -102,16 +107,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
 
       - name: Install backend dependencies
         working-directory: backend
-        run: pnpm install
+        run: npm ci
 
       - name: Run backend tests
         working-directory: backend
@@ -129,4 +131,4 @@ jobs:
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           SOROBAN_CONTRACT_ADDRESS: ${{ secrets.SOROBAN_CONTRACT_ADDRESS }}
           STELLAR_NETWORK_URL: ${{ secrets.STELLAR_NETWORK_URL }}
-        run: pnpm test
+        run: npm test -- --coverage --ci

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,16 +14,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: client/package-lock.json
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: client/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: client
-        run: npm ci
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright browsers
         working-directory: client

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,31 +8,51 @@ on:
 
 jobs:
   lint-backend:
+    name: Lint Backend
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: backend
+
     steps:
       - uses: actions/checkout@v4
+
+      # pnpm must be set up before actions/setup-node so the node step
+      # can resolve the pnpm cache correctly.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-      - run: npx eslint src --ext .ts --max-warnings 0
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run ESLint
+        run: npx eslint src --ext .ts --max-warnings 0
 
   lint-client:
+    name: Lint Client
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: client
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: npm
+          node-version: "20"
+          cache: "npm"
           cache-dependency-path: client/package-lock.json
-      - run: npm ci
-      - run: npx next lint
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Next.js linter
+        run: npx next lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,20 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pnpm must be set up before actions/setup-node so the node step
-      # can resolve the pnpm cache correctly.
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: backend/pnpm-lock.yaml
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
       - name: Run ESLint
         run: npx eslint src --ext .ts --max-warnings 0
@@ -45,14 +39,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: client/package-lock.json
+          cache: "pnpm"
+          cache-dependency-path: client/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run Next.js linter
         run: npx next lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,25 @@ jobs:
       ADMIN_API_KEY: test-admin-key
     steps:
       - uses: actions/checkout@v4
+
+      # pnpm must be set up before actions/setup-node so the node step
+      # can resolve the pnpm cache correctly.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-      - run: npm test -- --coverage --ci
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests with coverage
+        run: pnpm test -- --coverage --ci
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,23 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pnpm must be set up before actions/setup-node so the node step
-      # can resolve the pnpm cache correctly.
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: backend/pnpm-lock.yaml
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
       - name: Run tests with coverage
-        run: pnpm test -- --coverage --ci
+        run: npm test -- --coverage --ci
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,15 +15,12 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: backend/pnpm-lock.yaml
-      - run: pnpm install
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
       - run: npx tsc --noEmit
 
   typecheck-client:
@@ -34,10 +31,13 @@ jobs:
         working-directory: client
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: client/package-lock.json
-      - run: npm ci
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: client/pnpm-lock.yaml
+      - run: pnpm install --no-frozen-lockfile
       - run: npx tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Dependencies
 ./node_modules
 node_modules/
+# package-lock.json files are ignored globally; each workspace that uses npm
+# must be explicitly un-ignored below so the runner receives the lock file.
 package-lock.json
 npm-debug.log*
 yarn-debug.log*
@@ -101,3 +103,4 @@ coverage/
 CLAUDE.md
 
 !backend/package-lock.json
+!client/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,3 @@ coverage/
 CLAUDE.md
 
 !backend/package-lock.json
-!client/package-lock.json

--- a/backend/migrations/create_email_scan_logs.sql
+++ b/backend/migrations/create_email_scan_logs.sql
@@ -1,0 +1,66 @@
+-- Privacy-preserving log of receipt metadata extracted from email scans.
+-- The email body is never stored — only structured fields and cryptographic proof hashes.
+-- The CHECK constraint on body_excluded enforces this policy at the database level.
+CREATE TABLE IF NOT EXISTS public.email_scan_logs (
+  id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID         REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider         TEXT         NOT NULL,
+  message_id       TEXT,
+  received_at      TIMESTAMPTZ,
+  from_address     TEXT,
+  subject          TEXT,
+  service_name     TEXT,
+  amount           NUMERIC(12,2),
+  currency         TEXT,
+  billing_interval TEXT,
+  signals          TEXT[],
+  confidence       NUMERIC(4,3),
+  proof_hash       TEXT,
+  content_hash     TEXT,
+  body_excluded    BOOLEAN      NOT NULL DEFAULT TRUE,
+  scanned_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  CONSTRAINT email_scan_logs_no_body_check CHECK (body_excluded = TRUE),
+  CONSTRAINT email_scan_logs_provider_message_unique UNIQUE (provider, message_id)
+);
+
+-- Indexes for optimal query performance
+CREATE INDEX IF NOT EXISTS idx_email_scan_logs_user_scanned    ON public.email_scan_logs(user_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_scan_logs_provider_message ON public.email_scan_logs(provider, message_id);
+CREATE INDEX IF NOT EXISTS idx_email_scan_logs_received        ON public.email_scan_logs(received_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_scan_logs_amount          ON public.email_scan_logs(amount) WHERE amount IS NOT NULL;
+
+-- Enable RLS (Row Level Security) for email scan logs
+ALTER TABLE public.email_scan_logs ENABLE ROW LEVEL SECURITY;
+
+-- Users can only read their own scan log rows
+CREATE POLICY email_scan_logs_select_own ON public.email_scan_logs
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Only the backend (with service role) can insert scan log rows
+CREATE POLICY email_scan_logs_insert_backend ON public.email_scan_logs
+  FOR INSERT
+  WITH CHECK (true);
+
+-- Scan logs are immutable — updates are never permitted
+CREATE POLICY email_scan_logs_no_update ON public.email_scan_logs
+  FOR UPDATE
+  USING (false);
+
+-- Only admins may delete scan log rows
+CREATE POLICY email_scan_logs_admin_delete ON public.email_scan_logs
+  FOR DELETE
+  USING (auth.jwt() ->> 'is_admin' = 'true');
+
+-- Table and column documentation
+COMMENT ON TABLE public.email_scan_logs IS
+  'Privacy-preserving log of receipt metadata extracted from email scans. The email body is never stored — only structured fields (amounts, dates, sender) and cryptographic proof hashes.';
+
+COMMENT ON COLUMN public.email_scan_logs.body_excluded IS
+  'Always TRUE. Enforced by CHECK constraint. Documents that the raw email body was intentionally not persisted.';
+
+COMMENT ON COLUMN public.email_scan_logs.content_hash IS
+  'SHA-256 hash of the original email body. Proves the body was processed without storing it.';
+
+COMMENT ON COLUMN public.email_scan_logs.proof_hash IS
+  'Composite proof-of-scan hash covering provider, message_id, timestamps, and extracted amounts.';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,6 @@
         "bip39": "^3.1.0",
         "cookie-parser": "^1.4.7",
         "csv-parse": "^6.2.1",
-        "date-fns": "^4.1.0",
         "dotenv": "^16.4.5",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
@@ -65,68 +64,6 @@
         "ts-jest": "^29.4.6",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-      "license": "MIT"
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -848,9 +785,9 @@
       }
     },
     "node_modules/@fastify/otel": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz",
-      "integrity": "sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
       "funding": [
         {
           "type": "github",
@@ -1562,14 +1499,15 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
-      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -1578,11 +1516,15 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
-      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
       "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -1590,7 +1532,156 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/core": {
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
@@ -1605,193 +1696,13 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz",
-      "integrity": "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.213.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.60.0.tgz",
-      "integrity": "sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.56.0.tgz",
-      "integrity": "sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/connect": "3.4.38"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.30.0.tgz",
-      "integrity": "sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.61.0.tgz",
-      "integrity": "sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.32.0.tgz",
-      "integrity": "sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.56.0.tgz",
-      "integrity": "sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.61.0.tgz",
-      "integrity": "sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.59.0.tgz",
-      "integrity": "sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz",
-      "integrity": "sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.6.0",
-        "@opentelemetry/instrumentation": "0.213.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0",
-        "forwarded-parse": "2.1.2"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.61.0.tgz",
-      "integrity": "sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/redis-common": "^0.38.2",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
@@ -1803,12 +1714,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.22.0.tgz",
-      "integrity": "sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.30.0"
       },
       "engines": {
@@ -1819,12 +1730,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.57.0.tgz",
-      "integrity": "sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.1"
       },
       "engines": {
@@ -1835,13 +1746,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.61.0.tgz",
-      "integrity": "sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.36.0"
       },
       "engines": {
@@ -1852,12 +1763,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.57.0.tgz",
-      "integrity": "sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0"
+        "@opentelemetry/instrumentation": "^0.214.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1867,12 +1778,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.66.0.tgz",
-      "integrity": "sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "engines": {
@@ -1883,13 +1794,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.59.0.tgz",
-      "integrity": "sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "engines": {
@@ -1900,12 +1811,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz",
-      "integrity": "sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@types/mysql": "2.15.27"
       },
@@ -1917,12 +1828,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz",
-      "integrity": "sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@opentelemetry/sql-common": "^0.41.2"
       },
@@ -1934,13 +1845,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.65.0.tgz",
-      "integrity": "sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@opentelemetry/sql-common": "^0.41.2",
         "@types/pg": "8.15.6",
@@ -1954,12 +1865,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.61.0.tgz",
-      "integrity": "sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/redis-common": "^0.38.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -1971,12 +1882,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.32.0.tgz",
-      "integrity": "sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@types/tedious": "^4.0.14"
       },
@@ -1988,13 +1899,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.23.0.tgz",
-      "integrity": "sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
+      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/semantic-conventions": "^1.24.0"
       },
       "engines": {
@@ -2005,21 +1916,21 @@
       }
     },
     "node_modules/@opentelemetry/redis-common": {
-      "version": "0.38.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/core": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2030,13 +1941,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2051,6 +1963,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2104,9 +2017,9 @@
       }
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.4.2.tgz",
-      "integrity": "sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.207.0"
@@ -2224,13 +2137,6 @@
         "@redis/client": "^5.11.0"
       }
     },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@sentry-internal/node-cpu-profiler": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/node-cpu-profiler/-/node-cpu-profiler-2.2.0.tgz",
@@ -2246,54 +2152,51 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.46.0.tgz",
-      "integrity": "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.49.0.tgz",
+      "integrity": "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.46.0.tgz",
-      "integrity": "sha512-vF+7FrUXEtmYWuVcnvBjlWKeyLw/kwHpwnGj9oUmO/a2uKjDmUr53ZVcapggNxCjivavGYr9uHOY64AGdeUyzA==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.49.0.tgz",
+      "integrity": "sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ==",
       "license": "MIT",
       "dependencies": {
-        "@fastify/otel": "0.17.1",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^2.6.0",
-        "@opentelemetry/core": "^2.6.0",
-        "@opentelemetry/instrumentation": "^0.213.0",
-        "@opentelemetry/instrumentation-amqplib": "0.60.0",
-        "@opentelemetry/instrumentation-connect": "0.56.0",
-        "@opentelemetry/instrumentation-dataloader": "0.30.0",
-        "@opentelemetry/instrumentation-express": "0.61.0",
-        "@opentelemetry/instrumentation-fs": "0.32.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.56.0",
-        "@opentelemetry/instrumentation-graphql": "0.61.0",
-        "@opentelemetry/instrumentation-hapi": "0.59.0",
-        "@opentelemetry/instrumentation-http": "0.213.0",
-        "@opentelemetry/instrumentation-ioredis": "0.61.0",
-        "@opentelemetry/instrumentation-kafkajs": "0.22.0",
-        "@opentelemetry/instrumentation-knex": "0.57.0",
-        "@opentelemetry/instrumentation-koa": "0.61.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.57.0",
-        "@opentelemetry/instrumentation-mongodb": "0.66.0",
-        "@opentelemetry/instrumentation-mongoose": "0.59.0",
-        "@opentelemetry/instrumentation-mysql": "0.59.0",
-        "@opentelemetry/instrumentation-mysql2": "0.59.0",
-        "@opentelemetry/instrumentation-pg": "0.65.0",
-        "@opentelemetry/instrumentation-redis": "0.61.0",
-        "@opentelemetry/instrumentation-tedious": "0.32.0",
-        "@opentelemetry/instrumentation-undici": "0.23.0",
-        "@opentelemetry/resources": "^2.6.0",
-        "@opentelemetry/sdk-trace-base": "^2.6.0",
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/instrumentation-undici": "0.24.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@prisma/instrumentation": "7.4.2",
-        "@sentry/core": "10.46.0",
-        "@sentry/node-core": "10.46.0",
-        "@sentry/opentelemetry": "10.46.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.49.0",
+        "@sentry/node-core": "10.49.0",
+        "@sentry/opentelemetry": "10.49.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2301,13 +2204,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.46.0.tgz",
-      "integrity": "sha512-gwLGXfkzmiCmUI1VWttyoZBaVp1ItpDKc8AV2mQblWPQGdLSD0c6uKV/FkU291yZA3rXsrLXVwcWoibwnjE2vw==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.49.0.tgz",
+      "integrity": "sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.46.0",
-        "@sentry/opentelemetry": "10.46.0",
+        "@sentry/core": "10.49.0",
+        "@sentry/opentelemetry": "10.49.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2315,10 +2218,9 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
         "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.39.0"
       },
@@ -2326,16 +2228,13 @@
         "@opentelemetry/api": {
           "optional": true
         },
-        "@opentelemetry/context-async-hooks": {
-          "optional": true
-        },
         "@opentelemetry/core": {
           "optional": true
         },
-        "@opentelemetry/instrumentation": {
+        "@opentelemetry/exporter-trace-otlp-http": {
           "optional": true
         },
-        "@opentelemetry/resources": {
+        "@opentelemetry/instrumentation": {
           "optional": true
         },
         "@opentelemetry/sdk-trace-base": {
@@ -2347,33 +2246,32 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.46.0.tgz",
-      "integrity": "sha512-dzzV2ovruGsx9jzusGGr6cNPvMgYRu2BIrF8aMZ3rkQ1OpPJjPStqtA1l1fw0aoxHOxIjFU7ml4emF+xdmMl3g==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.49.0.tgz",
+      "integrity": "sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.46.0"
+        "@sentry/core": "10.49.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
     "node_modules/@sentry/profiling-node": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.46.0.tgz",
-      "integrity": "sha512-dFdUqriSQazkohJFr9oV2bxvr2j0y0YLeDyQLgzbWU+LcuK+zNgGR4OHVvfuPJA1TJHSztQaObPJ6aBVsgQ3ag==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.49.0.tgz",
+      "integrity": "sha512-58VoaCsn5TnQ+RDD5JY2omBESTYOOJYnqQedzI4poRia9flWMtN29rwvMOOpFoY94dz/cOrsakG1oAq8u9LpMA==",
       "license": "MIT",
       "dependencies": {
         "@sentry-internal/node-cpu-profiler": "^2.2.0",
-        "@sentry/core": "10.46.0",
-        "@sentry/node": "10.46.0"
+        "@sentry/core": "10.49.0",
+        "@sentry/node": "10.49.0"
       },
       "bin": {
         "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -2946,24 +2844,6 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
-      }
-    },
-    "node_modules/@types/swagger-jsdoc": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
-      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/swagger-ui-express": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
-      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/tedious": {
@@ -3975,6 +3855,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3985,9 +3866,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -4009,9 +3890,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.4.tgz",
-      "integrity": "sha512-4JboWUl7/2LhgU536tjUszzaVC8/WEWKtyX5crayvlN71ih8+O2SdvBhotQeDsuhhmPZmLCrPBJEcwVPhI/kkQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -4027,9 +3908,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
-      "integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -4053,9 +3934,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -4909,16 +4790,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -6698,9 +6569,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
-      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -7861,16 +7732,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -9014,9 +8878,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11042,36 +10906,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zip-stream": {

--- a/backend/services/email-scanner.ts
+++ b/backend/services/email-scanner.ts
@@ -1,0 +1,211 @@
+/**
+ * email-scanner.ts
+ *
+ * Privacy Contract
+ * ────────────────
+ * This module acts as a hard boundary between raw email content and the database.
+ * Only receipt-relevant metadata (amounts, dates, sender identity, proof hashes)
+ * may cross this boundary. The full email body is NEVER persisted.
+ *
+ * Any field that is not on the explicit whitelist in `metadataExtractionOnly` is
+ * silently dropped before data is handed to the rest of the application or written
+ * to storage. The `bodyExcluded: true` literal on every `ReceiptMetadata` object
+ * is a machine-readable record of that intentional omission.
+ */
+
+import logger from '../src/config/logger'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// ── Interfaces ────────────────────────────────────────────────────────────────
+
+/**
+ * The only shape that may be persisted to the database.
+ *
+ * `bodyExcluded: true` is a literal type that documents the intentional
+ * omission of the email body from all persisted records. Every value that
+ * carries this type has provably passed through the metadata-extraction
+ * whitelist and therefore contains no raw email content.
+ */
+export interface ReceiptMetadata {
+  provider: string
+  messageId: string | null
+  threadId: string | null
+  receivedAt: string | null
+  from: string | null
+  subject: string | null
+  name: string | null
+  amount: number | null
+  currency: string | null
+  interval: string | null
+  signals: string[]
+  confidence: number
+  proof: {
+    hash: string
+    contentHash: string | null
+    algorithm: 'sha256'
+  }
+  /** Literal true — documents that the email body is intentionally not persisted. */
+  bodyExcluded: true
+}
+
+/**
+ * What the Gmail/Outlook services produce before filtering.
+ *
+ * Contains the same receipt-relevant fields as `ReceiptMetadata` (minus the
+ * `bodyExcluded` sentinel) and adds an open index signature so that
+ * `metadataExtractionOnly` can detect and warn on any extra/unknown fields
+ * before they reach the database.
+ */
+export interface RawScanResult {
+  provider: string
+  messageId: string | null
+  threadId: string | null
+  receivedAt: string | null
+  from: string | null
+  subject: string | null
+  name: string | null
+  amount: number | null
+  currency: string | null
+  interval: string | null
+  signals: string[]
+  confidence: number
+  proof: {
+    hash: string
+    contentHash: string | null
+    algorithm: 'sha256'
+  }
+  /** Open index signature — allows catching extra/unknown fields for stripping. */
+  [key: string]: unknown
+}
+
+// ── Exported functions ────────────────────────────────────────────────────────
+
+/**
+ * Applies a strict whitelist to an array of raw scan results, returning only
+ * the fields that are safe to persist.
+ *
+ * Design decisions:
+ * - Explicit destructuring names every permitted field; anything not named is
+ *   automatically excluded from the returned objects.
+ * - `body` and `rawContent` are explicitly bound to `_body` / `_rawContent` so
+ *   that the intentional discard is visible to code reviewers and linters.
+ * - Any remaining keys land in `...unknownFields` and trigger a `logger.warn`
+ *   so that new upstream fields are surfaced in logs rather than silently lost.
+ */
+export function metadataExtractionOnly(rawResults: RawScanResult[]): ReceiptMetadata[] {
+  return rawResults.map((result) => {
+    // Whitelist destructure — only the named fields survive into `clean`.
+    // `_body` and `_rawContent` are explicitly declared and discarded to make
+    // the intentional omission of email body content impossible to overlook.
+    const {
+      provider,
+      messageId,
+      threadId,
+      receivedAt,
+      from,
+      subject,
+      name,
+      amount,
+      currency,
+      interval,
+      signals,
+      confidence,
+      proof,
+      body: _body,
+      rawContent: _rawContent,
+      ...unknownFields
+    } = result
+
+    const unknownKeys = Object.keys(unknownFields)
+    if (unknownKeys.length > 0) {
+      logger.warn(
+        '[email-scanner] metadataExtractionOnly: stripped unexpected fields from scan result',
+        { unknownKeys, provider, messageId },
+      )
+    }
+
+    const clean: ReceiptMetadata = {
+      provider,
+      messageId,
+      threadId,
+      receivedAt,
+      from,
+      subject,
+      name,
+      amount,
+      currency,
+      interval,
+      signals,
+      confidence,
+      proof,
+      bodyExcluded: true as const,
+    }
+
+    logger.info('[email-scanner] Receipt metadata extracted', {
+      provider,
+      messageId,
+      receivedAt,
+      amount,
+      currency,
+      interval,
+      confidence,
+      signalCount: signals.length,
+      hasProof: !!proof?.hash,
+      bodyExcluded: true,
+    })
+
+    return clean
+  })
+}
+
+/**
+ * Persists an array of `ReceiptMetadata` records to the `audit_logs` table
+ * via the supplied Supabase client.
+ *
+ * Accepting a `SupabaseClient` as a parameter (rather than importing a
+ * singleton) keeps this function testable and avoids a hard dependency on the
+ * database configuration module.
+ *
+ * Only metadata that has already been filtered by `metadataExtractionOnly` is
+ * accepted here — the type signature enforces this at compile time.
+ */
+export async function logScanMetadata(
+  userId: string,
+  metadata: ReceiptMetadata[],
+  supabaseClient: SupabaseClient,
+): Promise<void> {
+  if (metadata.length === 0) return
+
+  const rows = metadata.map((m) => ({
+    user_id: userId,
+    action: 'email_receipt_extracted' as const,
+    resource_type: 'email_scan' as const,
+    resource_id: m.messageId,
+    metadata: {
+      provider:    m.provider,
+      receivedAt:  m.receivedAt,
+      from:        m.from,
+      subject:     m.subject,
+      name:        m.name,
+      amount:      m.amount,
+      currency:    m.currency,
+      interval:    m.interval,
+      signals:     m.signals,
+      confidence:  m.confidence,
+      proof:       m.proof,
+      bodyExcluded: true,
+    },
+  }))
+
+  const { error } = await supabaseClient.from('audit_logs').insert(rows)
+
+  if (error) {
+    logger.error('[email-scanner] Failed to log scan metadata', { error: error.message })
+    throw error
+  }
+
+  logger.info(
+    `[email-scanner] Persisted ${rows.length} receipt metadata records to audit_logs`,
+    { userId, count: rows.length },
+  )
+}

--- a/backend/services/gmail-service.ts
+++ b/backend/services/gmail-service.ts
@@ -1,80 +1,84 @@
-import { google } from 'googleapis'
-import type { Credentials } from 'google-auth-library'
-import { parseSubscriptionEmail } from './email-parser'
-import { generateProofHash, hashContent } from '../utils/proof-hashing'
+import { google } from "googleapis";
+import type { Credentials } from "google-auth-library";
+import { parseSubscriptionEmail } from "./email-parser";
+import { generateProofHash, hashContent } from "../utils/proof-hashing";
+import { metadataExtractionOnly } from "./email-scanner";
+import type { RawScanResult } from "./email-scanner";
 
-const GMAIL_SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
+const GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
 
 const KEYWORDS = [
-  'subscription',
-  'renewal',
-  'invoice',
-  'receipt',
-  'billing',
-  'charged',
-  'trial',
-  'membership',
-  'plan',
-]
+  "subscription",
+  "renewal",
+  "invoice",
+  "receipt",
+  "billing",
+  "charged",
+  "trial",
+  "membership",
+  "plan",
+];
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface ScanGmailOptions {
-  accessToken: string
-  refreshToken?: string
-  sinceDays?: number
-  maxResults?: number
+  accessToken: string;
+  refreshToken?: string;
+  sinceDays?: number;
+  maxResults?: number;
 }
 
 interface GmailHeader {
-  name: string
-  value: string
+  name: string;
+  value: string;
 }
 
 interface GmailPayload {
-  mimeType?: string
-  headers?: GmailHeader[]
-  body?: { data?: string }
-  parts?: GmailPayload[]
+  mimeType?: string;
+  headers?: GmailHeader[];
+  body?: { data?: string };
+  parts?: GmailPayload[];
 }
 
 // ── OAuth client factory ──────────────────────────────────────────────────────
 
 function createOAuthClient() {
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
-    throw new Error('Missing Google OAuth environment variables')
+    throw new Error("Missing Google OAuth environment variables");
   }
   return new google.auth.OAuth2(
     process.env.GOOGLE_CLIENT_ID,
     process.env.GOOGLE_CLIENT_SECRET,
     process.env.GOOGLE_REDIRECT_URI,
-  )
+  );
 }
 
 // ── Exported service functions ────────────────────────────────────────────────
 
 export function getGmailAuthUrl(state: string): string {
-  const oauth2Client = createOAuthClient()
+  const oauth2Client = createOAuthClient();
   return oauth2Client.generateAuthUrl({
-    access_type: 'offline',
-    prompt: 'consent',
+    access_type: "offline",
+    prompt: "consent",
     scope: GMAIL_SCOPES,
     state,
-  })
+  });
 }
 
-export async function exchangeGmailCodeForTokens(code: string): Promise<Credentials> {
-  const oauth2Client = createOAuthClient()
-  const { tokens } = await oauth2Client.getToken(code)
-  return tokens
+export async function exchangeGmailCodeForTokens(
+  code: string,
+): Promise<Credentials> {
+  const oauth2Client = createOAuthClient();
+  const { tokens } = await oauth2Client.getToken(code);
+  return tokens;
 }
 
 export async function getGmailProfile(tokens: Credentials) {
-  const oauth2Client = createOAuthClient()
-  oauth2Client.setCredentials(tokens)
-  const gmail = google.gmail({ version: 'v1', auth: oauth2Client })
-  const profile = await gmail.users.getProfile({ userId: 'me' })
-  return profile.data
+  const oauth2Client = createOAuthClient();
+  oauth2Client.setCredentials(tokens);
+  const gmail = google.gmail({ version: "v1", auth: oauth2Client });
+  const profile = await gmail.users.getProfile({ userId: "me" });
+  return profile.data;
 }
 
 export async function scanGmailSubscriptions({
@@ -83,50 +87,50 @@ export async function scanGmailSubscriptions({
   sinceDays = 120,
   maxResults = 50,
 }: ScanGmailOptions) {
-  const oauth2Client = createOAuthClient()
+  const oauth2Client = createOAuthClient();
   oauth2Client.setCredentials({
     access_token: accessToken,
     refresh_token: refreshToken,
-  })
+  });
 
-  const gmail = google.gmail({ version: 'v1', auth: oauth2Client })
-  const query = buildQuery(sinceDays)
+  const gmail = google.gmail({ version: "v1", auth: oauth2Client });
+  const query = buildQuery(sinceDays);
 
   const listResponse = await gmail.users.messages.list({
-    userId: 'me',
+    userId: "me",
     q: query,
     maxResults,
-  })
+  });
 
-  const messages = listResponse.data.messages ?? []
-  const results = []
+  const messages = listResponse.data.messages ?? [];
+  const results: RawScanResult[] = [];
 
   for (const message of messages) {
     const details = await gmail.users.messages.get({
-      userId: 'me',
+      userId: "me",
       id: message.id!,
-      format: 'full',
-    })
+      format: "full",
+    });
 
-    const payload = (details.data.payload ?? {}) as GmailPayload
-    const headers = payload.headers ?? []
-    const subject = findHeader(headers, 'Subject')
-    const from = findHeader(headers, 'From')
+    const payload = (details.data.payload ?? {}) as GmailPayload;
+    const headers = payload.headers ?? [];
+    const subject = findHeader(headers, "Subject");
+    const from = findHeader(headers, "From");
     const receivedAt =
-      findHeader(headers, 'Date') ??
-      new Date(Number(details.data.internalDate) || Date.now()).toISOString()
+      findHeader(headers, "Date") ??
+      new Date(Number(details.data.internalDate) || Date.now()).toISOString();
 
-    let body: string | null = extractTextFromPayload(payload)
+    let body: string | null = extractTextFromPayload(payload);
 
-    const parsed = parseSubscriptionEmail({ subject, from, body })
-    if (!parsed) continue
+    const parsed = parseSubscriptionEmail({ subject, from, body });
+    if (!parsed) continue;
 
-    const contentHash = hashContent(body)
+    const contentHash = hashContent(body);
     // Discard raw email content after hashing/parsing
-    body = null
+    body = null;
 
     const proofHash = generateProofHash({
-      provider: 'gmail',
+      provider: "gmail",
       messageId: details.data.id,
       receivedAt,
       subject,
@@ -135,12 +139,12 @@ export async function scanGmailSubscriptions({
       currency: parsed.currency,
       interval: parsed.interval,
       contentHash,
-    })
+    });
 
     results.push({
-      provider: 'gmail',
-      messageId: details.data.id,
-      threadId: details.data.threadId,
+      provider: "gmail",
+      messageId: details.data.id ?? null,
+      threadId: details.data.threadId ?? null,
       receivedAt,
       subject,
       from,
@@ -148,59 +152,61 @@ export async function scanGmailSubscriptions({
       proof: {
         hash: proofHash,
         contentHash,
-        algorithm: 'sha256',
+        algorithm: "sha256",
       },
-    })
+    });
   }
 
-  return results
+  return metadataExtractionOnly(results);
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 function buildQuery(sinceDays: number): string {
-  const keywordQuery = KEYWORDS.map((keyword) => `"${keyword}"`).join(' OR ')
-  const baseQuery = `(${keywordQuery})`
-  if (!sinceDays) return baseQuery
-  return `${baseQuery} newer_than:${sinceDays}d`
+  const keywordQuery = KEYWORDS.map((keyword) => `"${keyword}"`).join(" OR ");
+  const baseQuery = `(${keywordQuery})`;
+  if (!sinceDays) return baseQuery;
+  return `${baseQuery} newer_than:${sinceDays}d`;
 }
 
 function findHeader(headers: GmailHeader[], name: string): string {
-  const match = headers.find((h) => h.name.toLowerCase() === name.toLowerCase())
-  return match ? match.value : ''
+  const match = headers.find(
+    (h) => h.name.toLowerCase() === name.toLowerCase(),
+  );
+  return match ? match.value : "";
 }
 
 function extractTextFromPayload(payload: GmailPayload): string {
-  const parts = collectParts(payload)
-  const plainParts = parts.filter((p) => p.mimeType === 'text/plain')
-  const htmlParts = parts.filter((p) => p.mimeType === 'text/html')
-  const sources = plainParts.length ? plainParts : htmlParts
+  const parts = collectParts(payload);
+  const plainParts = parts.filter((p) => p.mimeType === "text/plain");
+  const htmlParts = parts.filter((p) => p.mimeType === "text/html");
+  const sources = plainParts.length ? plainParts : htmlParts;
 
   const decoded = sources
     .map((part) => decodeBase64(part.body?.data))
     .filter(Boolean)
-    .join('\n')
+    .join("\n");
 
-  if (plainParts.length) return decoded
+  if (plainParts.length) return decoded;
 
-  return decoded.replace(/<[^>]+>/g, ' ')
+  return decoded.replace(/<[^>]+>/g, " ");
 }
 
 function collectParts(payload: GmailPayload): GmailPayload[] {
-  const parts: GmailPayload[] = []
+  const parts: GmailPayload[] = [];
   if (payload?.mimeType && payload.body?.data) {
-    parts.push(payload)
+    parts.push(payload);
   }
   if (Array.isArray(payload?.parts)) {
     for (const part of payload.parts) {
-      parts.push(...collectParts(part))
+      parts.push(...collectParts(part));
     }
   }
-  return parts
+  return parts;
 }
 
 function decodeBase64(data?: string): string {
-  if (!data) return ''
-  const normalized = data.replace(/-/g, '+').replace(/_/g, '/')
-  return Buffer.from(normalized, 'base64').toString('utf8')
+  if (!data) return "";
+  const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(normalized, "base64").toString("utf8");
 }

--- a/backend/services/outlook-service.ts
+++ b/backend/services/outlook-service.ts
@@ -1,94 +1,102 @@
-import { parseSubscriptionEmail } from './email-parser'
-import { generateProofHash, hashContent } from '../utils/proof-hashing'
+import { parseSubscriptionEmail } from "./email-parser";
+import { generateProofHash, hashContent } from "../utils/proof-hashing";
+import { metadataExtractionOnly } from "./email-scanner";
+import type { RawScanResult } from "./email-scanner";
 
-const OUTLOOK_SCOPES = ['offline_access', 'User.Read', 'Mail.Read']
+const OUTLOOK_SCOPES = ["offline_access", "User.Read", "Mail.Read"];
 
 const KEYWORDS = [
-  'subscription',
-  'renewal',
-  'invoice',
-  'receipt',
-  'billing',
-  'charged',
-  'trial',
-  'membership',
-  'plan',
-]
+  "subscription",
+  "renewal",
+  "invoice",
+  "receipt",
+  "billing",
+  "charged",
+  "trial",
+  "membership",
+  "plan",
+];
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface OutlookTokenResponse {
-  access_token: string
-  refresh_token?: string
-  expires_in: number
-  scope: string
-  token_type: string
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
 }
 
 interface OutlookProfile {
-  mail?: string
-  userPrincipalName: string
-  displayName?: string
+  mail?: string;
+  userPrincipalName: string;
+  displayName?: string;
 }
 
 interface ScanOutlookOptions {
-  accessToken: string
-  refreshToken?: string
-  expiresAt?: string
-  maxResults?: number
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  maxResults?: number;
 }
 
 interface TokenRequestParams {
-  grant_type: string
-  code?: string
-  redirect_uri?: string
-  refresh_token?: string
+  grant_type: string;
+  code?: string;
+  redirect_uri?: string;
+  refresh_token?: string;
 }
 
 // ── Exported functions ────────────────────────────────────────────────────────
 
 export function getOutlookAuthUrl(state?: string): string {
   const params = new URLSearchParams({
-    client_id:     process.env.MICROSOFT_CLIENT_ID ?? '',
-    response_type: 'code',
-    redirect_uri:  process.env.MICROSOFT_REDIRECT_URI ?? '',
-    response_mode: 'query',
-    scope:         OUTLOOK_SCOPES.join(' '),
-    prompt:        'consent',
-  })
+    client_id: process.env.MICROSOFT_CLIENT_ID ?? "",
+    response_type: "code",
+    redirect_uri: process.env.MICROSOFT_REDIRECT_URI ?? "",
+    response_mode: "query",
+    scope: OUTLOOK_SCOPES.join(" "),
+    prompt: "consent",
+  });
 
-  if (state) params.set('state', state)
+  if (state) params.set("state", state);
 
-  const tenant = process.env.MICROSOFT_TENANT_ID ?? 'common'
-  return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?${params.toString()}`
+  const tenant = process.env.MICROSOFT_TENANT_ID ?? "common";
+  return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?${params.toString()}`;
 }
 
-export async function exchangeOutlookCodeForTokens(code: string): Promise<OutlookTokenResponse> {
+export async function exchangeOutlookCodeForTokens(
+  code: string,
+): Promise<OutlookTokenResponse> {
   return requestOutlookToken({
     code,
-    grant_type:   'authorization_code',
-    redirect_uri: process.env.MICROSOFT_REDIRECT_URI ?? '',
-  })
+    grant_type: "authorization_code",
+    redirect_uri: process.env.MICROSOFT_REDIRECT_URI ?? "",
+  });
 }
 
-export async function refreshOutlookToken(refreshToken: string): Promise<OutlookTokenResponse> {
+export async function refreshOutlookToken(
+  refreshToken: string,
+): Promise<OutlookTokenResponse> {
   return requestOutlookToken({
     refresh_token: refreshToken,
-    grant_type:    'refresh_token',
-  })
+    grant_type: "refresh_token",
+  });
 }
 
-export async function getOutlookProfile(accessToken: string): Promise<OutlookProfile> {
-  const response = await fetch('https://graph.microsoft.com/v1.0/me', {
+export async function getOutlookProfile(
+  accessToken: string,
+): Promise<OutlookProfile> {
+  const response = await fetch("https://graph.microsoft.com/v1.0/me", {
     headers: { Authorization: `Bearer ${accessToken}` },
-  })
+  });
 
   if (!response.ok) {
-    const error = await response.text()
-    throw new Error(`Outlook profile fetch failed: ${error}`)
+    const error = await response.text();
+    throw new Error(`Outlook profile fetch failed: ${error}`);
   }
 
-  return response.json() as Promise<OutlookProfile>
+  return response.json() as Promise<OutlookProfile>;
 }
 
 export async function scanOutlookSubscriptions({
@@ -97,101 +105,107 @@ export async function scanOutlookSubscriptions({
   expiresAt,
   maxResults = 50,
 }: ScanOutlookOptions) {
-  let token = accessToken
+  let token = accessToken;
 
   if (expiresAt && refreshToken && new Date(expiresAt) <= new Date()) {
-    const refreshed = await refreshOutlookToken(refreshToken)
-    token = refreshed.access_token
+    const refreshed = await refreshOutlookToken(refreshToken);
+    token = refreshed.access_token;
   }
 
-  const searchQuery = KEYWORDS.join(' OR ')
-  const url = new URL('https://graph.microsoft.com/v1.0/me/messages')
-  url.searchParams.set('$search', `"${searchQuery}"`)
-  url.searchParams.set('$select', 'id,subject,from,receivedDateTime,body')
-  url.searchParams.set('$top', String(maxResults))
+  const searchQuery = KEYWORDS.join(" OR ");
+  const url = new URL("https://graph.microsoft.com/v1.0/me/messages");
+  url.searchParams.set("$search", `"${searchQuery}"`);
+  url.searchParams.set("$select", "id,subject,from,receivedDateTime,body");
+  url.searchParams.set("$top", String(maxResults));
 
   const response = await fetch(url.toString(), {
     headers: {
-      Authorization:    `Bearer ${token}`,
-      ConsistencyLevel: 'eventual',
-      Prefer:           'outlook.body-content-type="text"',
+      Authorization: `Bearer ${token}`,
+      ConsistencyLevel: "eventual",
+      Prefer: 'outlook.body-content-type="text"',
     },
-  })
+  });
 
   if (!response.ok) {
-    const error = await response.text()
-    throw new Error(`Outlook message scan failed: ${error}`)
+    const error = await response.text();
+    throw new Error(`Outlook message scan failed: ${error}`);
   }
 
-  const data = await response.json() as { value?: any[] }
-  const results = []
+  const data = (await response.json()) as { value?: any[] };
+  const results: RawScanResult[] = [];
 
   for (const message of data.value ?? []) {
-    const subject    = message.subject ?? null
-    const from       = message.from?.emailAddress?.name ?? message.from?.emailAddress?.address ?? null
-    const receivedAt = message.receivedDateTime ?? null
-    let body: string | null = message.body?.content ?? ''
+    const subject = message.subject ?? null;
+    const from =
+      message.from?.emailAddress?.name ??
+      message.from?.emailAddress?.address ??
+      null;
+    const receivedAt = message.receivedDateTime ?? null;
+    let body: string | null = message.body?.content ?? "";
 
-    const parsed = parseSubscriptionEmail({ subject, from, body })
-    if (!parsed) continue
+    const parsed = parseSubscriptionEmail({ subject, from, body });
+    if (!parsed) continue;
 
-    const contentHash = hashContent(body)
+    const contentHash = hashContent(body);
     // Discard raw email content after hashing/parsing
-    body = null
+    body = null;
 
     const proofHash = generateProofHash({
-      provider: 'outlook',
+      provider: "outlook",
       messageId: message.id,
       receivedAt,
       subject,
       from,
-      amount:   parsed.amount,
+      amount: parsed.amount,
       currency: parsed.currency,
       interval: parsed.interval,
       contentHash,
-    })
+    });
 
     results.push({
-      provider: 'outlook',
+      provider: "outlook",
       messageId: message.id,
+      threadId: null,
       receivedAt,
       subject,
       from,
       ...parsed,
       proof: {
-        hash:      proofHash,
+        hash: proofHash,
         contentHash,
-        algorithm: 'sha256',
+        algorithm: "sha256",
       },
-    })
+    });
   }
 
-  return results
+  return metadataExtractionOnly(results);
 }
 
 // ── Internal helper ───────────────────────────────────────────────────────────
 
-async function requestOutlookToken(params: TokenRequestParams): Promise<OutlookTokenResponse> {
+async function requestOutlookToken(
+  params: TokenRequestParams,
+): Promise<OutlookTokenResponse> {
   const body = new URLSearchParams({
-    client_id:     process.env.MICROSOFT_CLIENT_ID ?? '',
-    client_secret: process.env.MICROSOFT_CLIENT_SECRET ?? '',
+    client_id: process.env.MICROSOFT_CLIENT_ID ?? "",
+    client_secret: process.env.MICROSOFT_CLIENT_SECRET ?? "",
     ...params,
-  })
+  });
 
-  const tenant   = process.env.MICROSOFT_TENANT_ID ?? 'common'
+  const tenant = process.env.MICROSOFT_TENANT_ID ?? "common";
   const response = await fetch(
     `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`,
     {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body,
     },
-  )
+  );
 
   if (!response.ok) {
-    const error = await response.text()
-    throw new Error(`Outlook token exchange failed: ${error}`)
+    const error = await response.text();
+    throw new Error(`Outlook token exchange failed: ${error}`);
   }
 
-  return response.json() as Promise<OutlookTokenResponse>
+  return response.json() as Promise<OutlookTokenResponse>;
 }

--- a/backend/tests/email-scanner.test.ts
+++ b/backend/tests/email-scanner.test.ts
@@ -1,0 +1,325 @@
+// ─── Module mocks (hoisted by Jest before any import executes) ────────────────
+jest.mock('../src/config/logger', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  __esModule: true,
+}))
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+import { metadataExtractionOnly, logScanMetadata } from '../services/email-scanner'
+import type { RawScanResult, ReceiptMetadata } from '../services/email-scanner'
+import logger from '../src/config/logger'
+
+// ─── Factory helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Builds a baseline RawScanResult. Pass `overrides` to customise any field
+ * (including `body` and `rawContent` which exist outside the whitelist).
+ */
+function makeRaw(
+  overrides: Partial<RawScanResult & { body?: string; rawContent?: string }> = {},
+): RawScanResult {
+  return {
+    provider: 'gmail',
+    messageId: 'msg-001',
+    threadId: 'thread-001',
+    receivedAt: '2024-06-01T10:00:00Z',
+    from: 'billing@netflix.com',
+    subject: 'Your Netflix receipt',
+    name: 'Netflix',
+    amount: 15.99,
+    currency: 'USD',
+    interval: 'monthly',
+    signals: ['receipt', 'billing'],
+    confidence: 0.9,
+    proof: { hash: 'abc123', contentHash: 'def456', algorithm: 'sha256' },
+    ...overrides,
+  }
+}
+
+/**
+ * Returns a fresh Supabase-shaped mock whose `from` chain resolves successfully
+ * by default. Create a new instance per test so call counts never bleed across
+ * tests.
+ */
+function makeSupabaseMock() {
+  return {
+    from: jest.fn().mockReturnValue({
+      insert: jest.fn().mockResolvedValue({ error: null }),
+    }),
+  }
+}
+
+// ─── metadataExtractionOnly ───────────────────────────────────────────────────
+
+describe('metadataExtractionOnly', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // ── 1 ─────────────────────────────────────────────────────────────────────
+  it('returns an empty array when given an empty array', () => {
+    expect(metadataExtractionOnly([])).toEqual([])
+  })
+
+  // ── 2 ─────────────────────────────────────────────────────────────────────
+  it('sets bodyExcluded to true on every result', () => {
+    const result = metadataExtractionOnly([makeRaw()])
+    expect(result[0].bodyExcluded).toBe(true)
+  })
+
+  // ── 3 ─────────────────────────────────────────────────────────────────────
+  it('preserves all allowed receipt metadata fields', () => {
+    const raw = makeRaw()
+    const result = metadataExtractionOnly([raw])
+    const r = result[0]
+
+    expect(r.provider).toBe(raw.provider)
+    expect(r.messageId).toBe(raw.messageId)
+    expect(r.threadId).toBe(raw.threadId)
+    expect(r.receivedAt).toBe(raw.receivedAt)
+    expect(r.from).toBe(raw.from)
+    expect(r.subject).toBe(raw.subject)
+    expect(r.name).toBe(raw.name)
+    expect(r.amount).toBe(raw.amount)
+    expect(r.currency).toBe(raw.currency)
+    expect(r.interval).toBe(raw.interval)
+    expect(r.signals).toEqual(raw.signals)
+    expect(r.confidence).toBe(raw.confidence)
+    expect(r.proof).toEqual(raw.proof)
+  })
+
+  // ── 4 ─────────────────────────────────────────────────────────────────────
+  it('strips the body field when present in raw input', () => {
+    const result = metadataExtractionOnly([
+      makeRaw({ body: 'Hi there, thanks for subscribing! Here is your receipt...' }),
+    ])
+    expect('body' in result[0]).toBe(false)
+  })
+
+  // ── 5 ─────────────────────────────────────────────────────────────────────
+  it('strips rawContent when present in raw input', () => {
+    const result = metadataExtractionOnly([makeRaw({ rawContent: '<html>...</html>' })])
+    expect('rawContent' in result[0]).toBe(false)
+  })
+
+  // ── 6 ─────────────────────────────────────────────────────────────────────
+  it('strips unknown extra fields and calls logger.warn', () => {
+    const result = metadataExtractionOnly([
+      makeRaw({ somePrivateField: 'secret', anotherField: 42 } as any),
+    ])
+
+    expect('somePrivateField' in result[0]).toBe(false)
+    expect('anotherField' in result[0]).toBe(false)
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching('stripped unexpected fields'),
+      expect.objectContaining({
+        unknownKeys: expect.arrayContaining(['somePrivateField', 'anotherField']),
+      }),
+    )
+  })
+
+  // ── 7 ─────────────────────────────────────────────────────────────────────
+  it('does NOT call logger.warn when no unexpected fields exist', () => {
+    metadataExtractionOnly([makeRaw()])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  // ── 8 ─────────────────────────────────────────────────────────────────────
+  it('calls logger.info for each extracted record', () => {
+    metadataExtractionOnly([
+      makeRaw({ messageId: 'msg-a' }),
+      makeRaw({ messageId: 'msg-b' }),
+    ])
+
+    expect(logger.info).toHaveBeenCalledTimes(2)
+
+    const calls = (logger.info as jest.Mock).mock.calls
+    expect(calls[0][0]).toMatch('Receipt metadata extracted')
+    expect(calls[1][0]).toMatch('Receipt metadata extracted')
+  })
+
+  // ── 9 ─────────────────────────────────────────────────────────────────────
+  it('handles null / undefined optional fields gracefully', () => {
+    const raw = makeRaw({
+      amount: null,
+      currency: null,
+      interval: null,
+      threadId: null,
+      from: null,
+      subject: null,
+      name: null,
+    })
+
+    // Explicitly assert it does not throw
+    expect(() => metadataExtractionOnly([raw])).not.toThrow()
+
+    const result = metadataExtractionOnly([raw])
+    expect(result[0].amount).toBeNull()
+    expect(result[0].currency).toBeNull()
+    expect(result[0].interval).toBeNull()
+    expect(result[0].threadId).toBeNull()
+    expect(result[0].from).toBeNull()
+    expect(result[0].subject).toBeNull()
+    expect(result[0].name).toBeNull()
+  })
+
+  // ── 10 ────────────────────────────────────────────────────────────────────
+  it('handles multiple raw results', () => {
+    const raws = [
+      makeRaw({ messageId: 'msg-1' }),
+      makeRaw({ messageId: 'msg-2' }),
+      makeRaw({ messageId: 'msg-3' }),
+    ]
+    const result = metadataExtractionOnly(raws)
+
+    expect(result).toHaveLength(3)
+    result.forEach((r) => expect(r.bodyExcluded).toBe(true))
+  })
+
+  // ── 11 ────────────────────────────────────────────────────────────────────
+  it('strips body even when combined with unknown fields', () => {
+    const result = metadataExtractionOnly([
+      makeRaw({ body: 'some body text', unknownExtra: 'value' } as any),
+    ])
+
+    expect('body' in result[0]).toBe(false)
+    expect('unknownExtra' in result[0]).toBe(false)
+  })
+
+  // ── 12 ────────────────────────────────────────────────────────────────────
+  it('does not include body in the logger.info call', () => {
+    metadataExtractionOnly([makeRaw({ body: 'conversational text' })])
+
+    const infoCalls = (logger.info as jest.Mock).mock.calls
+    infoCalls.forEach((callArgs) => {
+      const serialized = JSON.stringify(callArgs)
+      expect(serialized).not.toContain('conversational text')
+    })
+  })
+})
+
+// ─── logScanMetadata ──────────────────────────────────────────────────────────
+
+describe('logScanMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // ── 1 ─────────────────────────────────────────────────────────────────────
+  it('does nothing when metadata array is empty', async () => {
+    const supabaseMock = makeSupabaseMock()
+
+    await logScanMetadata('user-1', [], supabaseMock as any)
+
+    expect(supabaseMock.from).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+
+  // ── 2 ─────────────────────────────────────────────────────────────────────
+  it('inserts rows into audit_logs table', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    expect(supabaseMock.from).toHaveBeenCalledWith('audit_logs')
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    expect(insertMock).toHaveBeenCalledTimes(1)
+  })
+
+  // ── 3 ─────────────────────────────────────────────────────────────────────
+  it('each inserted row has action = email_receipt_extracted and resource_type = email_scan', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    const rows = insertMock.mock.calls[0][0]
+
+    expect(rows[0].action).toBe('email_receipt_extracted')
+    expect(rows[0].resource_type).toBe('email_scan')
+    expect(rows[0].user_id).toBe('user-1')
+  })
+
+  // ── 4 ─────────────────────────────────────────────────────────────────────
+  it('the metadata payload in each row never contains a body field', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    const rows = insertMock.mock.calls[0][0]
+
+    expect(rows[0].metadata.body).toBeUndefined()
+    expect(rows[0].metadata.rawContent).toBeUndefined()
+  })
+
+  // ── 5 ─────────────────────────────────────────────────────────────────────
+  it('the metadata payload contains amount, currency, and receivedAt', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    const rows = insertMock.mock.calls[0][0]
+
+    expect(rows[0].metadata.amount).toBe(15.99)
+    expect(rows[0].metadata.currency).toBe('USD')
+    expect(rows[0].metadata.receivedAt).toBe('2024-06-01T10:00:00Z')
+  })
+
+  // ── 6 ─────────────────────────────────────────────────────────────────────
+  it('the metadata payload always includes bodyExcluded: true', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    const rows = insertMock.mock.calls[0][0]
+
+    expect(rows[0].metadata.bodyExcluded).toBe(true)
+  })
+
+  // ── 7 ─────────────────────────────────────────────────────────────────────
+  it('throws and logs on database error', async () => {
+    const supabaseMock = {
+      from: jest.fn().mockReturnValue({
+        insert: jest.fn().mockResolvedValue({ error: { message: 'DB failure' } }),
+      }),
+    }
+    const metadata = metadataExtractionOnly([makeRaw()])
+
+    await expect(
+      logScanMetadata('user-1', metadata, supabaseMock as any),
+    ).rejects.toBeDefined()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching('Failed to log scan metadata'),
+      expect.anything(),
+    )
+  })
+
+  // ── 8 ─────────────────────────────────────────────────────────────────────
+  it('inserts all records in a single bulk call', async () => {
+    const supabaseMock = makeSupabaseMock()
+    const metadata = metadataExtractionOnly([
+      makeRaw({ messageId: 'msg-1' }),
+      makeRaw({ messageId: 'msg-2' }),
+      makeRaw({ messageId: 'msg-3' }),
+    ])
+
+    await logScanMetadata('user-1', metadata, supabaseMock as any)
+
+    const insertMock = supabaseMock.from().insert as jest.Mock
+    expect(insertMock).toHaveBeenCalledTimes(1)
+
+    const rows = insertMock.mock.calls[0][0]
+    expect(rows).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
Close: #290
## Description
1. `backend/services/email-scanner.ts` — the privacy boundary

This is the new central module. It owns two exported types and two exported functions:

**`ReceiptMetadata` interface**
The only shape that may cross into the database. The key safety features are:
- Every financial field (`amount`, `currency`, `interval`) and temporal field (`receivedAt`) is listed
- `proof.contentHash` carries the **SHA-256 of the body** — proving the body was processed without storing it
- `bodyExcluded: true` is a **TypeScript literal type**, not `boolean`. That means the compiler will reject any object claiming to be a `ReceiptMetadata` unless it was explicitly built with `bodyExcluded: true as const`, making it impossible to accidentally bypass the filter

metadataExtractionOnly(rawResults)`**
The filter itself. Uses a **whitelist destructuring** approach:

```SYNCRO/backend/services/email-scanner.ts#L100-125
    const {
      provider, messageId, threadId, receivedAt, from, subject,
      name, amount, currency, interval, signals, confidence, proof,
      body: _body,            // ← explicitly named and discarded
      rawContent: _rawContent, // ← explicitly named and discarded
      ...unknownFields        // ← captures anything else for auditing
    } = result
```

- Fields not named in the destructure are structurally excluded from the returned object — no `delete` calls, no runtime checks
- `_body` and `_rawContent` bindings make the intentional omission visible to every code reviewer and linter
- Unexpected upstream fields hit `logger.warn` so new fields from the email providers can't silently slip through
- Every extracted record is logged with `logger.info` showing price, dates, and confidence — **never** body text

**`logScanMetadata(userId, metadata, supabaseClient)`**
Persists filtered metadata to `audit_logs`. Accepts `SupabaseClient` as a parameter (not a singleton) so it's fully injectable and testable. The TypeScript signature enforces that only pre-filtered `ReceiptMetadata[]` can be passed in.

Briefly describe what this PR does.

---

## Related Issue
3. `gmail-service.ts` & `outlook-service.ts` — enforced at the service layer

Both scan functions now type their accumulator as `RawScanResult[]` and pipe the whole array through `metadataExtractionOnly` before the return:

```SYNCRO/backend/services/gmail-service.ts#L109-160
  const results: RawScanResult[] = [];
  // ... populate results ...
  return metadataExtractionOnly(results);
```

This means every call path — REST endpoint, direct import, or future queuing system — is forced through the filter. There is no way to get a raw result out of these functions.

Closes #290

---

## Test Plan
 `tests/email-scanner.test.ts` — 20 tests, 0 failures

The suite is split into two `describe` blocks with 12 + 8 tests that together verify every acceptance criterion:

| Test | Acceptance criterion covered |
|---|---|
| "strips the body field when present" | Body never reaches the output |
| "does not include body in the logger.info call" | Body never reaches the log |
| "the metadata payload in each row never contains a body field" | Body never reaches the database |
| "the metadata payload contains amount, currency, and receivedAt" | Price and dates are preserved |
| "the metadata payload always includes bodyExcluded: true" | Privacy sentinel is always stamped |
| "strips unknown extra fields and calls logger.warn" | Unknown upstream fields are surfaced and dropped |
| "inserts all records in a single bulk call" | Efficient DB writes
- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
