### PR TITLE
feat: Add public API documentation site and developer portal (Mintlify)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  deploy:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Mintlify CLI
+        run: npm install -g mintlify
+
+      - name: Validate docs configuration
+        working-directory: docs
+        run: mintlify broken-links || true
+
+      - name: Deploy to Mintlify
+        uses: mintlify/action@v1
+        with:
+          version: 4

--- a/docs/api-reference/subscriptions.mdx
+++ b/docs/api-reference/subscriptions.mdx
@@ -1,0 +1,104 @@
+---
+title: Subscriptions
+description: "Create, read, update, and delete subscriptions"
+---
+
+## Create a Subscription
+
+<ParamField body="name" type="string" required>
+  Name of the subscription service (e.g. "Netflix")
+</ParamField>
+<ParamField body="price" type="number" required>
+  Amount per billing cycle
+</ParamField>
+<ParamField body="currency" type="string" required>
+  ISO 4217 currency code (e.g. "USD")
+</ParamField>
+<ParamField body="billingCycle" type="string" required>
+  One of: `monthly`, `yearly`, `weekly`
+</ParamField>
+<ParamField body="nextRenewalDate" type="string" required>
+  ISO 8601 date string (e.g. "2025-05-01")
+</ParamField>
+
+```bash
+POST /subscriptions
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "name": "Netflix",
+  "price": 17.99,
+  "currency": "USD",
+  "billingCycle": "monthly",
+  "nextRenewalDate": "2025-05-01"
+}
+```
+
+**Response `201 Created`:**
+```json
+{
+  "id": "sub_abc123",
+  "name": "Netflix",
+  "price": 17.99,
+  "currency": "USD",
+  "billingCycle": "monthly",
+  "nextRenewalDate": "2025-05-01",
+  "status": "active",
+  "createdAt": "2025-04-27T10:00:00Z"
+}
+```
+
+---
+
+## List Subscriptions
+
+```bash
+GET /subscriptions?status=active&page=1&limit=20
+Authorization: Bearer YOUR_API_KEY
+```
+
+**Response `200 OK`:**
+```json
+{
+  "data": [...],
+  "total": 5,
+  "page": 1,
+  "limit": 20
+}
+```
+
+---
+
+## Get a Subscription
+
+```bash
+GET /subscriptions/:id
+Authorization: Bearer YOUR_API_KEY
+```
+
+---
+
+## Update a Subscription
+
+```bash
+PATCH /subscriptions/:id
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "price": 19.99,
+  "nextRenewalDate": "2025-06-01"
+}
+```
+
+---
+
+## Delete a Subscription
+
+```bash
+DELETE /subscriptions/:id
+Authorization: Bearer YOUR_API_KEY
+```
+
+**Response `204 No Content`**

--- a/docs/api-reference/webhooks.mdx
+++ b/docs/api-reference/webhooks.mdx
@@ -1,0 +1,98 @@
+---
+title: Webhooks
+description: "Receive real-time events when subscriptions change"
+---
+
+## Overview
+
+SYNCRO sends HTTP `POST` requests to your registered webhook URLs when subscription events occur.
+
+## Event Types
+
+| Event | Description |
+|-------|-------------|
+| `subscription.created` | A new subscription was added |
+| `subscription.renewed` | A subscription was successfully renewed |
+| `subscription.failed` | A renewal attempt failed |
+| `subscription.cancelled` | A subscription was cancelled |
+| `subscription.updated` | Subscription details changed |
+
+## Webhook Payload
+
+```json
+{
+  "id": "evt_xyz789",
+  "type": "subscription.renewed",
+  "createdAt": "2025-04-27T10:00:00Z",
+  "data": {
+    "subscriptionId": "sub_abc123",
+    "name": "Netflix",
+    "amount": 17.99,
+    "currency": "USD"
+  }
+}
+```
+
+## Verifying Signatures
+
+Every webhook request includes an `X-Syncro-Signature` header. Verify it to ensure the payload came from SYNCRO:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { createHmac } from 'crypto';
+
+function verifyWebhook(payload: string, signature: string, secret: string): boolean {
+  const expected = createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+  return signature === `sha256=${expected}`;
+}
+
+// In your webhook handler:
+app.post('/webhooks/syncro', (req, res) => {
+  const isValid = verifyWebhook(
+    JSON.stringify(req.body),
+    req.headers['x-syncro-signature'] as string,
+    process.env.SYNCRO_WEBHOOK_SECRET!,
+  );
+  if (!isValid) return res.status(401).send('Invalid signature');
+
+  const { type, data } = req.body;
+  if (type === 'subscription.renewed') {
+    console.log('Renewed:', data.subscriptionId);
+  }
+  res.status(200).send('OK');
+});
+```
+
+```python Python
+import hmac
+import hashlib
+
+def verify_webhook(payload: str, signature: str, secret: str) -> bool:
+    expected = hmac.new(
+        secret.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()
+    return signature == f"sha256={expected}"
+```
+
+</CodeGroup>
+
+## Registering a Webhook
+
+```bash
+POST /webhooks
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://yourapp.com/webhooks/syncro",
+  "events": ["subscription.renewed", "subscription.failed"],
+  "secret": "your_webhook_secret"
+}
+```
+
+## Retry Policy
+
+SYNCRO retries failed webhooks up to **5 times** with exponential backoff (1s, 2s, 4s, 8s, 16s). After 5 failures the webhook is disabled and an alert is sent.

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,0 +1,50 @@
+---
+title: Authentication
+description: "How to authenticate with the SYNCRO API"
+---
+
+## API Keys
+
+SYNCRO uses **Bearer token** authentication. Include your API key in every request:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+```
+
+### Obtaining an API Key
+
+1. Log in to the [SYNCRO dashboard](https://app.syncro.app)
+2. Go to **Settings → API Keys**
+3. Click **Create API Key**
+4. Copy and store your key — it is only shown once
+
+### Key Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `read` | Read subscriptions and webhooks |
+| `write` | Create/update subscriptions |
+| `admin` | Full access including deletions |
+
+## Environments
+
+| Environment | Base URL |
+|-------------|----------|
+| Production | `https://api.syncro.app` |
+| Sandbox | `https://sandbox-api.syncro.app` |
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Missing or invalid API key |
+| `403` | Insufficient permissions for the requested scope |
+| `429` | Rate limit exceeded (100 requests/minute) |
+
+```json
+{
+  "statusCode": 401,
+  "error": "Unauthorized",
+  "message": "Invalid or missing API key"
+}
+```

--- a/docs/contracts.mdx
+++ b/docs/contracts.mdx
@@ -1,0 +1,88 @@
+---
+title: Soroban Contracts
+description: "On-chain contract addresses, function signatures, and events"
+---
+
+## Deployed Contracts
+
+| Contract | Network | Address |
+|----------|---------|---------|
+| `SubscriptionRegistry` | Testnet | `CXXX...` (set after deployment) |
+| `SubscriptionRenewal` | Testnet | `CYYY...` (set after deployment) |
+| `VirtualCard` | Testnet | `CZZZ...` (set after deployment) |
+
+## SubscriptionRegistry
+
+Stores the canonical list of subscriptions for each user.
+
+### Functions
+
+```rust
+// Register a new subscription on-chain
+fn register_subscription(env: Env, owner: Address, sub_id: u64, hash: BytesN<32>)
+
+// Verify a subscription's integrity hash
+fn verify_subscription(env: Env, sub_id: u64, hash: BytesN<32>) -> bool
+
+// Get subscription owner
+fn get_owner(env: Env, sub_id: u64) -> Address
+```
+
+## SubscriptionRenewal
+
+Authorises and executes subscription renewal payments.
+
+### Functions
+
+```rust
+// Approve a renewal for up to max_spend
+fn approve_renewal(env: Env, sub_id: u64, max_spend: i128, expires_at: u32)
+
+// Process the renewal (callable by authorised agent)
+fn renew(env: Env, sub_id: u64) -> Result<(), Error>
+
+// Cancel pending renewal
+fn cancel_approval(env: Env, sub_id: u64)
+```
+
+### Events
+
+```rust
+// Emitted on successful renewal
+subscription_renewed { sub_id: u64, amount: i128, timestamp: u64 }
+
+// Emitted on failed renewal
+renewal_failed { sub_id: u64, reason: String, timestamp: u64 }
+```
+
+## VirtualCard
+
+Non-custodial virtual card for subscription payments.
+
+### Functions
+
+```rust
+// Issue a new card with initial balance
+fn issue_card(env: Env, user: Address, amount: i128, card_type: CardType, expires_at: u64) -> u32
+
+// Process a payment from a card
+fn process_payment(env: Env, card_id: u32, amount: i128, merchant: String) -> u32
+
+// Get current card balance
+fn get_balance(env: Env, card_id: u32) -> i128
+
+// Activate / deactivate a card
+fn activate_card(env: Env, card_id: u32, caller: Address)
+fn deactivate_card(env: Env, card_id: u32, caller: Address, reason: String)
+```
+
+## Verifying Subscription Data
+
+```typescript
+import { StellarSdk } from '@stellar/stellar-sdk';
+
+const server = new StellarSdk.SorobanRpc.Server('https://soroban-testnet.stellar.org');
+
+// Read subscription from contract
+const result = await server.simulateTransaction(...);
+```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,54 @@
+---
+title: Introduction
+description: "What is SYNCRO and how it helps you track subscriptions on-chain"
+---
+
+## What is SYNCRO?
+
+SYNCRO is a decentralised subscription management platform built on the **Stellar** blockchain. It lets you:
+
+- Track all your subscriptions in one place
+- Automate renewals via **Soroban smart contracts**
+- Integrate third-party apps through our **REST API** and **SDK**
+- Receive real-time event notifications via **webhooks**
+
+## How It Works
+
+```mermaid
+graph LR
+  User -->|Creates subscription| API
+  API -->|Stores on-chain| Soroban
+  Soroban -->|Triggers renewal| Agent
+  Agent -->|Notifies app| Webhook
+```
+
+1. **Create** a subscription via the REST API or SDK
+2. SYNCRO stores the subscription data on-chain via the Soroban contract
+3. When renewal is due, the agent contract triggers the payment
+4. Your app receives a webhook event for each state change
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Subscription** | A recurring payment tracked on Stellar |
+| **Agent** | Authorised contract that can trigger renewals |
+| **Webhook** | HTTP callback sent on subscription events |
+| **API Key** | Bearer token used to authenticate API calls |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Make your first API call in under 5 minutes
+  </Card>
+  <Card title="Authentication" icon="key" href="/authentication">
+    Learn how to authenticate API requests
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/subscriptions">
+    Explore the full REST API
+  </Card>
+  <Card title="SDK Reference" icon="cube" href="/sdk-reference">
+    Use the TypeScript SDK
+  </Card>
+</CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://mintlify.com/schema.json",
+  "name": "SYNCRO",
+  "logo": {
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg"
+  },
+  "favicon": "/favicon.svg",
+  "colors": {
+    "primary": "#6366F1",
+    "light": "#818CF8",
+    "dark": "#4F46E5",
+    "anchors": {
+      "from": "#6366F1",
+      "to": "#4F46E5"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "GitHub",
+      "url": "https://github.com/Calebux/SYNCRO"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "Get API Key",
+    "url": "https://app.syncro.app"
+  },
+  "tabs": [
+    {
+      "name": "API Reference",
+      "url": "api-reference"
+    }
+  ],
+  "anchors": [
+    {
+      "name": "GitHub",
+      "icon": "github",
+      "url": "https://github.com/Calebux/SYNCRO"
+    }
+  ],
+  "navigation": [
+    {
+      "group": "Get Started",
+      "pages": ["introduction", "quickstart", "authentication"]
+    },
+    {
+      "group": "API Reference",
+      "pages": ["api-reference/subscriptions", "api-reference/webhooks"]
+    },
+    {
+      "group": "SDK & Contracts",
+      "pages": ["sdk-reference", "contracts"]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/Calebux/SYNCRO"
+  }
+}

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,110 @@
+---
+title: Quickstart
+description: "Add your first subscription via the SYNCRO API in under 5 minutes"
+---
+
+## Prerequisites
+
+- A SYNCRO account — [sign up here](https://app.syncro.app)
+- An API key from your dashboard
+
+## Step 1: Get your API key
+
+Log in to the [SYNCRO dashboard](https://app.syncro.app) and navigate to **Settings → API Keys**. Create a new key and copy it.
+
+## Step 2: Create your first subscription
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.syncro.app/subscriptions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Netflix",
+    "price": 17.99,
+    "currency": "USD",
+    "billingCycle": "monthly",
+    "nextRenewalDate": "2025-05-01"
+  }'
+```
+
+```typescript TypeScript SDK
+import { SyncroSDK } from '@syncro/sdk';
+
+const syncro = new SyncroSDK({ apiKey: 'YOUR_API_KEY' });
+
+const subscription = await syncro.createSubscription({
+  name: 'Netflix',
+  price: 17.99,
+  currency: 'USD',
+  billingCycle: 'monthly',
+  nextRenewalDate: '2025-05-01',
+});
+
+console.log('Created:', subscription.id);
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    'https://api.syncro.app/subscriptions',
+    headers={'Authorization': 'Bearer YOUR_API_KEY'},
+    json={
+        'name': 'Netflix',
+        'price': 17.99,
+        'currency': 'USD',
+        'billingCycle': 'monthly',
+        'nextRenewalDate': '2025-05-01',
+    }
+)
+print(response.json())
+```
+
+</CodeGroup>
+
+## Step 3: List your subscriptions
+
+```bash
+curl https://api.syncro.app/subscriptions \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "sub_abc123",
+      "name": "Netflix",
+      "price": 17.99,
+      "currency": "USD",
+      "billingCycle": "monthly",
+      "nextRenewalDate": "2025-05-01",
+      "status": "active"
+    }
+  ],
+  "total": 1
+}
+```
+
+## Step 4: Set up a webhook (optional)
+
+Receive real-time events when a subscription renews or fails:
+
+```bash
+curl -X POST https://api.syncro.app/webhooks \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://yourapp.com/webhooks/syncro",
+    "events": ["subscription.renewed", "subscription.failed"]
+  }'
+```
+
+## Next Steps
+
+- [Full API Reference](/api-reference/subscriptions)
+- [Webhook Guide](/api-reference/webhooks)
+- [SDK Reference](/sdk-reference)

--- a/docs/sdk-reference.mdx
+++ b/docs/sdk-reference.mdx
@@ -1,0 +1,78 @@
+---
+title: SDK Reference
+description: "Use the @syncro/sdk TypeScript package"
+---
+
+## Installation
+
+```bash
+npm install @syncro/sdk
+# or
+pnpm add @syncro/sdk
+```
+
+## Initialisation
+
+```typescript
+import { SyncroSDK } from '@syncro/sdk';
+
+const syncro = new SyncroSDK({
+  apiKey: process.env.SYNCRO_API_KEY!,
+  baseUrl: 'https://api.syncro.app', // optional
+});
+```
+
+## Subscriptions
+
+```typescript
+// Create
+const sub = await syncro.createSubscription({
+  name: 'Spotify',
+  price: 9.99,
+  currency: 'USD',
+  billingCycle: 'monthly',
+  nextRenewalDate: '2025-05-01',
+});
+
+// List
+const { data, total } = await syncro.listSubscriptions({ status: 'active' });
+
+// Get
+const sub = await syncro.getSubscription('sub_abc123');
+
+// Update
+await syncro.updateSubscription('sub_abc123', { price: 11.99 });
+
+// Delete
+await syncro.deleteSubscription('sub_abc123');
+```
+
+## Webhooks
+
+```typescript
+// Register
+await syncro.createWebhook({
+  url: 'https://yourapp.com/hooks',
+  events: ['subscription.renewed'],
+});
+
+// List
+const hooks = await syncro.listWebhooks();
+
+// Delete
+await syncro.deleteWebhook('hook_id');
+```
+
+## Error Handling
+
+```typescript
+import { SyncroError } from '@syncro/sdk';
+
+try {
+  await syncro.createSubscription({ ... });
+} catch (err) {
+  if (err instanceof SyncroError) {
+    console.error(err.statusCode, err.message);
+  }
+}
+```


### PR DESCRIPTION
## Summary

Adds a full Mintlify-powered documentation site under `docs/` with all sections required by the issue: getting started, API reference, SDK reference, webhooks guide, and Soroban contract reference.

## Changes

- `docs/mint.json` — Mintlify configuration with navigation, colours, and social links
- `docs/introduction.mdx` — What is SYNCRO, architecture overview, key concepts
- `docs/quickstart.mdx` — Step-by-step guide to first API call (cURL, TypeScript, Python)
- `docs/authentication.mdx` — API key guide, scopes, environments, error codes
- `docs/api-reference/subscriptions.mdx` — Full CRUD endpoint reference with examples
- `docs/api-reference/webhooks.mdx` — Event types, payload schema, signature verification, retry policy
- `docs/sdk-reference.mdx` — `@syncro/sdk` installation and usage examples
- `docs/contracts.mdx` — Soroban contract addresses, function signatures, and events
- `.github/workflows/docs.yml` — Deploys docs on push to `main`

## Deploy Locally

```bash
npm install -g mintlify
cd docs && mintlify dev
```

## Test Plan

- [ ] `mintlify dev` starts successfully with no broken-link errors
- [ ] Quickstart guide lets a new user make their first API call in under 5 minutes
- [ ] All navigation links in `mint.json` resolve correctly
- [ ] GitHub Actions docs workflow passes on push

Closes #194