### PR TITLE
Unify backend CI package manager to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,9 @@ jobs:
         working-directory: client
         run: npm audit --audit-level=high --omit=dev
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Audit backend dependencies
         working-directory: backend
-        run: pnpm audit --audit-level=high --prod
+        run: npm audit --audit-level=high --omit=dev
 
   # ──────────────────────────────────────────────
   # Job 3: Build the client


### PR DESCRIPTION

## Summary

This PR consolidates backend CI package management by standardizing on `npm` and removing the redundant `pnpm` path in backend workflows.

## What changed

- Updated `.github/workflows/ci.yml`
  - Backend dependency audit now uses `npm audit --audit-level=high --omit=dev`
  - Removed the redundant `pnpm` install/setup step for backend audit
- Confirmed backend CI jobs now rely on `backend/package-lock.json` consistently

## Why

- Prevents lockfile drift between `npm` and `pnpm`
- Reduces CI cache fragmentation and complexity
- Keeps backend dependency install strategy consistent across jobs

## Acceptance criteria

- [x] Backend CI uses a single package-manager strategy
- [x] Dependency install behavior is consistent across backend jobs
- [x] Redundant install paths are removed


Closes #422 

