### PR TITLE
#428 Refactor components/pages/teams.tsx to eliminate any models

### DIFF
--- a/client/components/pages/teams.tsx
+++ b/client/components/pages/teams.tsx
@@ -4,12 +4,14 @@ import { useState } from "react"
 import { Users, Plus, Search, Trash2, TrendingUp, Activity, Mail, Briefcase, User, DollarSign } from "lucide-react"
 import { showToast } from "@/components/ui/toast"
 import { StatusBadge, normalizeStatus } from "@/components/ui/status-badge"
+import { TeamMember, Workspace, TeamSubscription, EmailAccount } from "@/lib/types"
+import { canChangeRole, canRemoveMember } from "@/lib/team-utils"
 
 interface TeamsPageProps {
-  workspace: any
-  subscriptions: any[]
+  workspace: Workspace
+  subscriptions: TeamSubscription[]
   darkMode: boolean
-  emailAccounts: any[]
+  emailAccounts: EmailAccount[]
 }
 
 export default function TeamsPage({ workspace, subscriptions, darkMode, emailAccounts }: TeamsPageProps) {
@@ -26,7 +28,7 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
     },
   })
 
-  const [members, setMembers] = useState([
+  const [members, setMembers] = useState<TeamMember[]>([
     {
       id: 1,
       name: "Joy Anderson",
@@ -139,7 +141,7 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
   }
 
   const handleMemberLeave = (memberId: number) => {
-    const member = members.find((m: any) => m.id === memberId)
+    const member = members.find((m) => m.id === memberId)
     if (!member) return
 
     if (member.subscriptions.length === 0) {
@@ -149,7 +151,7 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
       )
 
       if (confirmDelete) {
-        setMembers(members.filter((m: any) => m.id !== memberId))
+        setMembers(members.filter((m) => m.id !== memberId))
       }
       return
     }
@@ -161,27 +163,24 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
 
     if (action) {
       // Archive member (mark as inactive)
-      setMembers(members.map((m: any) => (m.id === memberId ? { ...m, status: "inactive", leftAt: new Date() } : m)))
+      setMembers(members.map((m) => (m.id === memberId ? { ...m, status: "inactive", leftAt: new Date() } : m)))
     } else {
       // Transfer subscriptions to admin
-      const admin = members.find((m: any) => m.role === "Admin")
+      const admin = members.find((m) => m.role === "Admin")
       if (admin) {
         // In real implementation, would transfer subscriptions
         alert(`Subscriptions transferred to ${admin.name}`)
-        setMembers(members.filter((m: any) => m.id !== memberId))
+        setMembers(members.filter((m) => m.id !== memberId))
       }
     }
   }
 
   const handleDeleteMember = (id: number) => {
-    const member = members.find((m) => m.id === id)
-    if (!member) return
-
-    const adminCount = members.filter((m: any) => m.role === "Admin" && m.status === "active").length
-    if (member.role === "Admin" && adminCount === 1) {
+    const check = canRemoveMember(members, id);
+    if (!check.allowed) {
       showToast({
         title: "Cannot remove last admin",
-        description: "You must have at least one admin in the team. Promote another member to admin first.",
+        description: check.reason || "",
         variant: "error",
       })
       return
@@ -191,16 +190,13 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
   }
 
   const handleChangeRole = (memberId: number, newRole: string) => {
-    const member = members.find((m: any) => m.id === memberId)
-    if (!member) return
-
-    const adminCount = members.filter((m: any) => m.role === "Admin" && m.status === "active").length
-    if (member.role === "Admin" && newRole !== "Admin" && adminCount === 1) {
-      alert("Cannot change role: You must have at least one admin in the team. Promote another member to admin first.")
+    const check = canChangeRole(members, memberId, newRole);
+    if (!check.allowed) {
+      alert(check.reason)
       return
     }
 
-    setMembers(members.map((m: any) => (m.id === memberId ? { ...m, role: newRole } : m)))
+    setMembers(members.map((m) => (m.id === memberId ? { ...m, role: newRole } : m)))
   }
 
   /**
@@ -223,31 +219,31 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
     }
   }
 
-  const getFilteredEmailAccounts = (member: any) => {
+  const getFilteredEmailAccounts = (member: TeamMember) => {
     if (showWorkEmailsOnly) {
-      return member.emailAccounts.filter((acc: any) => acc.isWorkEmail)
+      return member.emailAccounts.filter((acc) => acc.isWorkEmail)
     }
     return member.emailAccounts
   }
 
-  const getFilteredSubscriptions = (member: any) => {
+  const getFilteredSubscriptions = (member: TeamMember) => {
     if (showWorkEmailsOnly) {
-      const workEmails = member.emailAccounts.filter((acc: any) => acc.isWorkEmail).map((acc: any) => acc.email)
-      return member.subscriptions.filter((sub: any) => workEmails.includes(sub.email))
+      const workEmails = member.emailAccounts.filter((acc) => acc.isWorkEmail).map((acc) => acc.email)
+      return member.subscriptions.filter((sub) => workEmails.includes(sub.email))
     }
     return member.subscriptions
   }
 
-  const totalUsage = members.reduce((sum: number, member: any) => {
+  const totalUsage = members.reduce((sum: number, member: TeamMember) => {
     const filteredSubs = getFilteredSubscriptions(member)
-    return sum + filteredSubs.reduce((subSum: number, sub: any) => subSum + sub.usage, 0)
+    return sum + filteredSubs.reduce((subSum: number, sub) => subSum + sub.usage, 0)
   }, 0)
 
-  const totalEmailAccounts = members.reduce((sum: number, member: any) => sum + getFilteredEmailAccounts(member).length, 0)
+  const totalEmailAccounts = members.reduce((sum: number, member: TeamMember) => sum + getFilteredEmailAccounts(member).length, 0)
 
   const getDepartmentSpending = () => {
     const spending: Record<string, number> = {}
-    members.forEach((member: any) => {
+    members.forEach((member: TeamMember) => {
       if (!spending[member.department]) {
         spending[member.department] = 0
       }
@@ -600,7 +596,7 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
       {activeTab === "emails" && (
         <div className="space-y-4">
           {members
-            .filter((m: any) => getFilteredEmailAccounts(m).length > 0)
+            .filter((m) => getFilteredEmailAccounts(m).length > 0)
             .map((member) => (
               <div
                 key={member.id}
@@ -627,8 +623,8 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
                 </div>
 
                 <div className="space-y-3">
-                  {getFilteredEmailAccounts(member).map((emailAccount: any, idx: number) => {
-                    const emailSubs = member.subscriptions.filter((sub: any) => sub.email === emailAccount.email)
+                  {getFilteredEmailAccounts(member).map((emailAccount, idx: number) => {
+                    const emailSubs = member.subscriptions.filter((sub) => sub.email === emailAccount.email)
                     const emailSpend = emailSubs.length * 20
                     return (
                       <div
@@ -697,7 +693,7 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
       {activeTab === "usage" && (
         <div className="space-y-6">
           {members
-            .filter((m: any) => m.status === "active")
+            .filter((m) => m.status === "active")
             .map((member) => {
               const filteredSubs = getFilteredSubscriptions(member)
               if (filteredSubs.length === 0 && showWorkEmailsOnly) return null
@@ -730,8 +726,8 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
                   </div>
 
                   <div className="space-y-3">
-                    {filteredSubs.map((sub: any, idx: number) => {
-                      const emailAccount = member.emailAccounts.find((acc: any) => acc.email === sub.email)
+                    {filteredSubs.map((sub, idx: number) => {
+                      const emailAccount = member.emailAccounts.find((acc) => acc.email === sub.email)
                       return (
                         <div
                           key={idx}

--- a/client/lib/__tests__/team-utils.test.ts
+++ b/client/lib/__tests__/team-utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { canChangeRole, canRemoveMember } from "../team-utils";
+import { TeamMember } from "../types";
+
+const mockMember = (id: number, role: string, status: string = "active"): TeamMember => ({
+  id,
+  name: `User ${id}`,
+  email: `user${id}@example.com`,
+  role,
+  department: "Engineering",
+  permissions: [],
+  status,
+  toolsUsed: 0,
+  monthlySpend: 0,
+  emailAccounts: [],
+  subscriptions: []
+});
+
+describe("team-utils", () => {
+  describe("canRemoveMember", () => {
+    it("should allow removing a non-admin", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Member"),
+      ];
+      const result = canRemoveMember(members, 2);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should allow removing an admin if there are other active admins", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Admin"),
+      ];
+      const result = canRemoveMember(members, 1);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should not allow removing the last active admin", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Member"),
+      ];
+      const result = canRemoveMember(members, 1);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("Cannot remove last admin");
+    });
+
+    it("should not allow removing the only active admin even if inactive admins exist", () => {
+      const members = [
+        mockMember(1, "Admin", "active"),
+        mockMember(2, "Admin", "inactive"),
+      ];
+      const result = canRemoveMember(members, 1);
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("canChangeRole", () => {
+    it("should allow a non-admin to change their role", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Member"),
+      ];
+      const result = canChangeRole(members, 2, "Viewer");
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should allow an admin to change their role if another active admin exists", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Admin"),
+      ];
+      const result = canChangeRole(members, 1, "Member");
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should not allow the last active admin to change their role", () => {
+      const members = [
+        mockMember(1, "Admin"),
+        mockMember(2, "Member"),
+      ];
+      const result = canChangeRole(members, 1, "Member");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("Cannot change role");
+    });
+  });
+});

--- a/client/lib/team-utils.ts
+++ b/client/lib/team-utils.ts
@@ -1,0 +1,40 @@
+import { TeamMember, TeamSubscription, EmailAccount } from "./types";
+
+export function canChangeRole(members: TeamMember[], memberId: number, newRole: string): { allowed: boolean; reason?: string } {
+  const member = members.find((m) => m.id === memberId);
+  if (!member) return { allowed: false, reason: "Member not found" };
+
+  const adminCount = members.filter((m) => m.role === "Admin" && m.status === "active").length;
+  if (member.role === "Admin" && newRole !== "Admin" && adminCount <= 1) {
+    return { allowed: false, reason: "Cannot change role: You must have at least one admin in the team. Promote another member to admin first." };
+  }
+
+  return { allowed: true };
+}
+
+export function canRemoveMember(members: TeamMember[], memberId: number): { allowed: boolean; reason?: string } {
+  const member = members.find((m) => m.id === memberId);
+  if (!member) return { allowed: false, reason: "Member not found" };
+
+  const adminCount = members.filter((m) => m.role === "Admin" && m.status === "active").length;
+  if (member.role === "Admin" && adminCount <= 1) {
+    return { allowed: false, reason: "Cannot remove last admin: You must have at least one admin in the team. Promote another member to admin first." };
+  }
+
+  return { allowed: true };
+}
+
+export function getFilteredEmailAccounts(member: TeamMember, showWorkEmailsOnly: boolean): EmailAccount[] {
+  if (showWorkEmailsOnly) {
+    return member.emailAccounts.filter((acc) => acc.isWorkEmail);
+  }
+  return member.emailAccounts;
+}
+
+export function getFilteredSubscriptions(member: TeamMember, showWorkEmailsOnly: boolean): TeamSubscription[] {
+  if (showWorkEmailsOnly) {
+    const workEmails = member.emailAccounts.filter((acc) => acc.isWorkEmail).map((acc) => acc.email);
+    return member.subscriptions.filter((sub) => workEmails.includes(sub.email));
+  }
+  return member.subscriptions;
+}

--- a/client/lib/types.ts
+++ b/client/lib/types.ts
@@ -166,3 +166,46 @@ export interface MFAStatus {
   nextLevel: 'aal1' | 'aal2';
   recoveryCodesRemaining: number;
 }
+
+// Teams Page Models
+export interface EmailAccount {
+  email: string;
+  isWorkEmail: boolean;
+}
+
+export interface TeamSubscription {
+  name: string;
+  usage: number;
+  lastUsed: string;
+  email: string;
+}
+
+export type TeamRole = "Admin" | "Billing Manager" | "Member" | "Viewer" | string;
+export type TeamMemberStatus = "active" | "pending" | "inactive" | string;
+
+export interface TeamMember {
+  id: number;
+  name: string;
+  email: string;
+  role: TeamRole;
+  department: string;
+  permissions: string[];
+  status: TeamMemberStatus;
+  toolsUsed: number;
+  monthlySpend: number;
+  emailAccounts: EmailAccount[];
+  subscriptions: TeamSubscription[];
+  leftAt?: Date;
+}
+
+export interface Workspace {
+  id?: string;
+  name?: string;
+  domain?: string;
+  plan?: string;
+}
+
+export interface TeamSettings {
+  spendingLimit: number;
+  departmentBudgets: Record<string, number>;
+}


### PR DESCRIPTION


closes #428 

### Changes Made

- **Type Definitions**: Added strict interfaces for `TeamMember`, `Workspace`, `TeamSubscription`, `EmailAccount`, and `TeamSettings` to `client/lib/types.ts`.
- **Component Refactoring**: Removed all `any` usages from `client/components/pages/teams.tsx`. Refactored `TeamsPageProps`, `useState` declarations, and all inline `.map()`, `.filter()`, and `.reduce()` operations to use strict types.
- **Logic Extraction**: Abstracted the complex role-change and removal guard logic out of the UI component and into pure, testable functions in a new utility file (`client/lib/team-utils.ts`).
- **Unit Testing**: Added tests in `client/lib/__tests__/team-utils.test.ts` to strictly enforce the admin-count invariants. 
  - Validates that the last active admin cannot be removed.
  - Validates that the last active admin cannot change their role.
  - Ensures non-admins and teams with multiple admins can freely change roles or be removed.

### Acceptance Criteria Met

- [x] Major team workflows compile with strict types.
- [x] Admin-count invariants are enforced with tests.

### How to Verify
Run the newly added utility tests via vitest:
```bash
npx vitest run client/lib/__tests__/team-utils.test.ts
```
And verify strict TypeScript compilation across the client:
```bash
npm run build
```
it ran successful