### PR TITLE
Strongly type integrations page state and add manage-action tests

### DIFF
--- a/client/components/__tests__/integrations-page.test.tsx
+++ b/client/components/__tests__/integrations-page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import IntegrationsPage from '../pages/integrations'
+import { Integration, IntegrationStatus } from '@/lib/integration-types'
+
+const integrations: Integration[] = [
+  {
+    id: 1,
+    name: 'GitHub',
+    type: 'Source Control',
+    status: IntegrationStatus.Connected,
+    lastSync: '5 minutes ago',
+    accounts: 2,
+  },
+  {
+    id: 2,
+    name: 'Gemini',
+    type: 'AI Assistant',
+    status: IntegrationStatus.Disconnected,
+    lastSync: 'Never',
+    accounts: 0,
+  },
+]
+
+describe('IntegrationsPage', () => {
+  test('opens manage modal when manage button is clicked', () => {
+    render(<IntegrationsPage integrations={integrations} onToggle={jest.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage' }))
+
+    expect(screen.getByText('Manage GitHub')).toBeInTheDocument()
+    expect(screen.getByText('Type:')).toBeInTheDocument()
+    expect(screen.getByText('Source Control')).toBeInTheDocument()
+  })
+
+  test('calls onToggle when the integration toggle button is clicked', () => {
+    const onToggle = jest.fn()
+
+    render(<IntegrationsPage integrations={integrations} onToggle={onToggle} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connected' }))
+
+    expect(onToggle).toHaveBeenCalledWith(1)
+  })
+
+  test('renders configure button for disconnected integrations', () => {
+    render(<IntegrationsPage integrations={integrations} onToggle={jest.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Configure' })).toBeInTheDocument()
+  })
+})

--- a/client/components/modals/manage-integration-modal.tsx
+++ b/client/components/modals/manage-integration-modal.tsx
@@ -2,8 +2,10 @@
 
 import { X } from "lucide-react"
 
+import type { Integration } from "@/lib/integration-types"
+
 interface ManageIntegrationModalProps {
-  integration: any
+  integration: Integration
   onClose: () => void
 }
 

--- a/client/components/pages/integrations.tsx
+++ b/client/components/pages/integrations.tsx
@@ -2,16 +2,18 @@
 
 import { useState } from "react"
 import ManageIntegrationModal from "@/components/modals/manage-integration-modal"
+import type { Integration } from "@/lib/integration-types"
+import { IntegrationStatus } from "@/lib/integration-types"
 
 interface IntegrationsPageProps {
-  integrations: any[]
+  integrations: Integration[]
   onToggle: (id: number) => void
   darkMode?: boolean
 }
 
 export default function IntegrationsPage({ integrations, onToggle, darkMode }: IntegrationsPageProps) {
-  const [sortBy, setSortBy] = useState("name")
-  const [selectedIntegration, setSelectedIntegration] = useState<any>(null)
+  const [sortBy, setSortBy] = useState<"name" | "recent">("name")
+  const [selectedIntegration, setSelectedIntegration] = useState<Integration | null>(null)
   const [showManageModal, setShowManageModal] = useState(false)
 
   const supportedTools = [
@@ -38,7 +40,7 @@ export default function IntegrationsPage({ integrations, onToggle, darkMode }: I
     return 0
   })
 
-  const handleManageIntegration = (integration: any) => {
+  const handleManageIntegration = (integration: Integration) => {
     setSelectedIntegration(integration)
     setShowManageModal(true)
   }
@@ -64,7 +66,7 @@ export default function IntegrationsPage({ integrations, onToggle, darkMode }: I
                 <button
                   onClick={() => onToggle(integration.id)}
                   className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    integration.status === "connected"
+                    integration.status === IntegrationStatus.Connected
                       ? darkMode
                         ? "bg-[#007A5C]/20 text-[#007A5C]"
                         : "bg-green-100 text-green-700"
@@ -73,7 +75,7 @@ export default function IntegrationsPage({ integrations, onToggle, darkMode }: I
                         : "bg-gray-100 text-gray-700"
                   }`}
                 >
-                  {integration.status === "connected" ? "Connected" : "Disconnected"}
+                  {integration.status === IntegrationStatus.Connected ? "Connected" : "Disconnected"}
                 </button>
               </div>
 
@@ -88,7 +90,7 @@ export default function IntegrationsPage({ integrations, onToggle, darkMode }: I
                   darkMode ? "text-[#FFD166] hover:bg-[#374151]" : "text-blue-600 hover:bg-blue-50"
                 }`}
               >
-                {integration.status === "connected" ? "Manage" : "Configure"}
+                {integration.status === IntegrationStatus.Connected ? "Manage" : "Configure"}
               </button>
             </div>
           ))}

--- a/client/hooks/use-email-accounts.ts
+++ b/client/hooks/use-email-accounts.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import type { Subscription } from "@/lib/supabase/subscriptions";
+import type { Integration, IntegrationStatus } from "@/lib/integration-types";
 
 interface UseEmailAccountsProps {
   initialAccounts: any[];
@@ -19,12 +20,12 @@ export function useEmailAccounts({
   onToast,
 }: UseEmailAccountsProps) {
   const [emailAccounts, setEmailAccounts] = useState(initialAccounts);
-  const [integrations, setIntegrations] = useState([
+  const [integrations, setIntegrations] = useState<Integration[]>([
     {
       id: 1,
       name: "Gmail",
       type: "Email Integration",
-      status: "connected",
+      status: IntegrationStatus.Connected,
       lastSync: "2 minutes ago",
       accounts: initialAccounts.length,
     },
@@ -32,7 +33,7 @@ export function useEmailAccounts({
       id: 3,
       name: "Manual tools",
       type: "Self-managed",
-      status: "connected",
+      status: IntegrationStatus.Connected,
       lastSync: "2 minutes ago",
       accounts: 0,
     },
@@ -171,7 +172,10 @@ export function useEmailAccounts({
         int.id === id
           ? {
               ...int,
-              status: int.status === "connected" ? "disconnected" : "connected",
+              status:
+                int.status === IntegrationStatus.Connected
+                  ? IntegrationStatus.Disconnected
+                  : IntegrationStatus.Connected,
             }
           : int
       )

--- a/client/lib/integration-types.ts
+++ b/client/lib/integration-types.ts
@@ -1,0 +1,13 @@
+export enum IntegrationStatus {
+  Connected = "connected",
+  Disconnected = "disconnected",
+}
+
+export interface Integration {
+  id: number
+  name: string
+  type: string
+  status: IntegrationStatus
+  lastSync: string
+  accounts: number
+}


### PR DESCRIPTION
## Summary

This PR strengthens typing for the integrations page by replacing untyped integration state and handlers with a shared `Integration` interface and `IntegrationStatus` enum.

## What changed

- Added `client/lib/integration-types.ts`
  - `Integration` interface
  - `IntegrationStatus` enum
- Updated `client/components/pages/integrations.tsx`
  - `integrations` is now `Integration[]`
  - `selectedIntegration` state is now `Integration | null`
  - `handleManageIntegration` now accepts `Integration`
  - Status checks use `IntegrationStatus.Connected`
- Updated `client/components/modals/manage-integration-modal.tsx`
  - Typed `integration` prop as `Integration`
- Updated `client/hooks/use-email-accounts.ts`
  - Typed `integrations` state as `Integration[]`
  - Replaced raw `"connected"` / `"disconnected"` strings with `IntegrationStatus`
- Added `client/components/__tests__/integrations-page.test.tsx`
  - Verifies manage modal opens
  - Verifies toggle action calls `onToggle`
  - Verifies disconnected integration renders `Configure`

## Acceptance criteria

- [x] Integrations state is strongly typed
- [x] `selectedIntegration` state is strongly typed
- [x] UI actions remain functionally equivalent
- [x] Manage flow behavior is covered by tests

## Related Issue

Closes #431 

---

