### PR TITLE
feat: Slack alerts, budget alerts, and Paystack integration

### DIFF
--- a/backend/services/paystack.ts
+++ b/backend/services/paystack.ts
@@ -1,0 +1,113 @@
+import logger from '../config/logger';
+
+const PAYSTACK_BASE = 'https://api.paystack.co';
+const SECRET_KEY = process.env.PAYSTACK_SECRET_KEY ?? '';
+
+async function paystackRequest<T>(
+  method: 'GET' | 'POST',
+  path: string,
+  body?: Record<string, unknown>
+): Promise<T> {
+  const res = await fetch(`${PAYSTACK_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${SECRET_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const json = (await res.json()) as { status: boolean; message: string; data: T };
+
+  if (!json.status) {
+    throw new Error(`Paystack error: ${json.message}`);
+  }
+
+  return json.data;
+}
+
+export interface InitializeResult {
+  authorization_url: string;
+  access_code: string;
+  reference: string;
+}
+
+/**
+ * Initialize a Naira wallet funding transaction.
+ * Returns a Paystack checkout URL the user completes in-browser.
+ */
+export async function initializeFunding(params: {
+  email: string;
+  amountKobo: number; // amount in kobo (100 kobo = ₦1)
+  reference: string;
+  callbackUrl?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<InitializeResult> {
+  return paystackRequest<InitializeResult>('POST', '/transaction/initialize', {
+    email: params.email,
+    amount: params.amountKobo,
+    reference: params.reference,
+    callback_url: params.callbackUrl,
+    currency: 'NGN',
+    channels: ['card', 'bank', 'ussd', 'bank_transfer'],
+    metadata: params.metadata,
+  });
+}
+
+export interface VerifyResult {
+  status: string; // 'success' | 'failed' | 'abandoned'
+  reference: string;
+  amount: number; // kobo
+  currency: string;
+  paid_at: string;
+  customer: { email: string };
+}
+
+/**
+ * Verify a completed transaction by reference.
+ */
+export async function verifyTransaction(reference: string): Promise<VerifyResult> {
+  return paystackRequest<VerifyResult>('GET', `/transaction/verify/${encodeURIComponent(reference)}`);
+}
+
+export interface SubAccount {
+  id: number;
+  subaccount_code: string;
+  business_name: string;
+  settlement_bank: string;
+  account_number: string;
+  percentage_charge: number;
+}
+
+/**
+ * Create a Paystack sub-account (for split payments / team wallets).
+ */
+export async function createSubAccount(params: {
+  businessName: string;
+  settlementBank: string; // bank code e.g. "058" for GTBank
+  accountNumber: string;
+  percentageCharge: number; // 0–100
+  description?: string;
+}): Promise<SubAccount> {
+  return paystackRequest<SubAccount>('POST', '/subaccount', {
+    business_name: params.businessName,
+    settlement_bank: params.settlementBank,
+    account_number: params.accountNumber,
+    percentage_charge: params.percentageCharge,
+    description: params.description,
+  });
+}
+
+/**
+ * Fetch an existing sub-account by its code.
+ */
+export async function getSubAccount(subaccountCode: string): Promise<SubAccount> {
+  return paystackRequest<SubAccount>('GET', `/subaccount/${encodeURIComponent(subaccountCode)}`);
+}
+
+/**
+ * List supported Nigerian banks (useful for the sub-account setup form).
+ */
+export async function listBanks(): Promise<Array<{ name: string; code: string }>> {
+  return paystackRequest<Array<{ name: string; code: string }>>('GET', '/bank?currency=NGN&country=nigeria');
+}

--- a/backend/src/jobs/reminder-job.ts
+++ b/backend/src/jobs/reminder-job.ts
@@ -1,6 +1,8 @@
 import cron from 'node-cron';
 import { reminderEngine } from '../services/reminder-engine';
 import { notificationPreferenceService } from '../services/notification-preference-service';
+import { checkBudgetAlerts } from '../services/budget-alert-service';
+import { supabase } from '../config/database';
 import logger from '../config/logger';
 
 /**
@@ -49,6 +51,25 @@ cron.schedule('*/30 * * * *', async () => {
     logger.info('Cron: retries processed successfully');
   } catch (error) {
     logger.error('Cron: failed to process retries:', error);
+  }
+});
+
+// Budget alerts — runs at 10:00 UTC daily
+cron.schedule('0 10 * * *', async () => {
+  logger.info('Cron: checking budget alerts');
+  try {
+    // Fetch all distinct user IDs that have a monthly_budget set
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('id')
+      .not('monthly_budget', 'is', null);
+
+    await Promise.allSettled(
+      (profiles ?? []).map((p: { id: string }) => checkBudgetAlerts(p.id))
+    );
+    logger.info('Cron: budget alerts processed');
+  } catch (error) {
+    logger.error('Cron: failed to process budget alerts:', error);
   }
 });
 

--- a/backend/src/routes/team.ts
+++ b/backend/src/routes/team.ts
@@ -480,4 +480,42 @@ router.delete('/:memberId', requireRole('owner', 'admin'), async (req: Authentic
   res.json({ success: true, message: 'Team member removed' });
 });
 
+// ---------------------------------------------------------------------------
+// PATCH /api/team/slack-webhook  — save Slack webhook URL (admin/owner only)
+// ---------------------------------------------------------------------------
+
+router.patch('/slack-webhook', requireRole('owner', 'admin'), async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { slack_webhook_url } = req.body as { slack_webhook_url: string | null };
+
+    const ctx = await resolveUserTeam(req.user!.id);
+    if (!ctx) {
+      return res.status(404).json({ success: false, error: 'No team found' });
+    }
+    if (!canManageTeam(ctx)) {
+      return res.status(403).json({ success: false, error: 'Only admins can update the Slack webhook' });
+    }
+
+    // Basic URL validation
+    if (slack_webhook_url && !slack_webhook_url.startsWith('https://hooks.slack.com/')) {
+      return res.status(400).json({ success: false, error: 'Invalid Slack webhook URL' });
+    }
+
+    const { error } = await supabase
+      .from('teams')
+      .update({ slack_webhook_url: slack_webhook_url ?? null })
+      .eq('id', ctx.teamId);
+
+    if (error) throw error;
+
+    res.json({ success: true, message: 'Slack webhook updated' });
+  } catch (error) {
+    logger.error('PATCH /api/team/slack-webhook error:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update Slack webhook',
+    });
+  }
+});
+
 export default router;

--- a/backend/src/services/budget-alert-service.ts
+++ b/backend/src/services/budget-alert-service.ts
@@ -1,0 +1,170 @@
+import { supabase } from '../config/database';
+import logger from '../config/logger';
+import { sendSlackAlert } from './slack-service';
+
+function currentMonth(): string {
+  return new Date().toISOString().substring(0, 7); // YYYY-MM
+}
+
+async function wasAlertSentThisMonth(userId: string, alertType: 'budget_warning' | 'budget_exceeded'): Promise<boolean> {
+  const { data } = await supabase
+    .from('budget_alert_logs')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('alert_type', alertType)
+    .eq('month', currentMonth())
+    .maybeSingle();
+  return !!data;
+}
+
+async function recordAlert(userId: string, alertType: 'budget_warning' | 'budget_exceeded'): Promise<void> {
+  await supabase.from('budget_alert_logs').upsert({
+    user_id: userId,
+    alert_type: alertType,
+    month: currentMonth(),
+  });
+}
+
+async function getTeamSlackWebhook(userId: string): Promise<string | null> {
+  // Check if user owns a team or is a member
+  const { data: ownedTeam } = await supabase
+    .from('teams')
+    .select('slack_webhook_url')
+    .eq('owner_id', userId)
+    .maybeSingle();
+
+  if (ownedTeam?.slack_webhook_url) return ownedTeam.slack_webhook_url;
+
+  const { data: membership } = await supabase
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (!membership) return null;
+
+  const { data: team } = await supabase
+    .from('teams')
+    .select('slack_webhook_url')
+    .eq('id', membership.team_id)
+    .maybeSingle();
+
+  return team?.slack_webhook_url ?? null;
+}
+
+export async function checkBudgetAlerts(userId: string): Promise<void> {
+  try {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('monthly_budget, budget_alert_threshold')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (!profile?.monthly_budget) return;
+
+    const threshold = profile.budget_alert_threshold ?? 80;
+
+    const { data: subs } = await supabase
+      .from('subscriptions')
+      .select('price, billing_cycle')
+      .eq('user_id', userId)
+      .eq('status', 'active');
+
+    const monthlyTotal = (subs ?? []).reduce((sum, sub) => {
+      const price = Number(sub.price);
+      switch ((sub.billing_cycle ?? '').toLowerCase()) {
+        case 'yearly':
+        case 'annual':
+          return sum + price / 12;
+        case 'quarterly':
+          return sum + price / 3;
+        case 'weekly':
+          return sum + price * (365 / 7 / 12);
+        default:
+          return sum + price;
+      }
+    }, 0);
+
+    const budget = Number(profile.monthly_budget);
+    const percentage = (monthlyTotal / budget) * 100;
+
+    let alertType: 'budget_warning' | 'budget_exceeded' | null = null;
+    let message = '';
+
+    if (percentage >= 100 && !(await wasAlertSentThisMonth(userId, 'budget_exceeded'))) {
+      alertType = 'budget_exceeded';
+      message = `🚨 You've exceeded your $${budget.toFixed(2)} monthly subscription budget by $${(monthlyTotal - budget).toFixed(2)}`;
+    } else if (percentage >= threshold && !(await wasAlertSentThisMonth(userId, 'budget_warning'))) {
+      alertType = 'budget_warning';
+      message = `⚠️ You've used ${percentage.toFixed(0)}% of your $${budget.toFixed(2)} monthly subscription budget ($${monthlyTotal.toFixed(2)}/$${budget.toFixed(2)})`;
+    }
+
+    if (!alertType) return;
+
+    // Insert in-app notification
+    await supabase.from('notifications').insert({
+      user_id: userId,
+      type: alertType,
+      message,
+      metadata: { month: currentMonth(), percentage, limit: budget, current: monthlyTotal },
+      read: false,
+    });
+
+    // Send Slack alert if team has a webhook configured
+    const webhookUrl = await getTeamSlackWebhook(userId);
+    if (webhookUrl) {
+      await sendSlackAlert(webhookUrl, message);
+    }
+
+    await recordAlert(userId, alertType);
+    logger.info('Budget alert sent', { userId, alertType, percentage });
+  } catch (err) {
+    logger.error('checkBudgetAlerts failed', { userId, err });
+  }
+}
+
+/**
+ * Returns how much adding a new subscription would push the monthly total,
+ * and whether it would exceed the budget.
+ */
+export async function wouldExceedBudget(
+  userId: string,
+  newMonthlyAmount: number
+): Promise<{ wouldExceed: boolean; newTotal: number; budget: number; overage: number } | null> {
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('monthly_budget')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (!profile?.monthly_budget) return null;
+
+  const { data: subs } = await supabase
+    .from('subscriptions')
+    .select('price, billing_cycle')
+    .eq('user_id', userId)
+    .eq('status', 'active');
+
+  const currentTotal = (subs ?? []).reduce((sum, sub) => {
+    const price = Number(sub.price);
+    switch ((sub.billing_cycle ?? '').toLowerCase()) {
+      case 'yearly':
+      case 'annual':
+        return sum + price / 12;
+      case 'quarterly':
+        return sum + price / 3;
+      default:
+        return sum + price;
+    }
+  }, 0);
+
+  const budget = Number(profile.monthly_budget);
+  const newTotal = currentTotal + newMonthlyAmount;
+
+  return {
+    wouldExceed: newTotal > budget,
+    newTotal,
+    budget,
+    overage: Math.max(0, newTotal - budget),
+  };
+}

--- a/backend/src/services/slack-service.ts
+++ b/backend/src/services/slack-service.ts
@@ -1,0 +1,16 @@
+import logger from '../config/logger';
+
+export async function sendSlackAlert(webhookUrl: string, text: string): Promise<void> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) {
+      logger.warn('Slack webhook returned non-OK status', { status: res.status });
+    }
+  } catch (err) {
+    logger.error('Failed to send Slack alert', { err });
+  }
+}

--- a/client/components/modals/add-subscription-modal.tsx
+++ b/client/components/modals/add-subscription-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect } from "react"
-import { X, Search, Plus, ChevronDown, ExternalLink } from "lucide-react"
+import { X, Search, Plus, ChevronDown, ExternalLink, AlertTriangle } from "lucide-react"
 import {
   SUBSCRIPTION_TEMPLATES,
   TEMPLATE_CATEGORIES,
@@ -9,6 +9,7 @@ import {
   type SubscriptionTemplate,
   type PriceTier,
 } from "@/lib/subscription-templates"
+import { wouldExceedBudget } from "@/lib/budget-utils"
 
 const DIFFICULTY_LABEL: Record<string, { label: string; color: string }> = {
   easy: { label: "Easy to cancel", color: "text-green-500" },
@@ -20,10 +21,14 @@ export default function AddSubscriptionModal({
   onAdd,
   onClose,
   darkMode,
+  currentMonthlyTotal = 0,
+  budgetLimit,
 }: {
   onAdd: (subscription: any) => void
   onClose: () => void
   darkMode?: boolean
+  currentMonthlyTotal?: number
+  budgetLimit?: number
 }) {
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedTemplate, setSelectedTemplate] = useState<SubscriptionTemplate | null>(null)
@@ -90,6 +95,14 @@ export default function AddSubscriptionModal({
     if (!formData.name || !formData.price) return
     onAdd(buildPayload())
   }
+
+  const newMonthlyPrice = formData.price
+    ? parseFloat(formData.price) / (formData.billingCycle === "yearly" ? 12 : formData.billingCycle === "quarterly" ? 3 : 1)
+    : 0
+  const budgetWarning =
+    budgetLimit && newMonthlyPrice > 0
+      ? wouldExceedBudget(currentMonthlyTotal, newMonthlyPrice, budgetLimit)
+      : null
 
   const base = darkMode ? "bg-[#2D3748] text-[#F9F6F2]" : "bg-white text-[#1E2A35]"
   const input = darkMode
@@ -397,6 +410,19 @@ export default function AddSubscriptionModal({
 
         {/* Footer */}
         <div className={`p-6 border-t ${darkMode ? "border-[#374151]" : "border-gray-200"}`}>
+          {budgetWarning?.exceeds && (
+            <div className={`mb-4 p-3 rounded-lg border flex items-start gap-2 ${
+              darkMode ? "bg-yellow-900/20 border-yellow-700" : "bg-yellow-50 border-yellow-200"
+            }`}>
+              <AlertTriangle className="w-4 h-4 text-yellow-500 shrink-0 mt-0.5" aria-hidden="true" />
+              <p className={`text-sm ${darkMode ? "text-yellow-300" : "text-yellow-800"}`}>
+                ⚠️ Adding this subscription would bring your monthly total to{" "}
+                <strong>${budgetWarning.newTotal.toFixed(2)}</strong>, exceeding your{" "}
+                <strong>${budgetLimit!.toFixed(2)}</strong> budget by{" "}
+                <strong>${budgetWarning.overage.toFixed(2)}</strong>.
+              </p>
+            </div>
+          )}
           <div className="flex gap-3">
             <button
               onClick={onClose}

--- a/client/components/pages/teams.tsx
+++ b/client/components/pages/teams.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Users, Plus, Search, Trash2, TrendingUp, Activity, Mail, Briefcase, User, DollarSign } from "lucide-react"
+import { Users, Plus, Search, Trash2, TrendingUp, Activity, Mail, Briefcase, User, DollarSign, Slack } from "lucide-react"
 import { showToast } from "@/components/ui/toast"
 import { StatusBadge, normalizeStatus } from "@/components/ui/status-badge"
 
@@ -16,6 +16,32 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTab, setActiveTab] = useState<"members" | "usage" | "emails">("members")
   const [showWorkEmailsOnly, setShowWorkEmailsOnly] = useState(true)
+
+  const [slackWebhookUrl, setSlackWebhookUrl] = useState(workspace?.slack_webhook_url ?? "")
+  const [savingSlack, setSavingSlack] = useState(false)
+
+  const handleSaveSlackWebhook = async () => {
+    if (slackWebhookUrl && !slackWebhookUrl.startsWith("https://hooks.slack.com/")) {
+      showToast({ title: "Invalid URL", description: "Must be a valid Slack webhook URL.", variant: "error" })
+      return
+    }
+    setSavingSlack(true)
+    try {
+      const res = await fetch("/api/team/slack-webhook", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slack_webhook_url: slackWebhookUrl || null }),
+      })
+      if (!res.ok) throw new Error("Failed")
+      showToast({ title: "Saved", description: "Slack webhook updated.", variant: "success" })
+    } catch {
+      showToast({ title: "Error", description: "Could not save webhook.", variant: "error" })
+    } finally {
+      setSavingSlack(false)
+    }
+  }
+
+  const isAdmin = members.some((m: any) => m.email === workspace?.currentUserEmail && m.role === "Admin")
 
   const [teamSettings, setTeamSettings] = useState({
     spendingLimit: 1000,
@@ -372,6 +398,39 @@ export default function TeamsPage({ workspace, subscriptions, darkMode, emailAcc
           </div>
         </div>
       </div>
+
+      {/* Slack Alerts — admin only */}
+      {isAdmin && (
+        <div
+          className={`${darkMode ? "bg-[#2D3748]" : "bg-white"} p-6 rounded-xl border ${darkMode ? "border-gray-700" : "border-gray-200"}`}
+        >
+          <div className="flex items-center gap-2 mb-4">
+            <Slack className={`w-5 h-5 ${darkMode ? "text-[#FFD166]" : "text-[#1E2A35]"}`} />
+            <h3 className={`text-lg font-semibold ${darkMode ? "text-white" : "text-[#1E2A35]"}`}>Slack Alerts</h3>
+          </div>
+          <p className={`text-sm mb-3 ${darkMode ? "text-gray-400" : "text-gray-600"}`}>
+            Paste a Slack Incoming Webhook URL to receive budget and team alerts in a channel (e.g. #accounting).
+          </p>
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={slackWebhookUrl}
+              onChange={(e) => setSlackWebhookUrl(e.target.value)}
+              placeholder="https://hooks.slack.com/services/..."
+              className={`flex-1 px-4 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-[#FFD166] ${
+                darkMode ? "bg-[#1E2A35] border-gray-700 text-white" : "bg-white border-gray-200 text-[#1E2A35]"
+              }`}
+            />
+            <button
+              onClick={handleSaveSlackWebhook}
+              disabled={savingSlack}
+              className="px-4 py-2 bg-[#007A5C] text-white rounded-lg text-sm font-medium hover:bg-[#007A5C]/90 disabled:opacity-50"
+            >
+              {savingSlack ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Tab Buttons and Work Email Filter Toggle */}
       <div className="flex items-center justify-between">

--- a/client/lib/budget-utils.ts
+++ b/client/lib/budget-utils.ts
@@ -30,3 +30,27 @@ export function checkBudgetAlerts(
 
     return null;
 }
+
+/** Returns true + overage if adding `newMonthlyAmount` would exceed the budget. */
+export function wouldExceedBudget(
+    currentTotal: number,
+    newMonthlyAmount: number,
+    budgetLimit: number
+): { exceeds: boolean; newTotal: number; overage: number } {
+    const newTotal = currentTotal + newMonthlyAmount;
+    return {
+        exceeds: newTotal > budgetLimit,
+        newTotal,
+        overage: Math.max(0, newTotal - budgetLimit),
+    };
+}
+
+/** Annual projection message. */
+export function annualProjection(
+    monthlyTotal: number,
+    annualBudget: number
+): string | null {
+    const projected = monthlyTotal * 12;
+    if (projected <= annualBudget) return null;
+    return `At your current rate, you'll spend $${projected.toFixed(0)} on subscriptions this year — $${(projected - annualBudget).toFixed(0)} over your $${annualBudget} annual budget.`;
+}

--- a/supabase/migrations/20260501000000_budget_and_slack.sql
+++ b/supabase/migrations/20260501000000_budget_and_slack.sql
@@ -1,0 +1,27 @@
+-- 1. Add Slack webhook URL to teams
+ALTER TABLE public.teams
+  ADD COLUMN IF NOT EXISTS slack_webhook_url TEXT;
+
+-- 2. Add budget columns to profiles (if profiles table exists)
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS monthly_budget DECIMAL(10,2),
+  ADD COLUMN IF NOT EXISTS budget_alert_threshold INT DEFAULT 80;
+
+-- 3. Track sent budget alerts to prevent duplicates
+CREATE TABLE IF NOT EXISTS public.budget_alert_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  alert_type TEXT NOT NULL CHECK (alert_type IN ('budget_warning', 'budget_exceeded')),
+  month TEXT NOT NULL, -- YYYY-MM
+  sent_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  UNIQUE(user_id, alert_type, month)
+);
+
+ALTER TABLE public.budget_alert_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "budget_alert_logs_own"
+  ON public.budget_alert_logs FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS budget_alert_logs_user_month_idx
+  ON public.budget_alert_logs(user_id, month);


### PR DESCRIPTION
This PR
 closes #316 
closes #306 
closes #183 




- supabase/migrations: add slack_webhook_url to teams, monthly_budget + budget_alert_threshold to profiles, budget_alert_logs dedup table
- backend/src/services/slack-service.ts: sendSlackAlert() via webhook URL
- backend/src/services/budget-alert-service.ts: checkBudgetAlerts() with 80%/100% thresholds, monthly dedup, Slack forwarding; wouldExceedBudget()
- backend/src/routes/team.ts: PATCH /api/team/slack-webhook (admin/owner)
- backend/src/jobs/reminder-job.ts: daily 10:00 UTC cron for budget alerts
- backend/services/paystack.ts: initializeFunding, verifyTransaction, createSubAccount, getSubAccount, listBanks for NGN wallet funding
- client/lib/budget-utils.ts: wouldExceedBudget(), annualProjection() helpers
- client/components/modals/add-subscription-modal.tsx: inline budget warning when adding a subscription that would exceed the budget
- client/components/pages/teams.tsx: Slack webhook input panel for admins


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
