### PR TITLE
fix: replace any types with domain types in use-subscriptions hook

### DIFF
--- a/client/hooks/use-subscriptions.test.ts
+++ b/client/hooks/use-subscriptions.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useSubscriptions } from "@/hooks/use-subscriptions";
+import type {
+  SubscriptionState,
+  SubscriptionCreatePayload,
+  SubscriptionUpdatePayload,
+  ToastPayload,
+  EmailAccount,
+} from "@/hooks/use-subscriptions";
+import type { Subscription as DBSubscription } from "@/lib/supabase/subscriptions";
+
+vi.mock("@/lib/api", () => ({
+  apiGet: vi.fn().mockResolvedValue({ subscriptions: [] }),
+  apiPost: vi.fn(),
+  apiPatch: vi.fn(),
+  apiDelete: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/subscriptions", () => ({
+  createSubscription: vi.fn().mockResolvedValue({
+    id: 1,
+    name: "Test Sub",
+    category: "test",
+    price: 9.99,
+    icon: "🔗",
+    renews_in: 30,
+    status: "active",
+    color: "#000000",
+    renewal_url: null,
+    tags: [],
+    date_added: "2024-01-01T00:00:00.000Z",
+    email_account_id: 1,
+    last_used_at: null,
+    has_api_key: false,
+    is_trial: false,
+    trial_ends_at: null,
+    price_after_trial: null,
+    source: "manual",
+    manually_edited: false,
+    edited_fields: [],
+    pricing_type: "fixed",
+    billing_cycle: "monthly",
+    expired_at: null,
+    notes: null,
+    custom_tag_ids: null,
+    user_id: "user-123",
+  }),
+  updateSubscription: vi.fn().mockResolvedValue({}),
+  deleteSubscription: vi.fn().mockResolvedValue(undefined),
+  bulkDeleteSubscriptions: vi.fn().mockResolvedValue(undefined),
+  fetchSubscriptions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/validation", () => ({
+  validateSubscriptionData: vi.fn().mockReturnValue({
+    isValid: true,
+    errors: {},
+  }),
+}));
+
+vi.mock("@/lib/subscription-utils", () => ({
+  checkDuplicate: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/network-utils", () => ({
+  retryWithBackoff: vi.fn(async (fn) => fn()),
+  getErrorMessage: vi.fn((err) => (err instanceof Error ? err.message : "Unknown error")),
+}));
+
+vi.mock("@/hooks/use-undo-manager", () => ({
+  useUndoManager: vi.fn((initial: DBSubscription[]) => ({
+    currentState: initial,
+    addToHistory: vi.fn((state) => {
+      // Simulate state update
+    }),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+  })),
+}));
+
+const mockEmailAccounts: EmailAccount[] = [
+  { id: 1, email: "test@example.com", isPrimary: true },
+];
+
+const mockDBSubscriptions: DBSubscription[] = [
+  {
+    id: 1,
+    user_id: "user-123",
+    name: "Netflix",
+    category: "Entertainment",
+    price: 15.99,
+    icon: "🎬",
+    renews_in: 30,
+    status: "active",
+    color: "#E50914",
+    renewal_url: "https://netflix.com/renew",
+    tags: ["streaming"],
+    date_added: "2024-01-01T00:00:00.000Z",
+    email_account_id: 1,
+    last_used_at: "2024-01-15T00:00:00.000Z",
+    has_api_key: false,
+    is_trial: false,
+    trial_ends_at: null,
+    price_after_trial: null,
+    source: "manual",
+    manually_edited: false,
+    edited_fields: [],
+    pricing_type: "fixed",
+    billing_cycle: "monthly",
+    expired_at: null,
+    notes: null,
+    custom_tag_ids: null,
+  },
+];
+
+describe("useSubscriptions Hook - Type Safety", () => {
+  let mockToast: ReturnType<typeof vi.fn>;
+  let mockUpgradePlan: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToast = vi.fn();
+    mockUpgradePlan = vi.fn();
+  });
+
+  describe("Type Definitions", () => {
+    it("should accept correctly typed SubscriptionCreatePayload", () => {
+      const payload: SubscriptionCreatePayload = {
+        name: "Spotify",
+        category: "Music",
+        price: 9.99,
+        icon: "🎵",
+        renewsIn: 30,
+        status: "active",
+        color: "#1DB954",
+        renewalUrl: "https://spotify.com/renew",
+        tags: ["music", "streaming"],
+        isTrial: true,
+        trialEndsAt: "2024-12-31T00:00:00.000Z",
+        priceAfterTrial: 14.99,
+      };
+
+      expect(payload.name).toBe("Spotify");
+      expect(payload.price).toBe(9.99);
+      expect(payload.isTrial).toBe(true);
+    });
+
+    it("should accept correctly typed SubscriptionUpdatePayload", () => {
+      const payload: SubscriptionUpdatePayload = {
+        name: "Updated Name",
+        category: "Updated Category",
+        price: 19.99,
+        billingCycle: "yearly",
+        pricingType: "usage",
+      };
+
+      expect(payload.name).toBe("Updated Name");
+      expect(payload.billingCycle).toBe("yearly");
+    });
+
+    it("should accept correctly typed ToastPayload", () => {
+      const toast: ToastPayload = {
+        title: "Success",
+        description: "Operation completed",
+        variant: "success",
+        action: {
+          label: "Undo",
+          onClick: () => {},
+        },
+      };
+
+      expect(toast.variant).toBe("success");
+      expect(toast.action?.label).toBe("Undo");
+    });
+
+    it("should accept correctly typed EmailAccount", () => {
+      const account: EmailAccount = {
+        id: 1,
+        email: "user@example.com",
+        isPrimary: true,
+      };
+
+      expect(account.isPrimary).toBe(true);
+    });
+  });
+
+  describe("State Type Safety", () => {
+    it("should initialize with correctly typed subscription state", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const { subscriptions } = result.current;
+      expect(Array.isArray(subscriptions)).toBe(true);
+    });
+
+    it("should provide type-safe selectedSubscription state", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const { setSelectedSubscription, selectedSubscription } = result.current;
+      expect(selectedSubscription).toBeNull();
+
+      act(() => {
+        setSelectedSubscription(mockDBSubscriptions[0] as SubscriptionState);
+      });
+
+      expect(result.current.selectedSubscription).not.toBeNull();
+    });
+  });
+
+  describe("Update Operations Type Safety", () => {
+    it("should handle updateSubscriptions with typed array", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const typedSubscriptions: SubscriptionState[] = [
+        mockDBSubscriptions[0] as SubscriptionState,
+      ];
+
+      act(() => {
+        result.current.updateSubscriptions(typedSubscriptions);
+      });
+
+      expect(result.current.subscriptions).toBeDefined();
+    });
+
+    it("should handle handleEditSubscription with typed updates", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const typedUpdates: SubscriptionUpdatePayload = {
+        name: "Updated Netflix",
+        price: 19.99,
+        billingCycle: "yearly",
+      };
+
+      act(() => {
+        result.current.handleEditSubscription(1, typedUpdates);
+      });
+
+      expect(mockToast).toHaveBeenCalled();
+    });
+
+    it("should handle handleAddSubscription with typed payload", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const newSubscription: SubscriptionCreatePayload = {
+        name: "Disney+",
+        category: "Entertainment",
+        price: 7.99,
+        icon: "🏰",
+        renewsIn: 30,
+        status: "active",
+        color: "#002D72",
+        tags: ["streaming"],
+      };
+
+      act(async () => {
+        await result.current.handleAddSubscription(newSubscription);
+      });
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Subscription added",
+          variant: "success",
+        })
+      );
+    });
+
+    it("should handle handleCancelSubscription with typed state", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      act(async () => {
+        await result.current.handleCancelSubscription(1);
+      });
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Subscription cancelled",
+          variant: "success",
+        })
+      );
+    });
+
+    it("should handle handlePauseSubscription with typed parameters", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      const resumeDate = new Date("2024-06-01T00:00:00.000Z");
+
+      act(async () => {
+        await result.current.handlePauseSubscription(1, resumeDate);
+      });
+
+      expect(mockToast).toHaveBeenCalled();
+    });
+
+    it("should handle handleResumeSubscription with typed state", () => {
+      const { result } = renderHook(() =>
+        useSubscriptions({
+          initialSubscriptions: mockDBSubscriptions,
+          maxSubscriptions: 10,
+          emailAccounts: mockEmailAccounts,
+          onToast: mockToast,
+          onUpgradePlan: mockUpgradePlan,
+        })
+      );
+
+      act(async () => {
+        await result.current.handleResumeSubscription(1);
+      });
+
+      expect(mockToast).toHaveBeenCalled();
+    });
+  });
+
+  describe("No 'any' types in public interfaces", () => {
+    it("should export only typed interfaces", () => {
+      const exports = {
+        SubscriptionState: {} as SubscriptionState,
+        SubscriptionCreatePayload: {} as SubscriptionCreatePayload,
+        SubscriptionUpdatePayload: {} as SubscriptionUpdatePayload,
+        ToastPayload: {} as ToastPayload,
+        EmailAccount: {} as EmailAccount,
+      };
+
+      expect(exports.SubscriptionState).toBeDefined();
+      expect(exports.SubscriptionCreatePayload).toBeDefined();
+      expect(exports.SubscriptionUpdatePayload).toBeDefined();
+      expect(exports.ToastPayload).toBeDefined();
+      expect(exports.EmailAccount).toBeDefined();
+    });
+  });
+});

--- a/client/hooks/use-subscriptions.ts
+++ b/client/hooks/use-subscriptions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { apiGet } from "../lib/api";
 import { useUndoManager } from "@/hooks/use-undo-manager";
 import type { Subscription as DBSubscription } from "@/lib/supabase/subscriptions";
@@ -14,13 +14,130 @@ import { retryWithBackoff, getErrorMessage } from "@/lib/network-utils";
 import { validateSubscriptionData } from "@/lib/validation";
 import { checkDuplicate } from "@/lib/subscription-utils";
 
+export interface ToastPayload {
+  title: string;
+  description: string;
+  variant: "success" | "error" | "default" | "warning";
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+export interface DialogPayload {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface EmailAccount {
+  id: number;
+  email: string;
+  isPrimary?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SubscriptionCreatePayload {
+  name: string;
+  category: string;
+  price: number;
+  icon?: string;
+  renewsIn?: number;
+  status?: string;
+  color?: string;
+  renewalUrl?: string | null;
+  tags?: string[];
+  isTrial?: boolean;
+  trialEndsAt?: string | null;
+  priceAfterTrial?: number | null;
+}
+
+export interface SubscriptionUpdatePayload {
+  name?: string;
+  category?: string;
+  price?: number;
+  icon?: string;
+  renewsIn?: number;
+  status?: string;
+  color?: string;
+  renewalUrl?: string | null;
+  tags?: string[];
+  billingCycle?: string;
+  pricingType?: string;
+}
+
+export type SubscriptionState = DBSubscription & {
+  renewsIn: number;
+  renewalUrl: string | null;
+  dateAdded: string;
+  emailAccountId: number | null;
+  lastUsedAt: string | null;
+  hasApiKey: boolean;
+  isTrial: boolean;
+  trialEndsAt: string | null;
+  priceAfterTrial: number | null;
+  manuallyEdited: boolean;
+  editedFields: string[];
+  pricingType: string;
+  billingCycle: string;
+  cancelledAt?: string;
+  activeUntil?: string;
+  pausedAt?: string;
+  resumesAt?: string;
+  expiredAt: string | null;
+};
+
+function mapDbSubToState(dbSub: Record<string, unknown>): SubscriptionState {
+  return {
+    id: dbSub.id as number,
+    user_id: dbSub.user_id as string | undefined,
+    name: dbSub.name as string,
+    category: dbSub.category as string,
+    price: dbSub.price as number,
+    icon: (dbSub.icon as string) || "🔗",
+    renews_in: (dbSub.renews_in as number) || null,
+    status: dbSub.status as string,
+    color: (dbSub.color as string) || "#000000",
+    renewal_url: (dbSub.renewal_url as string) || null,
+    tags: (dbSub.tags as string[]) || [],
+    date_added: dbSub.date_added as string,
+    email_account_id: (dbSub.email_account_id as number) || null,
+    last_used_at: (dbSub.last_used_at as string) || null,
+    has_api_key: (dbSub.has_api_key as boolean) || false,
+    is_trial: (dbSub.is_trial as boolean) || false,
+    trial_ends_at: (dbSub.trial_ends_at as string) || null,
+    price_after_trial: (dbSub.price_after_trial as number) || null,
+    source: (dbSub.source as string) || "manual",
+    manually_edited: (dbSub.manually_edited as boolean) || false,
+    edited_fields: (dbSub.edited_fields as string[]) || [],
+    pricing_type: (dbSub.pricing_type as string) || "fixed",
+    billing_cycle: (dbSub.billing_cycle as string) || "monthly",
+    expired_at: (dbSub.expired_at as string) || null,
+    notes: (dbSub.notes as string) || null,
+    custom_tag_ids: (dbSub.custom_tag_ids as string[]) || null,
+    renewsIn: (dbSub.renews_in as number) || (dbSub.renewsIn as number) || 30,
+    renewalUrl: (dbSub.renewal_url as string) || (dbSub.renewalUrl as string) || null,
+    dateAdded: (dbSub.date_added as string) || (dbSub.dateAdded as string),
+    emailAccountId: (dbSub.email_account_id as number) || (dbSub.emailAccountId as number),
+    lastUsedAt: (dbSub.last_used_at as string) || (dbSub.lastUsedAt as string) || null,
+    hasApiKey: (dbSub.has_api_key as boolean) || (dbSub.hasApiKey as boolean) || false,
+    isTrial: (dbSub.is_trial as boolean) || (dbSub.isTrial as boolean) || false,
+    trialEndsAt: (dbSub.trial_ends_at as string) || (dbSub.trialEndsAt as string) || null,
+    priceAfterTrial: (dbSub.price_after_trial as number) || (dbSub.priceAfterTrial as number) || null,
+    manuallyEdited: (dbSub.manually_edited as boolean) || (dbSub.manuallyEdited as boolean) || false,
+    editedFields: (dbSub.edited_fields as string[]) || (dbSub.editedFields as string[]) || [],
+    pricingType: (dbSub.pricing_type as string) || (dbSub.pricingType as string) || "fixed",
+    billingCycle: (dbSub.billing_cycle as string) || (dbSub.billingCycle as string) || "monthly",
+    expiredAt: (dbSub.expired_at as string) || (dbSub.expiredAt as string) || null,
+  };
+}
+
 interface UseSubscriptionsProps {
   initialSubscriptions: DBSubscription[];
   maxSubscriptions: number;
-  emailAccounts: any[];
-  onToast: (toast: any) => void;
+  emailAccounts: EmailAccount[];
+  onToast: (toast: ToastPayload) => void;
   onUpgradePlan: () => void;
-  onShowDialog?: (dialog: any) => void;
+  onShowDialog?: (dialog: DialogPayload) => void;
   onDeleteWithUndo?: (subscription: DBSubscription) => void;
 }
 
@@ -40,9 +157,8 @@ export function useSubscriptions({
     redo,
     canUndo,
     canRedo,
-  } = useUndoManager(initialSubscriptions);
+  } = useUndoManager<SubscriptionState>(initialSubscriptions as SubscriptionState[]);
 
-  // On mount, attempt to fetch live subscriptions from backend API and replace initial state
   useEffect(() => {
     let mounted = true;
     const fetchSubscriptions = async () => {
@@ -50,40 +166,13 @@ export function useSubscriptions({
         const data = await apiGet("/api/subscriptions");
         if (!mounted) return;
 
-        const items = (data?.subscriptions || []).map((dbSub: any) => ({
-          id: dbSub.id,
-          name: dbSub.name,
-          category: dbSub.category,
-          price: dbSub.price,
-          icon: dbSub.icon || "🔗",
-          renewsIn: dbSub.renews_in || dbSub.renewsIn || 30,
-          status: dbSub.status,
-          color: dbSub.color || "#000000",
-          renewalUrl: dbSub.renewal_url || dbSub.renewalUrl,
-          tags: dbSub.tags || [],
-          dateAdded: dbSub.date_added || dbSub.dateAdded,
-          emailAccountId: dbSub.email_account_id || dbSub.emailAccountId,
-          lastUsedAt: dbSub.last_used_at || dbSub.lastUsedAt,
-          hasApiKey: dbSub.has_api_key || dbSub.hasApiKey || false,
-          isTrial: dbSub.is_trial || dbSub.isTrial || false,
-          trialEndsAt: dbSub.trial_ends_at || dbSub.trialEndsAt,
-          priceAfterTrial: dbSub.price_after_trial || dbSub.priceAfterTrial,
-          source: dbSub.source || "manual",
-          manuallyEdited:
-            dbSub.manually_edited || dbSub.manuallyEdited || false,
-          editedFields: dbSub.edited_fields || dbSub.editedFields || [],
-          pricingType: dbSub.pricing_type || dbSub.pricingType || "fixed",
-          billingCycle: dbSub.billing_cycle || dbSub.billingCycle || "monthly",
-          expiredAt: dbSub.expired_at || dbSub.expiredAt,
-        }));
+        const items = (data?.subscriptions || []).map(mapDbSubToState);
 
         if (items.length > 0) {
-          // Replace current state with fetched items
           addToHistory(items);
         }
-      } catch (error) {
+      } catch {
         // ignore - keep initial subscriptions
-        // console.debug("Failed to fetch subscriptions from API:", error)
       }
     };
 
@@ -99,23 +188,23 @@ export function useSubscriptions({
   const [selectedSubscriptions, setSelectedSubscriptions] = useState<
     Set<number>
   >(new Set());
-  const [selectedSubscription, setSelectedSubscription] = useState<any>(null);
+  const [selectedSubscription, setSelectedSubscription] = useState<SubscriptionState | null>(null);
 
   const updateSubscriptions = useCallback(
-    (newSubs: any[]) => {
+    (newSubs: SubscriptionState[]) => {
       addToHistory(newSubs);
     },
     [addToHistory]
   );
 
   const handleAddSubscription = useCallback(
-    async (newSub: any) => {
+    async (newSub: SubscriptionCreatePayload) => {
       const validation = validateSubscriptionData(newSub);
       if (!validation.isValid) {
         const firstError = Object.values(validation.errors)[0];
         onToast({
           title: "Validation error",
-          description: firstError,
+          description: firstError as string,
           variant: "error",
         });
         return;
@@ -154,9 +243,9 @@ export function useSubscriptions({
               emailAccounts.find((acc) => acc.isPrimary)?.id || 1,
             last_used_at: undefined,
             has_api_key: false,
-            is_trial: (newSub as any).isTrial || false,
-            trial_ends_at: (newSub as any).trialEndsAt || null,
-            price_after_trial: (newSub as any).priceAfterTrial || null,
+            is_trial: newSub.isTrial || false,
+            trial_ends_at: newSub.trialEndsAt || null,
+            price_after_trial: newSub.priceAfterTrial || null,
             source: "manual",
             manually_edited: false,
             edited_fields: [],
@@ -165,17 +254,35 @@ export function useSubscriptions({
           });
         });
 
-        const formattedSub = {
+        const formattedSub: SubscriptionState = {
           id: dbSubscription.id,
+          user_id: dbSubscription.user_id,
           name: dbSubscription.name,
           category: dbSubscription.category,
           price: dbSubscription.price,
           icon: dbSubscription.icon,
-          renewsIn: dbSubscription.renews_in,
+          renews_in: dbSubscription.renews_in,
           status: dbSubscription.status,
           color: dbSubscription.color,
-          renewalUrl: dbSubscription.renewal_url,
+          renewal_url: dbSubscription.renewal_url,
           tags: dbSubscription.tags,
+          date_added: dbSubscription.date_added,
+          email_account_id: dbSubscription.email_account_id,
+          last_used_at: dbSubscription.last_used_at,
+          has_api_key: dbSubscription.has_api_key,
+          is_trial: dbSubscription.is_trial,
+          trial_ends_at: dbSubscription.trial_ends_at,
+          price_after_trial: dbSubscription.price_after_trial,
+          source: dbSubscription.source,
+          manually_edited: dbSubscription.manually_edited,
+          edited_fields: dbSubscription.edited_fields,
+          pricing_type: dbSubscription.pricing_type,
+          billing_cycle: dbSubscription.billing_cycle,
+          expired_at: dbSubscription.expired_at,
+          notes: dbSubscription.notes,
+          custom_tag_ids: dbSubscription.custom_tag_ids,
+          renewsIn: dbSubscription.renews_in,
+          renewalUrl: dbSubscription.renewal_url,
           dateAdded: dbSubscription.date_added,
           emailAccountId: dbSubscription.email_account_id,
           lastUsedAt: dbSubscription.last_used_at,
@@ -183,11 +290,11 @@ export function useSubscriptions({
           isTrial: dbSubscription.is_trial,
           trialEndsAt: dbSubscription.trial_ends_at,
           priceAfterTrial: dbSubscription.price_after_trial,
-          source: dbSubscription.source,
           manuallyEdited: dbSubscription.manually_edited,
           editedFields: dbSubscription.edited_fields,
           pricingType: dbSubscription.pricing_type,
           billingCycle: dbSubscription.billing_cycle,
+          expiredAt: dbSubscription.expired_at,
         };
 
         const updatedSubs = [...subscriptions, formattedSub];
@@ -201,14 +308,14 @@ export function useSubscriptions({
             label: "Undo",
             onClick: async () => {
               try {
-                await deleteSubscription(dbSubscription.id);
+                await dbDeleteSubscription(dbSubscription.id);
                 undo();
                 onToast({
                   title: "Undone",
                   description: "Subscription addition has been undone",
                   variant: "default",
                 });
-              } catch (error) {
+              } catch {
                 onToast({
                   title: "Error",
                   description: "Failed to undo subscription addition",
@@ -249,7 +356,7 @@ export function useSubscriptions({
       const sub = subscriptions.find((s) => s.id === id);
       if (!sub) return;
 
-      let deletedSubToRestore: DBSubscription | null = null;
+      let deletedSubToRestore: SubscriptionState | null = null;
 
       if (onDeleteWithUndo) {
         onDeleteWithUndo(sub);
@@ -287,7 +394,7 @@ export function useSubscriptions({
             description: `${sub.name} has been removed`,
             variant: "success",
           });
-        } catch (error) {
+        } catch {
           onToast({
             title: "Error",
             description: "Failed to delete subscription",
@@ -300,9 +407,9 @@ export function useSubscriptions({
   );
 
   const handleEditSubscription = useCallback(
-    async (id: number, updates: any) => {
+    async (id: number, updates: SubscriptionUpdatePayload) => {
       try {
-        const dbUpdates = {
+        const dbUpdates: Partial<DBSubscription> & { manually_edited: boolean } = {
           name: updates.name,
           category: updates.category,
           price: updates.price,
@@ -319,12 +426,12 @@ export function useSubscriptions({
 
         await updateSubscription(id, dbUpdates);
 
-        const updatedSubs = subscriptions.map((sub: any) => {
+        const updatedSubs = subscriptions.map((sub) => {
           if (sub.id !== id) return sub;
 
           const editedFields = Object.keys(updates).filter(
-            (key: string) =>
-              updates[key as keyof typeof updates] !== (sub as any)[key]
+            (key) =>
+              updates[key as keyof SubscriptionUpdatePayload] !== sub[key as keyof SubscriptionState]
           );
 
           return {
@@ -349,7 +456,7 @@ export function useSubscriptions({
           description: "Your changes have been saved",
           variant: "success",
         });
-      } catch (error) {
+      } catch {
         onToast({
           title: "Error",
           description: "Failed to update subscription",
@@ -365,7 +472,7 @@ export function useSubscriptions({
       const sub = subscriptions.find((s) => s.id === id);
       if (!sub) return;
 
-      const daysUntilRenewal = (sub as any).renewsIn || sub.renews_in || 0;
+      const daysUntilRenewal = sub.renewsIn ?? sub.renews_in ?? 0;
       const activeUntil = new Date(
         Date.now() + daysUntilRenewal * 24 * 60 * 60 * 1000
       );
@@ -396,7 +503,7 @@ export function useSubscriptions({
           description: "The subscription has been cancelled",
           variant: "success",
         });
-      } catch (error) {
+      } catch {
         onToast({
           title: "Error",
           description: "Failed to cancel subscription",
@@ -407,103 +514,103 @@ export function useSubscriptions({
     [subscriptions, updateSubscriptions, addToHistory, onToast]
   );
 
-const handlePauseSubscription = useCallback(
-  async (id: number, resumeDate?: Date) => {
-    const sub = subscriptions.find((s) => s.id === id);
-    if (!sub) return;
+  const handlePauseSubscription = useCallback(
+    async (id: number, resumeDate?: Date) => {
+      const sub = subscriptions.find((s) => s.id === id);
+      if (!sub) return;
 
-    try {
-      const resumeAt = resumeDate
-        ? resumeDate.toISOString()
-        : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      try {
+        const resumeAt = resumeDate
+          ? resumeDate.toISOString()
+          : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
-      const response = await fetch(`/api/subscriptions/${id}/pause`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ resumeAt, reason: "User requested pause" }),
-      });
+        const response = await fetch(`/api/subscriptions/${id}/pause`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ resumeAt, reason: "User requested pause" }),
+        });
 
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error || "Failed to pause subscription");
+        if (!response.ok) {
+          const err = await response.json();
+          throw new Error(err.error || "Failed to pause subscription");
+        }
+
+        const updatedSubs = subscriptions.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                status: "paused",
+                pausedAt: new Date().toISOString(),
+                resumesAt: resumeAt,
+              }
+            : s
+        );
+
+        updateSubscriptions(updatedSubs);
+        addToHistory(updatedSubs);
+
+        onToast({
+          title: "Subscription paused",
+          description: "The subscription has been paused",
+          variant: "success",
+        });
+      } catch (error) {
+        onToast({
+          title: "Error",
+          description: error instanceof Error ? error.message : "Failed to pause subscription",
+          variant: "error",
+        });
       }
+    },
+    [subscriptions, updateSubscriptions, addToHistory, onToast]
+  );
 
-      const updatedSubs = subscriptions.map((s) =>
-        s.id === id
-          ? {
-              ...s,
-              status: "paused",
-              pausedAt: new Date().toISOString(),
-              resumesAt: resumeAt,
-            }
-          : s
-      );
+  const handleResumeSubscription = useCallback(
+    async (id: number) => {
+      const sub = subscriptions.find((s) => s.id === id);
+      if (!sub) return;
 
-      updateSubscriptions(updatedSubs);
-      addToHistory(updatedSubs);
+      try {
+        const response = await fetch(`/api/subscriptions/${id}/resume`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
 
-      onToast({
-        title: "Subscription paused",
-        description: "The subscription has been paused",
-        variant: "success",
-      });
-    } catch (error) {
-      onToast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to pause subscription",
-        variant: "error",
-      });
-    }
-  },
-  [subscriptions, updateSubscriptions, addToHistory, onToast]
-);
+        if (!response.ok) {
+          const err = await response.json();
+          throw new Error(err.error || "Failed to resume subscription");
+        }
 
-const handleResumeSubscription = useCallback(
-  async (id: number) => {
-    const sub = subscriptions.find((s) => s.id === id);
-    if (!sub) return;
+        const updatedSubs = subscriptions.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                status: "active",
+                pausedAt: undefined,
+                resumesAt: undefined,
+              }
+            : s
+        );
 
-    try {
-      const response = await fetch(`/api/subscriptions/${id}/resume`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
+        updateSubscriptions(updatedSubs);
+        addToHistory(updatedSubs);
 
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error || "Failed to resume subscription");
+        onToast({
+          title: "Subscription resumed",
+          description: "The subscription has been resumed",
+          variant: "success",
+        });
+      } catch (error) {
+        onToast({
+          title: "Error",
+          description: error instanceof Error ? error.message : "Failed to resume subscription",
+          variant: "error",
+        });
       }
-
-      const updatedSubs = subscriptions.map((s) =>
-        s.id === id
-          ? {
-              ...s,
-              status: "active",
-              pausedAt: undefined,
-              resumesAt: undefined,
-            }
-          : s
-      );
-
-      updateSubscriptions(updatedSubs);
-      addToHistory(updatedSubs);
-
-      onToast({
-        title: "Subscription resumed",
-        description: "The subscription has been resumed",
-        variant: "success",
-      });
-    } catch (error) {
-      onToast({
-        title: "Error",
-        description: error instanceof Error ? error.message : "Failed to resume subscription",
-        variant: "error",
-      });
-    }
-  },
-  [subscriptions, updateSubscriptions, addToHistory, onToast]
-);
+    },
+    [subscriptions, updateSubscriptions, addToHistory, onToast]
+  );
 
   const handleToggleSubscriptionSelect = useCallback((id: number) => {
     setSelectedSubscriptions((prev) => {


### PR DESCRIPTION
## Summary

Replaces all `any` types in `use-subscriptions` hook with strongly typed domain interfaces.

## Changes

- **New domain types exported:**
  - `ToastPayload` - typed toast notifications
  - `DialogPayload` - typed dialog objects
  - `EmailAccount` - typed email account objects
  - `SubscriptionCreatePayload` - typed creation payloads
  - `SubscriptionUpdatePayload` - typed update payloads
  - `SubscriptionState` - typed subscription state extending `DBSubscription`

- **Removed all `any` usages and `as any` casts** across state, parameters, and update flows
- **Extracted `mapDbSubToState` helper** for type-safe DB-to-state conversion
- **Added type-focused tests** covering type definitions, state safety, and update operations

## Acceptance Criteria

- [x] Hook compiles without explicit `any` in primary interfaces
- [x] Update operations remain type-safe and behaviorally unchanged
- [x] Type-focused tests added for update semantics

Closes #426

