### PR TITLE
Type notification panel props and callbacks

### DIFF
--- a/client/components/app/app-client.tsx
+++ b/client/components/app/app-client.tsx
@@ -29,6 +29,7 @@ import type { Subscription as DBSubscription } from "@/lib/supabase/subscription
 import { createSubscription } from "@/lib/supabase/subscriptions";
 import { isOnline } from "@/lib/network-utils";
 import type { Currency } from "@/lib/currency-utils";
+import type { DetectedSubscription } from "@/lib/notification-types";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
 import { useConfirmationDialog } from "@/hooks/use-confirmation-dialog";
@@ -469,7 +470,7 @@ function AppContent({
         });
     };
 
-    const handleAddFromNotification = (subscription: any) => {
+    const handleAddFromNotification = (subscription: DetectedSubscription) => {
         if (checkDuplicate(subscriptions, subscription.name)) {
             alert(`${subscription.name} already exists in your subscriptions!`);
             return;

--- a/client/components/notifications-panel.tsx
+++ b/client/components/notifications-panel.tsx
@@ -14,13 +14,19 @@ import {
 } from "lucide-react"
 import { useEffect, useRef } from "react"
 import { EmptyState } from "@/components/ui/empty-state"
+import type {
+  Notification,
+  DetectedSubscription,
+  NotificationActionHandler,
+  NotificationType,
+} from "@/lib/notification-types"
 
 interface NotificationsPanelProps {
-  notifications: any[]
-  onMarkRead: (id: number) => void
+  notifications: Notification[]
+  onMarkRead: (id: Notification["id"]) => void
   onClose: () => void
-  onAddSubscription: (subscription: any) => void
-  onResolveAction: (action: string, data: any) => void
+  onAddSubscription: (subscription: DetectedSubscription) => void
+  onResolveAction: NotificationActionHandler
   darkMode?: boolean
 }
 
@@ -39,7 +45,7 @@ export default function NotificationsPanel({
     closeButtonRef.current?.focus()
   }, [])
 
-  const getNotificationIcon = (type: string) => {
+  const getNotificationIcon = (type: NotificationType) => {
     const iconClass = "w-5 h-5"
     switch (type) {
       case "duplicate":

--- a/client/hooks/use-notification-actions.ts
+++ b/client/hooks/use-notification-actions.ts
@@ -2,6 +2,10 @@
 
 import { useCallback } from "react";
 import type { Subscription } from "@/lib/supabase/subscriptions";
+import type {
+  NotificationActionHandler,
+  NotificationDuplicateInfo,
+} from "@/lib/notification-types";
 
 interface UseNotificationActionsProps {
   subscriptions: Subscription[];
@@ -22,13 +26,13 @@ export function useNotificationActions({
   onToast,
   onShowInsightsPage,
 }: UseNotificationActionsProps) {
-  const handleResolveNotificationAction = useCallback(
-    (action: string, data: any) => {
+  const handleResolveNotificationAction = useCallback<NotificationActionHandler>(
+    (action, data) => {
       console.log("[v0] Resolving notification action:", action, data);
 
       switch (action) {
         case "resolve_duplicate":
-          const duplicateInfo = data;
+          const duplicateInfo = data as NotificationDuplicateInfo;
           const subsToKeep = duplicateInfo.subscriptions[0];
           const subsToRemove = duplicateInfo.subscriptions.slice(1);
 

--- a/client/hooks/use-notifications.ts
+++ b/client/hooks/use-notifications.ts
@@ -8,15 +8,7 @@ import {
 } from "@/lib/subscription-utils";
 import type { Subscription } from "@/lib/supabase/subscriptions";
 import type { BudgetAlert } from "@/lib/budget-utils";
-
-interface Notification {
-  id: string | number;
-  title: string;
-  description: string;
-  type: string;
-  read: boolean;
-  [key: string]: any;
-}
+import type { Notification } from "@/lib/notification-types";
 
 interface UseNotificationsProps {
   subscriptions: Subscription[];
@@ -46,6 +38,7 @@ export function useNotifications({
         count: 2,
         totalCost: 40,
         potentialSavings: 20,
+        subscriptions: [{ id: 1, name: "ChatGPT Plus" }],
       },
     },
     {
@@ -151,7 +144,7 @@ export function useNotifications({
     });
   }, [priceChanges, renewalReminders, budgetAlert, consolidationSuggestions]);
 
-  const handleMarkNotificationRead = useCallback((id: number) => {
+  const handleMarkNotificationRead = useCallback((id: Notification["id"]) => {
     setNotifications((prev) =>
       prev.map((n) => (n.id === id ? { ...n, read: true } : n))
     );

--- a/client/lib/notification-types.ts
+++ b/client/lib/notification-types.ts
@@ -1,0 +1,119 @@
+export type NotificationAction =
+  | "resolve_duplicate"
+  | "cancel_unused"
+  | "cancel_trial"
+  | "view_consolidation"
+
+export type NotificationType =
+  | "duplicate"
+  | "unused"
+  | "trial"
+  | "price_change"
+  | "renewal"
+  | "budget"
+  | "consolidation"
+  | "alert"
+  | "info"
+
+export interface NotificationBase {
+  id: string | number
+  title: string
+  description: string
+  type: NotificationType
+  read: boolean
+}
+
+export interface NotificationDuplicateInfo {
+  subscriptions: Array<{
+    id: number
+    name: string
+    [key: string]: unknown
+  }>
+  potentialSavings: number
+  name: string
+  count: number
+  totalCost: number
+}
+
+export interface DetectedSubscription {
+  name: string
+  category: string
+  price: number
+  logo: string
+  tags: string[]
+  renewsIn: number
+  status: string
+  icon: string
+  color: string
+  renewalUrl: string
+  emailAccountId: number
+  [key: string]: unknown
+}
+
+export interface DuplicateNotification extends NotificationBase {
+  type: "duplicate"
+  duplicateInfo: NotificationDuplicateInfo
+}
+
+export interface UnusedNotification extends NotificationBase {
+  type: "unused"
+  subscriptionId: number
+}
+
+export interface TrialNotification extends NotificationBase {
+  type: "trial"
+  subscriptionId: number
+}
+
+export interface PriceChangeNotification extends NotificationBase {
+  type: "price_change"
+  priceChangeInfo: unknown
+}
+
+export interface RenewalNotification extends NotificationBase {
+  type: "renewal"
+  subscriptionId: number
+}
+
+export interface BudgetNotification extends NotificationBase {
+  type: "budget"
+}
+
+export interface ConsolidationNotification extends NotificationBase {
+  type: "consolidation"
+  suggestionId: number
+}
+
+export interface AlertNotification extends NotificationBase {
+  type: "alert"
+  detectedSubscription: DetectedSubscription
+}
+
+export interface InfoNotification extends NotificationBase {
+  type: "info"
+}
+
+export type Notification =
+  | DuplicateNotification
+  | UnusedNotification
+  | TrialNotification
+  | PriceChangeNotification
+  | RenewalNotification
+  | BudgetNotification
+  | ConsolidationNotification
+  | AlertNotification
+  | InfoNotification
+
+export type NotificationActionPayloadMap = {
+  resolve_duplicate: NotificationDuplicateInfo
+  cancel_unused: number
+  cancel_trial: number
+  view_consolidation: number
+}
+
+export type NotificationActionHandler = {
+  (action: "resolve_duplicate", payload: NotificationDuplicateInfo): void
+  (action: "cancel_unused", payload: number): void
+  (action: "cancel_trial", payload: number): void
+  (action: "view_consolidation", payload: number): void
+}


### PR DESCRIPTION
## Summary
Fixes untyped notification panel props and callbacks by implementing discriminated unions for notification types and action payloads.

## Changes
- ✅ Created `client/lib/notification-types.ts` with:
  - `Notification` discriminated union (9 notification types)
  - `NotificationAction` union for 4 action types
  - `NotificationActionHandler` with exhaustive action-to-payload mapping
  - `NotificationDuplicateInfo` and `DetectedSubscription` types

- ✅ Updated `client/components/notifications-panel.tsx`:
  - `notifications: any[]` → `notifications: Notification[]`
  - `onMarkRead: (id: number)` → `onMarkRead: (id: Notification["id"])`
  - `onAddSubscription: (subscription: any)` → `onAddSubscription: (subscription: DetectedSubscription)`
  - `onResolveAction: (action: string, data: any)` → `onResolveAction: NotificationActionHandler`

- ✅ Updated `client/hooks/use-notification-actions.ts`:
  - Handler callback now typed with `NotificationActionHandler`
  - Payload validation at compile time per action type

- ✅ Updated `client/hooks/use-notifications.ts`:
  - Removed untyped local interface
  - Uses exported `Notification` type from notification-types

- ✅ Updated `client/components/app/app-client.tsx`:
  - `handleAddFromNotification` now accepts `DetectedSubscription`

## Acceptance Criteria Met
- [x] Notification actions are exhaustively typed
- [x] Invalid action payloads fail at compile time
- [x] All props have precise types instead of `any[]`

## Testing
Manual type verification shows discriminated union correctly narrows:
- `resolve_duplicate` → requires `NotificationDuplicateInfo` payload
- `cancel_unused` → requires `number` (subscriptionId)
- `cancel_trial` → requires `number` (subscriptionId)
- `view_consolidation` → requires `number` (suggestionId)

## Related Issue

Closes #432
---

