### PR TITLE
feat(subscriptions): add pause state (#299)

### DIFF
--- a/client/app/api/subscriptions/[id]/pause/route.ts
+++ b/client/app/api/subscriptions/[id]/pause/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest } from "next/server"
+import { z } from "zod"
+import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { HttpStatus } from "@/lib/api/types"
+import { createClient } from "@/lib/supabase/server"
+import { checkOwnership } from "@/lib/api/auth"
+
+const pauseSchema = z.object({
+  resumeAt: z.string().datetime({ offset: true }).optional(),
+  reason: z.string().max(500).optional(),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  return createApiRoute(
+    async (req: NextRequest, context, user) => {
+      if (!user) throw new Error("User not authenticated")
+      if (!id) throw ApiErrors.notFound("Subscription")
+
+      const body = await validateRequestBody(req, pauseSchema)
+
+      if (body.resumeAt && new Date(body.resumeAt) <= new Date()) {
+        throw ApiErrors.validationError("resumeAt must be a future date", "resumeAt")
+      }
+
+      const supabase = await createClient()
+
+      const { data: existing, error: fetchError } = await supabase
+        .from("subscriptions")
+        .select("user_id, status")
+        .eq("id", id)
+        .single()
+
+      if (fetchError || !existing) throw ApiErrors.notFound("Subscription")
+      checkOwnership(user.id, existing.user_id)
+
+      if (existing.status === "paused") {
+        throw ApiErrors.conflict("Subscription is already paused")
+      }
+      if (existing.status === "cancelled") {
+        throw ApiErrors.validationError("Cannot pause a cancelled subscription")
+      }
+
+      const { data, error } = await supabase
+        .from("subscriptions")
+        .update({
+          status: "paused",
+          paused_at: new Date().toISOString(),
+          resumes_at: body.resumeAt ?? null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", id)
+        .eq("user_id", user.id)
+        .select()
+        .single()
+
+      if (error) throw new Error(`Failed to pause subscription: ${error.message}`)
+
+      return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
+    },
+    { requireAuth: true, rateLimit: RateLimiters.standard }
+  )(request)
+}

--- a/client/app/api/subscriptions/[id]/resume/route.ts
+++ b/client/app/api/subscriptions/[id]/resume/route.ts
@@ -1,0 +1,52 @@
+import { type NextRequest } from "next/server"
+import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { HttpStatus } from "@/lib/api/types"
+import { createClient } from "@/lib/supabase/server"
+import { checkOwnership } from "@/lib/api/auth"
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  return createApiRoute(
+    async (req: NextRequest, context, user) => {
+      if (!user) throw new Error("User not authenticated")
+      if (!id) throw ApiErrors.notFound("Subscription")
+
+      const supabase = await createClient()
+
+      const { data: existing, error: fetchError } = await supabase
+        .from("subscriptions")
+        .select("user_id, status")
+        .eq("id", id)
+        .single()
+
+      if (fetchError || !existing) throw ApiErrors.notFound("Subscription")
+      checkOwnership(user.id, existing.user_id)
+
+      if (existing.status !== "paused") {
+        throw ApiErrors.conflict("Subscription is not paused")
+      }
+
+      const { data, error } = await supabase
+        .from("subscriptions")
+        .update({
+          status: "active",
+          paused_at: null,
+          resumes_at: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", id)
+        .eq("user_id", user.id)
+        .select()
+        .single()
+
+      if (error) throw new Error(`Failed to resume subscription: ${error.message}`)
+
+      return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
+    },
+    { requireAuth: true, rateLimit: RateLimiters.standard }
+  )(request)
+}

--- a/client/app/api/subscriptions/[id]/route.ts
+++ b/client/app/api/subscriptions/[id]/route.ts
@@ -10,7 +10,7 @@ const updateSubscriptionSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   category: z.string().min(1).optional(),
   price: z.number().positive().optional(),
-  status: z.enum(["active", "cancelled", "expired"]).optional(),
+  status: z.enum(["active", "cancelled", "expired", "paused"]).optional(),
   renewsIn: z.number().int().min(0).optional(),
   email: z.string().email().optional(),
 })

--- a/client/hooks/use-subscriptions.ts
+++ b/client/hooks/use-subscriptions.ts
@@ -73,6 +73,8 @@ export function useSubscriptions({
           pricingType: dbSub.pricing_type || dbSub.pricingType || "fixed",
           billingCycle: dbSub.billing_cycle || dbSub.billingCycle || "monthly",
           expiredAt: dbSub.expired_at || dbSub.expiredAt,
+          pausedAt: dbSub.paused_at || dbSub.pausedAt,
+          resumesAt: dbSub.resumes_at || dbSub.resumesAt,
         }));
 
         if (items.length > 0) {


### PR DESCRIPTION
- Add 'paused' to status enum in PATCH /api/subscriptions/[id] schema
- Add POST /api/subscriptions/[id]/pause Next.js route (sets status, paused_at, resumes_at; guards against double-pause and pausing cancelled subs)
- Add POST /api/subscriptions/[id]/resume Next.js route (clears pause fields, restores active; guards against resuming non-paused subs)
- Map paused_at/resumes_at fields in useSubscriptions fetch so the 'Resumes on…' message renders correctly in ManageSubscriptionModal

Reminder engine already filters status = 'active', so paused subs suppress alerts automatically. SubscriptionCard already renders opacity-50 + Paused badge. Backend Express routes and auto-resume cron job were already in place.


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
