### PR TITLE
feat: add dependency vulnerability scanning to CI (#335)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,46 @@ jobs:
         run: node backend/scripts/validate-env.js
 
   # ──────────────────────────────────────────────
-  # Job 2: Build the client
+  # Job 2: Dependency vulnerability scan
+  # Blocks PRs with High or Critical vulnerabilities.
+  # ──────────────────────────────────────────────
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    needs: validate-env
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: Audit client dependencies
+        working-directory: client
+        run: npm audit --audit-level=high --omit=dev
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Audit backend dependencies
+        working-directory: backend
+        run: pnpm audit --audit-level=high --prod
+
+  # ──────────────────────────────────────────────
+  # Job 3: Build the client
   # Only runs if validate-env passes.
   # ──────────────────────────────────────────────
   build-client:
     name: Build Client
     runs-on: ubuntu-latest
-    needs: validate-env
+    needs: [validate-env, security-audit]
 
     steps:
       - name: Checkout repository
@@ -93,7 +126,7 @@ jobs:
   test-backend:
     name: Test Backend
     runs-on: ubuntu-latest
-    needs: validate-env
+    needs: [validate-env, security-audit]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Adds a `security-audit` job to `.github/workflows/ci.yml` that blocks PRs containing High or Critical severity vulnerabilities.

## Changes
- New `security-audit` job (runs after `validate-env`):
  - **Client:** `npm audit --audit-level=high --omit=dev` (skips devDependencies)
  - **Backend:** `pnpm audit --audit-level=high --prod` (production deps only)
- `build-client` and `test-backend` now `needs: [validate-env, security-audit]` — so a vulnerable PR blocks all downstream jobs

## Acceptance Criteria
- [x] PR shows a red X if a High/Critical vulnerable package is added
- [x] Dev-only vulnerabilities do not block the PR
- [x] No new dependencies introduced (uses built-in `npm audit` / `pnpm audit`)

Closes #335