### PR TITLE
ht

### DIFF
--- a/backend/src/services/webhook-service.ts
+++ b/backend/src/services/webhook-service.ts
@@ -4,7 +4,8 @@ import crypto from 'crypto';
 import { 
   Webhook, 
   WebhookDelivery, 
-  WebhookEventType, 
+  WebhookEventType,
+  WebhookEventPayloadMap,
   WebhookCreateInput, 
   WebhookUpdateInput 
 } from '../types/webhook';
@@ -99,7 +100,7 @@ export class WebhookService {
   /**
    * Dispatch an event to all applicable webhooks
    */
-  async dispatchEvent(userId: string, eventType: WebhookEventType, data: any): Promise<void> {
+  async dispatchEvent<E extends WebhookEventType>(userId: string, eventType: E, data: WebhookEventPayloadMap[E]): Promise<void> {
     try {
       // Find all enabled webhooks for this user subscribed to this event
       const { data: webhooks, error } = await supabase
@@ -164,7 +165,7 @@ export class WebhookService {
   /**
    * Create a delivery record
    */
-  private async createDelivery(webhookId: string, eventType: WebhookEventType, payload: any): Promise<WebhookDelivery> {
+  private async createDelivery<E extends WebhookEventType>(webhookId: string, eventType: E, payload: { id: string; type: E; created: number; data: WebhookEventPayloadMap[E] }): Promise<WebhookDelivery> {
     const { data, error } = await supabase
       .from('webhook_deliveries')
       .insert({
@@ -204,7 +205,7 @@ export class WebhookService {
       throw new Error(`Delivery ${deliveryId} not found`);
     }
 
-    const webhook = (delivery as any).webhooks as Webhook;
+    const webhook = (delivery as WebhookDelivery & { webhooks: Webhook }).webhooks;
     const payloadString = JSON.stringify(delivery.payload);
     const signature = crypto
       .createHmac('sha256', webhook.secret)

--- a/backend/src/types/webhook.ts
+++ b/backend/src/types/webhook.ts
@@ -18,11 +18,51 @@ export interface Webhook {
   updated_at: string;
 }
 
+export interface WebhookEventPayloadMap {
+  'subscription.renewal_due': {
+    subscription_id: string;
+    subscription_name: string;
+    renewal_date: string;
+    amount: number;
+    currency: string;
+  };
+  'subscription.renewed': {
+    subscription_id: string;
+    subscription_name: string;
+    renewed_at: string;
+    amount: number;
+    currency: string;
+  };
+  'subscription.renewal_failed': {
+    subscription_id: string;
+    subscription_name: string;
+    failed_at: string;
+    reason: string;
+  };
+  'subscription.cancelled': {
+    subscription_id: string;
+    subscription_name: string;
+    cancelled_at: string;
+  };
+  'subscription.risk_score_changed': {
+    subscription_id: string;
+    subscription_name: string;
+    previous_score: number;
+    new_score: number;
+  };
+  'reminder.sent': {
+    subscription_id: string;
+    subscription_name: string;
+    reminder_type: string;
+    sent_at: string;
+  };
+}
+
 export interface WebhookDelivery {
   id: string;
   webhook_id: string;
   event_type: WebhookEventType;
-  payload: any;
+  payload: WebhookEventPayloadMap[WebhookEventType];
   response_code: number | null;
   response_body: string | null;
   status: 'pending' | 'success' | 'failed' | 'retrying';


### PR DESCRIPTION
fix: type webhook payload contracts in backend webhook-service #439
Description:
Closes #439
Changes

Added WebhookEventPayloadMap interface mapping each WebhookEventType to its strongly-typed payload shape in webhook.ts
Replaced payload: any in WebhookDelivery with payload: WebhookEventPayloadMap[WebhookEventType]
Typed dispatchEvent and createDelivery with generic E extends WebhookEventType to enforce payload schema per event type
Removed (delivery as any).webhooks unsafe cast in sendDelivery, replaced with (delivery as WebhookDelivery & { webhooks: Webhook }).webhooks

Acceptance Criteria Met

Invalid payloads fail before persistence/delivery — enforced at compile time via generics
Compile-time mapping exists for each event type via WebhookEventPayloadMap
No remaining data: any in dispatch or delivery creation signatures
