### PR TITLE
Implement insufficient balance check for prepaid users

### DIFF
--- a/backend/src/services/reminder-engine.ts
+++ b/backend/src/services/reminder-engine.ts
@@ -15,6 +15,7 @@ import { userPreferenceService } from './user-preference-service';
 import { notificationPreferenceService } from './notification-preference-service';
 import { quietHoursService } from './quiet-hours-service';
 import { delayedNotificationService } from './delayed-notification-service';
+import { analyticsService } from './analytics-service';
 
 export interface ReminderEngineOptions {
   defaultDaysBefore?: number[];
@@ -114,6 +115,121 @@ export class ReminderEngine {
     } catch (error) {
       logger.error('Error processing delayed notifications:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Check for insufficient wallet balance for prepaid users
+   */
+  async checkInsufficientBalance(): Promise<void> {
+    logger.info('Checking for insufficient wallet balance');
+
+    try {
+      // Get all users with budgets
+      const { data: budgets, error } = await supabase
+        .from('monthly_budgets')
+        .select('user_id, budget_limit')
+        .is('category', null); // Overall budget
+
+      if (error) {
+        logger.error('Failed to fetch budgets:', error);
+        throw error;
+      }
+
+      if (!budgets || budgets.length === 0) {
+        logger.info('No users with budgets found');
+        return;
+      }
+
+      for (const budget of budgets) {
+        try {
+          await this.checkUserInsufficientBalance(budget.user_id, budget.budget_limit);
+        } catch (error) {
+          logger.error(`Failed to check balance for user ${budget.user_id}:`, error);
+        }
+      }
+    } catch (error) {
+      logger.error('Error checking insufficient balance:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check insufficient balance for a specific user
+   */
+  private async checkUserInsufficientBalance(userId: string, budgetLimit: number): Promise<void> {
+    // Get analytics summary to get current spend
+    const summary = await analyticsService.getSummary(userId);
+    const remainingBalance = budgetLimit - summary.budget_status.current_spend;
+
+    if (remainingBalance <= 0) {
+      // Already over budget, perhaps already alerted
+      return;
+    }
+
+    // Get active subscriptions
+    const { data: subscriptions, error } = await supabase
+      .from('subscriptions')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('status', 'active');
+
+    if (error) {
+      logger.error('Failed to fetch subscriptions:', error);
+      throw error;
+    }
+
+    if (!subscriptions || subscriptions.length === 0) {
+      return;
+    }
+
+    const userProfile = await this.getUserProfile(userId);
+    if (!userProfile) {
+      logger.warn(`User profile ${userId} not found`);
+      return;
+    }
+
+    const preferences = await userPreferenceService.getPreferences(userId);
+
+    for (const sub of subscriptions) {
+      if (sub.price > remainingBalance) {
+        // Send critical alert
+        const payload: NotificationPayload = {
+          title: 'Insufficient Wallet Balance',
+          body: `Wallet balance ($${remainingBalance.toFixed(2)}) is insufficient for ${sub.name} ($${sub.price.toFixed(2)}).`,
+          subscription: sub as Subscription,
+          reminderType: 'renewal',
+          daysBefore: 0,
+          renewalDate: sub.next_billing_date || new Date().toISOString(),
+          priority: 'critical',
+        };
+
+        // Send directly without delivery records
+        const deliveryChannels = preferences.notification_channels;
+
+        // Email delivery
+        if (deliveryChannels.includes('email') && preferences.email_opt_ins.reminders) {
+          await emailService.sendReminderEmail(
+            userProfile.email,
+            payload,
+            { maxAttempts: this.maxRetryAttempts },
+          );
+        }
+
+        // Push delivery
+        if (deliveryChannels.includes('push')) {
+          const pushSubscription = await this.getPushSubscription(userId);
+          if (pushSubscription) {
+            await pushService.sendPushNotification(
+              pushSubscription,
+              payload,
+              { maxAttempts: this.maxRetryAttempts },
+            );
+          }
+        }
+
+        logger.info(`Sent insufficient balance alert for user ${userId}, subscription ${sub.name}`);
+      }
     }
   }
 


### PR DESCRIPTION
- Add checkInsufficientBalance method to ReminderEngine
- Check if remaining wallet balance < subscription price
- Send critical alert notification via email and push
- Alert message: 'Wallet balance () is insufficient for Service ().'


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #324

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
