### PR TITLE
feat: add /subs Telegram command via Telegraf (#321)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,6 +35,7 @@
         "p-limit": "^3.1.0",
         "rate-limit-redis": "^4.3.1",
         "redis": "^5.12.1",
+        "telegraf": "^4.16.3",
         "uuid": "^14.0.0",
         "web-push": "^3.6.7",
         "winston": "^3.19.0",
@@ -97,6 +98,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1422,6 +1424,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1443,6 +1446,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
       "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1848,6 +1852,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
       "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.0",
         "@opentelemetry/resources": "2.7.0",
@@ -1865,6 +1870,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1987,6 +1993,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2356,6 +2363,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@telegraf/types": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
+      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -2511,6 +2524,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2638,6 +2652,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2875,6 +2890,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3379,6 +3395,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3792,6 +3809,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4033,6 +4051,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4094,6 +4113,22 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -4108,6 +4143,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5048,6 +5089,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5397,6 +5439,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
       "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -6630,6 +6673,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7714,8 +7758,18 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -8045,6 +8099,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -8201,6 +8264,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8769,6 +8833,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-compare": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -8783,6 +8856,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sandwich-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
+      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -9373,6 +9455,48 @@
         "streamx": "^2.12.5"
       }
     },
+    "node_modules/telegraf": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
+      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
+      "license": "MIT",
+      "dependencies": {
+        "@telegraf/types": "^7.1.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.7.0",
+        "p-timeout": "^4.1.0",
+        "safe-compare": "^1.1.4",
+        "sandwich-stream": "^2.0.2"
+      },
+      "bin": {
+        "telegraf": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/telegraf/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -9524,6 +9648,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -9628,6 +9758,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9817,6 +9948,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10031,6 +10163,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10073,6 +10221,7 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,6 +49,7 @@
     "p-limit": "^3.1.0",
     "rate-limit-redis": "^4.3.1",
     "redis": "^5.12.1",
+    "telegraf": "^4.16.3",
     "uuid": "^14.0.0",
     "web-push": "^3.6.7",
     "winston": "^3.19.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -60,6 +60,8 @@ import { createAdminLimiter, RateLimiterFactory } from './middleware/rate-limit-
 import { scheduleAutoResume } from './jobs/auto-resume';
 import { errorHandler } from './middleware/errorHandler';
 import { swaggerSpec } from './swagger';
+import { telegramCommandService } from './services/telegram-command-service';
+import telegramRoutes from './routes/telegram';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -101,6 +103,11 @@ app.use(express.urlencoded({ extended: true }));
 // Request context and logging
 app.use(requestIdMiddleware);
 app.use(requestLoggerMiddleware);
+
+// Telegram webhook — mounted before CSRF because updates arrive from Telegram servers,
+// not a browser session, so there is no CSRF cookie/header to validate.
+telegramCommandService.init();
+app.use('/api/telegram', telegramRoutes);
 
 // CSRF protection (double-submit cookie) for all mutating API routes
 app.use('/api', csrfProtection);
@@ -303,6 +310,7 @@ const shutdown = () => {
   logger.info('Shutting down gracefully');
   schedulerService.stop();
   eventListener.stop();
+  telegramCommandService.stop();
   stopIndexer();
   server.close(() => {
     logger.info('Server closed');

--- a/backend/src/routes/telegram.ts
+++ b/backend/src/routes/telegram.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { telegramCommandService } from '../services/telegram-command-service';
+import logger from '../config/logger';
+
+const router = express.Router();
+
+/**
+ * POST /api/v1/telegram/webhook
+ *
+ * Receives incoming updates from the Telegram Bot API.
+ * Telegram must be configured to POST to this URL via `setWebhook`.
+ * The route is intentionally unauthenticated — Telegraf validates the
+ * secret_token header (TELEGRAM_WEBHOOK_SECRET) to confirm origin.
+ */
+router.post('/webhook', (req, res, next) => {
+  const bot = telegramCommandService.getBot();
+
+  if (!bot) {
+    logger.warn('[TelegramRoute] Webhook received but bot is not initialised');
+    res.sendStatus(503);
+    return;
+  }
+
+  // Telegraf's built-in webhook callback — handles parsing and dispatching
+  bot.handleUpdate(req.body, res).catch((err: unknown) => {
+    logger.error('[TelegramRoute] Error handling webhook update', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    next(err);
+  });
+});
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -8,6 +8,7 @@ import digestRoutes from '../digest';
 import pushNotificationsRoutes from '../push-notifications';
 import userRoutes from '../user';
 import integrationRoutes from '../integrations';
+import telegramRoutes from '../telegram';
 
 import { schedulerService } from '../../services/scheduler';
 import { reminderEngine } from '../../services/reminder-engine';
@@ -32,6 +33,9 @@ v1Router.use('/integrations', integrationRoutes);
 
 // Auth alias (some parts of frontend might use /api/v1/auth)
 v1Router.use('/auth', userRoutes);
+
+// Telegram Bot Webhook
+v1Router.use('/telegram', telegramRoutes);
 
 // Reminders Routes
 v1Router.get('/reminders/status', (req: express.Request, res: express.Response) => {

--- a/backend/src/services/telegram-command-service.ts
+++ b/backend/src/services/telegram-command-service.ts
@@ -1,0 +1,198 @@
+import { Telegraf, Context } from 'telegraf';
+import { randomUUID } from 'crypto';
+import logger from '../config/logger';
+import { supabase, trackDbRequest } from '../config/database';
+import { Subscription } from '../types/subscription';
+
+// ─── Monthly Cost Normalisation ───────────────────────────────────────────────
+
+const CYCLE_DIVISOR: Record<Subscription['billing_cycle'], number> = {
+  monthly: 1,
+  quarterly: 3,
+  yearly: 12,
+};
+
+function toMonthlyAmount(price: number, cycle: Subscription['billing_cycle']): number {
+  return price / CYCLE_DIVISOR[cycle];
+}
+
+// ─── Formatting ───────────────────────────────────────────────────────────────
+
+function formatSubsList(subs: Subscription[]): string {
+  const lines = subs.map((s) => {
+    const monthly = toMonthlyAmount(s.price, s.billing_cycle);
+    return `• *${escapeMarkdown(s.name)}* — ${s.currency} ${monthly.toFixed(2)}/mo`;
+  });
+
+  const total = subs.reduce(
+    (sum, s) => sum + toMonthlyAmount(s.price, s.billing_cycle),
+    0
+  );
+
+  // Group currencies — if mixed, show per-currency totals; otherwise show single total
+  const currencies = [...new Set(subs.map((s) => s.currency))];
+  let totalLine: string;
+
+  if (currencies.length === 1) {
+    totalLine = `\n💳 *Total:* ${currencies[0]} ${total.toFixed(2)}/mo`;
+  } else {
+    const perCurrency = currencies.map((cur) => {
+      const curTotal = subs
+        .filter((s) => s.currency === cur)
+        .reduce((sum, s) => sum + toMonthlyAmount(s.price, s.billing_cycle), 0);
+      return `${cur} ${curTotal.toFixed(2)}`;
+    });
+    totalLine = `\n💳 *Total:* ${perCurrency.join(' + ')}/mo`;
+  }
+
+  return (
+    `📋 *Your Active Subscriptions* (${subs.length})\n\n` +
+    lines.join('\n') +
+    totalLine
+  );
+}
+
+/** Escape characters that have special meaning in Telegram Markdown v1. */
+function escapeMarkdown(text: string): string {
+  return text.replace(/[_*[\]()~`>#+=|{}.!-]/g, '\\$&');
+}
+
+// ─── DB Helpers ───────────────────────────────────────────────────────────────
+
+async function getUserIdByChatId(chatId: string): Promise<string | null> {
+  const release = trackDbRequest();
+  try {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('telegram_chat_id', chatId)
+      .single();
+
+    if (error || !data?.id) return null;
+    return data.id as string;
+  } finally {
+    release();
+  }
+}
+
+async function getActiveSubscriptions(userId: string): Promise<Subscription[]> {
+  const release = trackDbRequest();
+  try {
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .select('id, name, price, currency, billing_cycle, status')
+      .eq('user_id', userId)
+      .eq('status', 'active')
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+    return (data as Subscription[]) ?? [];
+  } finally {
+    release();
+  }
+}
+
+// ─── Command Handler ──────────────────────────────────────────────────────────
+
+async function handleSubsCommand(ctx: Context): Promise<void> {
+  const requestId = randomUUID();
+  const chatId = String(ctx.chat?.id);
+
+  logger.info('[TelegramCommandService] /subs command received', { requestId, chatId });
+
+  let userId: string | null;
+  try {
+    userId = await getUserIdByChatId(chatId);
+  } catch (err) {
+    logger.error('[TelegramCommandService] DB error looking up user', {
+      requestId,
+      chatId,
+      error: (err as Error).message,
+    });
+    await ctx.reply('⚠️ Something went wrong. Please try again later.');
+    return;
+  }
+
+  if (!userId) {
+    await ctx.reply(
+      '🔗 Your Telegram account is not linked to a SYNCRO account.\n\n' +
+        'Log in to SYNCRO and connect Telegram in your notification settings.'
+    );
+    return;
+  }
+
+  let subs: Subscription[];
+  try {
+    subs = await getActiveSubscriptions(userId);
+  } catch (err) {
+    logger.error('[TelegramCommandService] DB error fetching subscriptions', {
+      requestId,
+      userId,
+      error: (err as Error).message,
+    });
+    await ctx.reply('⚠️ Could not load your subscriptions. Please try again later.');
+    return;
+  }
+
+  if (subs.length === 0) {
+    await ctx.reply('📭 You have no active subscriptions tracked in SYNCRO.');
+    return;
+  }
+
+  const message = formatSubsList(subs);
+  await ctx.reply(message, { parse_mode: 'Markdown' });
+
+  logger.info('[TelegramCommandService] /subs reply sent', {
+    requestId,
+    userId,
+    count: subs.length,
+  });
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class TelegramCommandService {
+  private bot: Telegraf | null = null;
+
+  /** Initialises the Telegraf bot and registers command handlers. */
+  init(): Telegraf | null {
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) {
+      logger.warn(
+        '[TelegramCommandService] TELEGRAM_BOT_TOKEN not set — command bot disabled'
+      );
+      return null;
+    }
+
+    this.bot = new Telegraf(token);
+    this.bot.command('subs', handleSubsCommand);
+
+    logger.info('[TelegramCommandService] Command handlers registered');
+    return this.bot;
+  }
+
+  /** Returns the underlying Telegraf instance (null if not initialised). */
+  getBot(): Telegraf | null {
+    return this.bot;
+  }
+
+  /**
+   * Starts long-polling. Use this only in development/environments without a
+   * public HTTPS URL for webhooks.
+   */
+  async startPolling(): Promise<void> {
+    if (!this.bot) return;
+    await this.bot.launch();
+    logger.info('[TelegramCommandService] Long-polling started');
+  }
+
+  /** Gracefully stops polling. */
+  stop(): void {
+    this.bot?.stop();
+  }
+}
+
+export const telegramCommandService = new TelegramCommandService();
+
+// Exported for unit tests
+export { handleSubsCommand, formatSubsList, toMonthlyAmount, getUserIdByChatId, getActiveSubscriptions };

--- a/backend/tests/telegram-command-service.test.ts
+++ b/backend/tests/telegram-command-service.test.ts
@@ -1,0 +1,234 @@
+import { formatSubsList, toMonthlyAmount } from '../src/services/telegram-command-service';
+import { Subscription } from '../src/types/subscription';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+jest.mock('../src/config/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+var mockSingle = jest.fn();
+var mockOrder = jest.fn(() => ({ single: mockSingle }));
+var mockEqStatus = jest.fn(() => ({ order: mockOrder }));
+var mockEqUser = jest.fn(() => ({ eq: mockEqStatus, single: mockSingle, order: mockOrder }));
+var mockSelect = jest.fn(() => ({ eq: mockEqUser }));
+var mockFrom = jest.fn(() => ({ select: mockSelect }));
+var mockTrackDbRequest = jest.fn(() => jest.fn());
+
+jest.mock('../src/config/database', () => ({
+  get supabase() { return { from: mockFrom }; },
+  get trackDbRequest() { return mockTrackDbRequest; },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSub(overrides: Partial<Subscription> = {}): Subscription {
+  return {
+    id: 'sub-1',
+    user_id: 'user-1',
+    email_account_id: null,
+    merchant_id: null,
+    name: 'Netflix',
+    provider: 'Netflix',
+    price: 15,
+    currency: 'USD',
+    billing_cycle: 'monthly',
+    status: 'active',
+    next_billing_date: null,
+    category: null,
+    logo_url: null,
+    website_url: null,
+    renewal_url: null,
+    notes: null,
+    visibility: 'private',
+    tags: [],
+    expired_at: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    paused_at: null,
+    resume_at: null,
+    pause_reason: null,
+    last_interaction_at: null,
+    ...overrides,
+  };
+}
+
+// ─── toMonthlyAmount ─────────────────────────────────────────────────────────
+
+describe('toMonthlyAmount', () => {
+  it('returns the price unchanged for monthly billing', () => {
+    expect(toMonthlyAmount(15, 'monthly')).toBe(15);
+  });
+
+  it('divides by 12 for yearly billing', () => {
+    expect(toMonthlyAmount(120, 'yearly')).toBe(10);
+  });
+
+  it('divides by 3 for quarterly billing', () => {
+    expect(toMonthlyAmount(30, 'quarterly')).toBe(10);
+  });
+});
+
+// ─── formatSubsList ──────────────────────────────────────────────────────────
+
+describe('formatSubsList', () => {
+  it('includes each subscription name and monthly cost', () => {
+    const subs = [
+      makeSub({ name: 'Netflix', price: 15, billing_cycle: 'monthly', currency: 'USD' }),
+      makeSub({ id: 'sub-2', name: 'Spotify', price: 9.99, billing_cycle: 'monthly', currency: 'USD' }),
+    ];
+
+    const output = formatSubsList(subs);
+
+    expect(output).toContain('Netflix');
+    expect(output).toContain('Spotify');
+    expect(output).toContain('15.00');
+    expect(output).toContain('9.99');
+  });
+
+  it('normalises yearly price to monthly equivalent', () => {
+    const subs = [makeSub({ name: 'iCloud', price: 120, billing_cycle: 'yearly', currency: 'USD' })];
+    const output = formatSubsList(subs);
+    expect(output).toContain('10.00');
+  });
+
+  it('normalises quarterly price to monthly equivalent', () => {
+    const subs = [makeSub({ name: 'Adobe', price: 60, billing_cycle: 'quarterly', currency: 'USD' })];
+    const output = formatSubsList(subs);
+    expect(output).toContain('20.00');
+  });
+
+  it('shows total monthly spend for single currency', () => {
+    const subs = [
+      makeSub({ price: 10, billing_cycle: 'monthly', currency: 'USD' }),
+      makeSub({ id: 'sub-2', price: 20, billing_cycle: 'monthly', currency: 'USD' }),
+    ];
+    const output = formatSubsList(subs);
+    expect(output).toContain('30.00');
+    expect(output).toContain('Total');
+  });
+
+  it('shows per-currency totals when subscriptions use different currencies', () => {
+    const subs = [
+      makeSub({ price: 10, billing_cycle: 'monthly', currency: 'USD' }),
+      makeSub({ id: 'sub-2', price: 8, billing_cycle: 'monthly', currency: 'EUR' }),
+    ];
+    const output = formatSubsList(subs);
+    expect(output).toContain('USD 10.00');
+    expect(output).toContain('EUR 8.00');
+  });
+
+  it('includes subscription count in the header', () => {
+    const subs = [
+      makeSub(),
+      makeSub({ id: 'sub-2', name: 'Spotify' }),
+    ];
+    const output = formatSubsList(subs);
+    expect(output).toContain('(2)');
+  });
+});
+
+// ─── Command handler integration (ctx mocking) ───────────────────────────────
+
+describe('/subs command handler', () => {
+  // Dynamically import so mocks are applied before module load
+  let handleSubsCommand: typeof import('../src/services/telegram-command-service').handleSubsCommand;
+
+  beforeAll(async () => {
+    const mod = await import('../src/services/telegram-command-service');
+    handleSubsCommand = mod.handleSubsCommand;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTrackDbRequest.mockReturnValue(jest.fn());
+  });
+
+  function makeCtx(chatId: number | undefined, replyFn = jest.fn()): any {
+    return {
+      chat: chatId !== undefined ? { id: chatId } : undefined,
+      reply: replyFn,
+    };
+  }
+
+  it('replies with not-linked message when chat_id has no matching user', async () => {
+    // getUserIdByChatId returns null
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEqUser });
+    mockEqUser.mockReturnValue({ single: mockSingle });
+    mockSingle.mockResolvedValue({ data: null, error: null });
+
+    const reply = jest.fn();
+    await handleSubsCommand(makeCtx(12345, reply));
+
+    expect(reply).toHaveBeenCalledWith(expect.stringContaining('not linked'));
+  });
+
+  it('replies with empty message when user has no active subscriptions', async () => {
+    // First call: getUserIdByChatId → returns user
+    mockSingle.mockResolvedValueOnce({ data: { id: 'user-1' }, error: null });
+
+    // Second call: getActiveSubscriptions → returns empty array
+    const mockOrderResult = jest.fn().mockResolvedValue({ data: [], error: null });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: mockSingle }) }) };
+      return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ order: mockOrderResult }) }) }) };
+    });
+
+    const reply = jest.fn();
+    await handleSubsCommand(makeCtx(12345, reply));
+
+    expect(reply).toHaveBeenCalledWith(expect.stringContaining('no active subscriptions'));
+  });
+
+  it('replies with formatted list when user has active subscriptions', async () => {
+    const activeSub = makeSub({ name: 'Netflix', price: 15, billing_cycle: 'monthly' });
+
+    // Chain: profiles lookup → subscriptions lookup
+    let profileCalled = false;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'user-1' }, error: null }) }),
+          }),
+        };
+      }
+      // subscriptions table
+      return {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              order: jest.fn().mockResolvedValue({ data: [activeSub], error: null }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    const reply = jest.fn();
+    await handleSubsCommand(makeCtx(12345, reply));
+
+    expect(reply).toHaveBeenCalledWith(
+      expect.stringContaining('Netflix'),
+      expect.objectContaining({ parse_mode: 'Markdown' })
+    );
+  });
+
+  it('replies with error message when DB lookup throws', async () => {
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockRejectedValue(new Error('DB error')),
+        }),
+      }),
+    }));
+
+    const reply = jest.fn();
+    await handleSubsCommand(makeCtx(12345, reply));
+
+    expect(reply).toHaveBeenCalledWith(expect.stringContaining('went wrong'));
+  });
+});


### PR DESCRIPTION
closes #321 

Registers a /subs command handler using Telegraf. When a user types /subs the bot looks up their SYNCRO account by telegram_chat_id, fetches all active subscriptions, and replies with a formatted list and total monthly spend (yearly/quarterly costs normalised to a monthly figure).

- New TelegramCommandService wraps Telegraf and registers command handlers
- Webhook route at POST /api/telegram/webhook (pre-CSRF, machine-to-machine)
- Mixed-currency totals shown per currency when subscriptions differ
- 13 unit tests covering formatting, normalisation, and command flow


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
