### PR TITLE
feat: Add dependency vulnerability scanning (Dependabot + npm audit CI)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: cargo
+    directory: /contracts
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - contracts
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,53 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  audit:
+    name: Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: pnpm install --frozen-lockfile
+
+      - name: Security audit - backend
+        working-directory: backend
+        run: pnpm audit --audit-level=high
+        continue-on-error: false
+
+      - name: Set up Node.js for client
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install client dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Security audit - client
+        working-directory: client
+        run: npm audit --audit-level=high
+        continue-on-error: false


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for automated weekly dependency updates across npm (backend/client) and cargo (contracts)
- Adds `.github/workflows/security-audit.yml` that runs `pnpm audit`/`npm audit --audit-level=high` on every PR/push, blocking merges on high or critical CVEs

## Changes

- `.github/dependabot.yml` — Dependabot config for npm (backend, client) and cargo (contracts), weekly on Mondays
- `.github/workflows/security-audit.yml` — CI job that audits both backend (pnpm) and client (npm) dependencies

## Test Plan

- [ ] Confirm Dependabot PRs are opened weekly for outdated/vulnerable packages
- [ ] Confirm CI fails on PR when a high-severity vulnerability is present
- [ ] Confirm CI passes when no high/critical vulnerabilities exist
- [ ] Existing workflows (ci.yml, test.yml, etc.) continue to pass

Closes #139