### PR TITLE
feat: improve dashboard bootstrap error handling and observability (#512)

### DIFF
--- a/client/app/page-data.ts
+++ b/client/app/page-data.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { buildQueryWarning, type DataLoadWarning } from '@/lib/dashboard-bootstrap'
 
 export type InitialPriceChange = {
   id: string
@@ -10,6 +11,16 @@ export type InitialPriceChange = {
   changeType: 'increase' | 'decrease'
   annualImpact: number
   percentChange: number
+}
+
+export type InitialDataResult = {
+  subscriptions: any[]
+  emailAccounts: any[]
+  payments: any[]
+  priceChanges: InitialPriceChange[]
+  consolidationSuggestions: any[]
+  warnings: DataLoadWarning[]
+  isDemo: boolean
 }
 
 function transformSubscription(dbSub: any): any {
@@ -67,76 +78,134 @@ function normalizePriceChange(
   }
 }
 
-export async function getInitialData() {
+export async function getInitialData(): Promise<InitialDataResult> {
+  const warnings: DataLoadWarning[] = []
+
+  let supabase: Awaited<ReturnType<typeof createClient>>
+  let user: { id: string } | null = null
+
   try {
-    const supabase = await createClient()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-
-    if (!user) {
-      return {
-        subscriptions: [],
-        emailAccounts: [],
-        payments: [],
-        priceChanges: [],
-        consolidationSuggestions: [],
-      }
+    supabase = await createClient()
+    const { data, error } = await supabase.auth.getUser()
+    if (error) {
+      console.error('[dashboard] auth.getUser failed', {
+        component: 'getInitialData',
+        query: 'auth',
+        code: error.status,
+        message: error.message,
+      })
     }
-
-    const [subscriptionsResult, emailAccountsResult, paymentsResult] = await Promise.all([
-      supabase
-        .from('subscriptions')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('date_added', { ascending: false }),
-      supabase.from('email_accounts').select('*').eq('user_id', user.id),
-      supabase
-        .from('payments')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false }),
-    ])
-
-    const subscriptions = subscriptionsResult.data?.map(transformSubscription) || []
-    const emailAccounts = emailAccountsResult.data || []
-    const payments = paymentsResult.data || []
-
-    const subscriptionsById = new Map<number, any>(
-      (subscriptionsResult.data || []).map((sub: any) => [sub.id, sub]),
-    )
-
-    const priceHistoryResult = await supabase
-      .from('subscription_price_history')
-      .select('id,subscription_id,old_price,new_price,changed_at')
-      .eq('user_id', user.id)
-      .order('changed_at', { ascending: false })
-
-    if (priceHistoryResult.error) {
-      console.error('Error fetching price change history:', priceHistoryResult.error)
-    }
-
-    const priceChanges = priceHistoryResult.data
-      ? priceHistoryResult.data.map((change: any) =>
-          normalizePriceChange(change, subscriptionsById),
-        )
-      : []
-
-    return {
-      subscriptions,
-      emailAccounts,
-      payments,
-      priceChanges,
-      consolidationSuggestions: [],
-    }
+    user = data?.user ?? null
   } catch (error) {
-    console.error('Error fetching initial data:', error)
+    console.error('[dashboard] supabase client init failed', {
+      component: 'getInitialData',
+      query: 'auth',
+      message: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  if (!user) {
     return {
       subscriptions: [],
       emailAccounts: [],
       payments: [],
       priceChanges: [],
       consolidationSuggestions: [],
+      warnings: [],
+      isDemo: true,
     }
+  }
+
+  const [subscriptionsResult, emailAccountsResult, paymentsResult] =
+    await Promise.allSettled([
+      supabase!
+        .from('subscriptions')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('date_added', { ascending: false }),
+      supabase!.from('email_accounts').select('*').eq('user_id', user.id),
+      supabase!
+        .from('payments')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false }),
+    ])
+
+  let subscriptions: any[]
+  if (
+    subscriptionsResult.status === 'fulfilled' &&
+    !subscriptionsResult.value.error &&
+    subscriptionsResult.value.data
+  ) {
+    subscriptions = subscriptionsResult.value.data.map(transformSubscription)
+  } else {
+    const reason =
+      subscriptionsResult.status === 'rejected'
+        ? subscriptionsResult.reason
+        : subscriptionsResult.value.error
+    warnings.push(buildQueryWarning('subscriptions', reason))
+    subscriptions = []
+  }
+
+  let emailAccounts: any[]
+  if (
+    emailAccountsResult.status === 'fulfilled' &&
+    !emailAccountsResult.value.error &&
+    emailAccountsResult.value.data
+  ) {
+    emailAccounts = emailAccountsResult.value.data
+  } else {
+    const reason =
+      emailAccountsResult.status === 'rejected'
+        ? emailAccountsResult.reason
+        : emailAccountsResult.value.error
+    warnings.push(buildQueryWarning('email_accounts', reason))
+    emailAccounts = []
+  }
+
+  let payments: any[]
+  if (
+    paymentsResult.status === 'fulfilled' &&
+    !paymentsResult.value.error &&
+    paymentsResult.value.data
+  ) {
+    payments = paymentsResult.value.data
+  } else {
+    const reason =
+      paymentsResult.status === 'rejected'
+        ? paymentsResult.reason
+        : paymentsResult.value.error
+    warnings.push(buildQueryWarning('payments', reason))
+    payments = []
+  }
+
+  const subscriptionsById = new Map<number, any>(
+    subscriptions.map((sub: any) => [sub.id, sub]),
+  )
+
+  const priceHistoryResult = await supabase!
+    .from('subscription_price_history')
+    .select('id,subscription_id,old_price,new_price,changed_at')
+    .eq('user_id', user.id)
+    .order('changed_at', { ascending: false })
+
+  let priceChanges: InitialPriceChange[]
+  if (priceHistoryResult.error) {
+    warnings.push(buildQueryWarning('price_history', priceHistoryResult.error))
+    priceChanges = []
+  } else {
+    priceChanges = (priceHistoryResult.data ?? []).map((change: any) =>
+      normalizePriceChange(change, subscriptionsById),
+    )
+  }
+
+  return {
+    subscriptions,
+    emailAccounts,
+    payments,
+    priceChanges,
+    consolidationSuggestions: [],
+    warnings,
+    isDemo: false,
   }
 }

--- a/client/app/page.test.ts
+++ b/client/app/page.test.ts
@@ -22,34 +22,126 @@ function makeQuery(result: any) {
   return query as unknown as SupabaseQuery
 }
 
-describe('HomePage server payload', () => {
+describe('getInitialData — unauthenticated', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  it('returns empty initial data for unauthenticated users', async () => {
+  it('returns isDemo=true with empty datasets for unauthenticated users', async () => {
     const mockSupabase = {
       auth: {
-        getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: new Error('No session') }),
+        getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
       },
     }
-
     vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
 
-    const initialData = await getInitialData()
+    const result = await getInitialData()
 
-    expect(initialData).toEqual({
-      subscriptions: [],
-      emailAccounts: [],
-      payments: [],
-      priceChanges: [],
-      consolidationSuggestions: [],
+    expect(result.isDemo).toBe(true)
+    expect(result.warnings).toHaveLength(0)
+    expect(result.subscriptions).toEqual([])
+    expect(result.emailAccounts).toEqual([])
+  })
+
+  it('returns isDemo=true when auth throws', async () => {
+    vi.mocked(createClient).mockRejectedValue(new Error('connection refused'))
+
+    const result = await getInitialData()
+
+    expect(result.isDemo).toBe(true)
+    expect(result.warnings).toHaveLength(0)
+  })
+})
+
+describe('getInitialData — partial failures', () => {
+  const mockUser = { id: 'user-123' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('adds a warning and returns empty array when subscriptions query fails', async () => {
+    const failedQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'timeout', code: 'PGRST_TIMEOUT' } }),
+    }
+    const okQuery = makeQuery({ data: [], error: null })
+    const priceHistoryQuery = makeQuery({ data: [], error: null })
+
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'subscriptions') return failedQuery
+      if (table === 'subscription_price_history') return priceHistoryQuery
+      return okQuery
     })
+
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
+      from: fromMock,
+    } as any)
+
+    const result = await getInitialData()
+
+    expect(result.isDemo).toBe(false)
+    expect(result.subscriptions).toEqual([])
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ query: 'subscriptions' }),
+      ]),
+    )
+  })
+
+  it('adds a warning and returns empty array when email_accounts query fails', async () => {
+    const okQuery = makeQuery({ data: [], error: null })
+    const failedQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'forbidden', status: 403 } }),
+    }
+
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'email_accounts') return failedQuery
+      return okQuery
+    })
+
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
+      from: fromMock,
+    } as any)
+
+    const result = await getInitialData()
+
+    expect(result.emailAccounts).toEqual([])
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ query: 'email_accounts' }),
+      ]),
+    )
+  })
+
+  it('surfaces warnings for all failed queries independently (partial load)', async () => {
+    const failedQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'error', code: '500' } }),
+    }
+
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
+      from: vi.fn().mockReturnValue(failedQuery),
+    } as any)
+
+    const result = await getInitialData()
+
+    const queryNames = result.warnings.map((w) => w.query)
+    expect(queryNames).toContain('subscriptions')
+    expect(queryNames).toContain('email_accounts')
+    expect(queryNames).toContain('payments')
   })
 
   it('loads and normalizes historical price changes for authenticated users', async () => {
-    const mockUser = { id: 'user-123' }
-
     const subscriptionsResult = {
       data: [
         {
@@ -86,8 +178,6 @@ describe('HomePage server payload', () => {
       error: null,
     }
 
-    const emailAccountsResult = { data: [], error: null }
-    const paymentsResult = { data: [], error: null }
     const priceHistoryResult = {
       data: [
         {
@@ -103,25 +193,20 @@ describe('HomePage server payload', () => {
 
     const fromMock = vi.fn((table: string) => {
       if (table === 'subscriptions') return makeQuery(subscriptionsResult)
-      if (table === 'email_accounts') return makeQuery(emailAccountsResult)
-      if (table === 'payments') return makeQuery(paymentsResult)
       if (table === 'subscription_price_history') return makeQuery(priceHistoryResult)
       return makeQuery({ data: [], error: null })
     })
 
-    const mockSupabase = {
-      auth: {
-        getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-      },
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }) },
       from: fromMock,
-    }
+    } as any)
 
-    vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+    const result = await getInitialData()
 
-    const initialData = await getInitialData()
-
-    expect(initialData.priceChanges).toHaveLength(1)
-    expect(initialData.priceChanges[0]).toMatchObject({
+    expect(result.warnings).toHaveLength(0)
+    expect(result.priceChanges).toHaveLength(1)
+    expect(result.priceChanges[0]).toMatchObject({
       id: 'history-uuid',
       subscriptionId: 1,
       name: 'ChatGPT Plus',

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -24,6 +24,8 @@ export default async function HomePage() {
         initialPayments={initialData.payments}
         initialPriceChanges={initialData.priceChanges}
         initialConsolidationSuggestions={initialData.consolidationSuggestions}
+        dataLoadWarnings={initialData.warnings}
+        isDemo={initialData.isDemo}
       />
     </Suspense>
   );

--- a/client/components/app/app-client.tsx
+++ b/client/components/app/app-client.tsx
@@ -73,6 +73,8 @@ export function AppClient({
     initialPayments = [],
     initialPriceChanges = [],
     initialConsolidationSuggestions = [],
+    dataLoadWarnings = [],
+    isDemo = false,
 }: AppClientProps) {
     return (
         <UndoProvider>
@@ -82,6 +84,8 @@ export function AppClient({
                 initialPayments={initialPayments}
                 initialPriceChanges={initialPriceChanges}
                 initialConsolidationSuggestions={initialConsolidationSuggestions}
+                dataLoadWarnings={dataLoadWarnings}
+                isDemo={isDemo}
             />
         </UndoProvider>
     );
@@ -93,12 +97,16 @@ function AppContent({
     initialPayments = [],
     initialPriceChanges = [],
     initialConsolidationSuggestions = [],
+    dataLoadWarnings = [],
+    isDemo = false,
 }: {
     initialSubscriptions: DBSubscription[];
     initialEmailAccounts: EmailAccount[];
     initialPayments?: Payment[];
     initialPriceChanges?: PriceChange[];
     initialConsolidationSuggestions?: ConsolidationSuggestion[];
+    dataLoadWarnings?: import('@/lib/dashboard-bootstrap').DataLoadWarning[];
+    isDemo?: boolean;
 }) {
     // Analytics state
     const [analyticsSummary, setAnalyticsSummary] = useState<AnalyticsSummary | undefined>(undefined);
@@ -633,6 +641,30 @@ function AppContent({
                     }
                 }}
             >
+                {dataLoadWarnings.length > 0 && (
+                    <div
+                        role="alert"
+                        aria-live="polite"
+                        className={`mx-4 mt-4 rounded-lg border px-4 py-3 text-sm flex items-start gap-2 ${
+                            darkMode
+                                ? "border-yellow-600 bg-yellow-900/30 text-yellow-300"
+                                : "border-yellow-400 bg-yellow-50 text-yellow-800"
+                        }`}
+                    >
+                        <span className="mt-0.5 shrink-0">⚠️</span>
+                        <div>
+                            <p className="font-medium">Some data could not be loaded</p>
+                            <ul className="mt-1 list-disc list-inside space-y-0.5">
+                                {dataLoadWarnings.map((w) => (
+                                    <li key={w.query}>{w.message}</li>
+                                ))}
+                            </ul>
+                            <p className="mt-1 opacity-75">
+                                Try refreshing the page. If the issue persists, contact support.
+                            </p>
+                        </div>
+                    </div>
+                )}
                 {showInsightsPage ? (
                     <InsightsPage
                         insights={notifications}

--- a/client/components/app/app-client.types.ts
+++ b/client/components/app/app-client.types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Subscription as DBSubscription } from "@/lib/supabase/subscriptions";
+import type { DataLoadWarning } from "@/lib/dashboard-bootstrap";
 
 /**
  * Email account linked to user subscriptions
@@ -100,4 +101,6 @@ export interface AppClientProps {
     initialPayments: Payment[];
     initialPriceChanges?: PriceChange[];
     initialConsolidationSuggestions?: ConsolidationSuggestion[];
+    dataLoadWarnings?: DataLoadWarning[];
+    isDemo?: boolean;
 }

--- a/client/lib/dashboard-bootstrap.ts
+++ b/client/lib/dashboard-bootstrap.ts
@@ -1,0 +1,40 @@
+export type DataLoadWarning = {
+  query: 'subscriptions' | 'email_accounts' | 'payments' | 'price_history'
+  message: string
+  code?: string
+}
+
+type QueryError = {
+  message?: string
+  code?: string
+  status?: number | string
+} | null
+
+const USER_MESSAGES: Record<DataLoadWarning['query'], string> = {
+  subscriptions: 'Could not load subscriptions. Showing cached data.',
+  email_accounts: 'Could not load email accounts.',
+  payments: 'Could not load payment history.',
+  price_history: 'Could not load price change history.',
+}
+
+/**
+ * Converts a Supabase query error or rejected Promise reason into a structured
+ * DataLoadWarning and emits a tagged log entry for monitoring.
+ */
+export function buildQueryWarning(
+  query: DataLoadWarning['query'],
+  reason: QueryError | unknown,
+): DataLoadWarning {
+  const err = reason as QueryError
+  const code = String(err?.code ?? err?.status ?? 'unknown')
+  const message = err?.message ?? String(reason)
+
+  console.error(`[dashboard] ${query} query failed`, {
+    component: 'getInitialData',
+    query,
+    code,
+    message,
+  })
+
+  return { query, message: USER_MESSAGES[query], code }
+}


### PR DESCRIPTION
closes #512 

- Replace Promise.all with Promise.allSettled so one query failure does not abort remaining fetches (partial-load support)
- Add buildQueryWarning() utility that emits structured console.error logs with component/query/code/message tags for monitoring
- Thread dataLoadWarnings and isDemo through AppClientProps so the client can distinguish empty state vs failed data fetch
- Render accessible warning banner in AppContent when any query fails, distinguishing partial load from a clean empty state
- Expand page.test.ts with regression tests covering: unauthenticated path, auth init failure, per-query partial failures, and independent warning accumulation across all three parallel queries


## Description

Briefly describe what this PR does.

---

## Related Issue

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
