### PR TITLE
fix(#379): forward CSP violations to Sentry and persist to DB

### DIFF
--- a/client/app/api/csp-report/route.ts
+++ b/client/app/api/csp-report/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
+import * as Sentry from "@sentry/nextjs"
+import { createClient } from "@/lib/supabase/server"
+import { checkRateLimit } from "@/lib/api/rate-limit"
 
-/**
- * CSP Violation Report Schema
- */
 const CspReportSchema = z.object({
   "csp-report": z.object({
     "document-uri": z.string().url(),
@@ -18,56 +18,58 @@ const CspReportSchema = z.object({
   }),
 })
 
-/**
- * CSP Violation Report Endpoint
- * 
- * Receives Content Security Policy violation reports from browsers.
- * These reports help identify policy violations without blocking content (report-only mode).
- * 
- * After 1 week of clean reports, switch to enforcing mode in middleware.ts
- */
-export async function POST(request: NextRequest) {
-  try {
-    const rawBody = await request.json()
-    const result = CspReportSchema.safeParse(rawBody)
+// 30 reports per minute per IP — enough signal, not a flood
+const CSP_RATE_LIMIT = { windowMs: 60_000, maxRequests: 30 }
 
-    if (!result.success) {
-      return NextResponse.json(
-        { 
-          success: false, 
-          error: "Invalid report format", 
-          details: result.error.format() 
-        },
-        { status: 400 }
-      )
-    }
+// Only persist 20% of reports to avoid noise; Sentry captures the rest
+const SAMPLE_RATE = 0.2
 
-    const report = result.data["csp-report"]
-
-    // Log the violation for monitoring
-    // In production, you might want to send this to a logging service
-    console.error("CSP Violation Report:", {
-      documentURI: report["document-uri"],
-      violatedDirective: report["violated-directive"],
-      blockedURI: report["blocked-uri"],
-      sourceFile: report["source-file"],
-      lineNumber: report["line-number"],
-      columnNumber: report["column-number"],
-      timeStamp: new Date().toISOString(),
-      userAgent: request.headers.get("user-agent"),
-    })
-
-    // TODO: In production, consider:
-    // - Sending reports to a monitoring service (e.g., Sentry, Datadog)
-    // - Storing reports in a database for analysis
-    // - Setting up alerts for high-frequency violations
-
-    return NextResponse.json({ success: true })
-  } catch (error) {
-    console.error("Error processing CSP report:", error)
-    return NextResponse.json(
-      { success: false, error: "Failed to process report" },
-      { status: 500 }
-    )
+// Strip fields that could leak user data
+function sanitize(report: z.infer<typeof CspReportSchema>["csp-report"]) {
+  return {
+    violated_directive: report["violated-directive"],
+    blocked_uri: report["blocked-uri"] ?? null,
+    // Remove query strings from URIs to avoid leaking tokens/PII
+    document_uri: report["document-uri"].split("?")[0],
+    disposition: report["disposition"] ?? null,
   }
+}
+
+export async function POST(request: NextRequest) {
+  const rateCheck = checkRateLimit(request, CSP_RATE_LIMIT)
+  if (!rateCheck.allowed) {
+    return NextResponse.json({ success: false }, { status: 429 })
+  }
+
+  let result
+  try {
+    result = CspReportSchema.safeParse(await request.json())
+  } catch {
+    return NextResponse.json({ success: false }, { status: 400 })
+  }
+
+  if (!result.success) {
+    return NextResponse.json({ success: false }, { status: 400 })
+  }
+
+  const clean = sanitize(result.data["csp-report"])
+
+  // Always send to Sentry so violations are queryable and can trigger alerts
+  Sentry.captureEvent({
+    message: `CSP violation: ${clean.violated_directive}`,
+    level: "warning",
+    tags: {
+      csp_directive: clean.violated_directive,
+      disposition: clean.disposition ?? "unknown",
+    },
+    extra: clean,
+  })
+
+  // Persist a sample to DB for ad-hoc querying / dashboards
+  if (Math.random() < SAMPLE_RATE) {
+    const supabase = await createClient()
+    await supabase.from("csp_violations").insert(clean)
+  }
+
+  return NextResponse.json({ success: true })
 }

--- a/client/supabase/migrations/20260426_create_csp_violations.sql
+++ b/client/supabase/migrations/20260426_create_csp_violations.sql
@@ -1,0 +1,11 @@
+create table if not exists csp_violations (
+  id uuid primary key default gen_random_uuid(),
+  violated_directive text not null,
+  blocked_uri text,
+  document_uri text,
+  disposition text,
+  created_at timestamptz not null default now()
+);
+
+create index on csp_violations (violated_directive);
+create index on csp_violations (created_at);


### PR DESCRIPTION
- Rewrite csp-report route to send all violations to Sentry as warning-level events tagged by directive (queryable + alertable)
- Persist 20% sample to new csp_violations table to avoid log floods
- Rate limit endpoint to 30 req/min per IP using existing checkRateLimit
- Sanitize report fields: strip query strings from URIs, drop script-sample
- Add migration 20260426_create_csp_violations.sql with indexes on violated_directive and created_at for efficient querying


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
closed #379