### PR TITLE
chore: standardize on npm as sole package manager (#480)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,7 @@ jobs:
           # Matches sdk/.tool-versions (nodejs 23.4.0)
           node-version: "23.4.0"
           cache: "npm"
-          cache-dependency-path: |
-            sdk/package-lock.json
-            sdk/package.json
+          cache-dependency-path: sdk/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -176,25 +174,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: client/pnpm-lock.yaml
+          cache: "npm"
+          cache-dependency-path: client/package-lock.json
 
       - name: Install client dependencies
         working-directory: client
-        run: pnpm install --no-frozen-lockfile
+        run: npm ci
 
       - name: Run client unit tests
         working-directory: client
-        run: pnpm test
+        run: npm test
 
   test-backend:
     name: Test Backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,21 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: client/pnpm-lock.yaml
+          cache: "npm"
+          cache-dependency-path: client/package-lock.json
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: npm ci
 
       - name: Run client unit tests
-        run: pnpm test
+        run: npm test
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# This repository uses npm as its sole package manager.
+# Do not commit yarn.lock or pnpm-lock.yaml files.
+# The authoritative lockfiles are:
+#   backend/package-lock.json
+#   client/package-lock.json
+#   sdk/package-lock.json
+engine-strict=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Thank you for your interest in contributing! This guide will help you set up the
 ---
 ## Development Setup
 - Node.js >= 20
-- npm or yarn
+- npm (bundled with Node.js — do not use yarn or pnpm)
 - Supabase CLI (for database)
 - (Optional) Stellar CLI for contract interactions
 ---

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "description": "backend for synchro",
   "license": "ISC",
   "author": "",
+  "packageManager": "npm@10.9.2",
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {

--- a/client/README.md
+++ b/client/README.md
@@ -86,16 +86,12 @@ client/
 
 ### Prerequisites
 - Node.js 20+
-- npm, yarn, or npm
+- npm (bundled with Node.js)
 
 ### Installation
 
 ```bash
 cd client
-npm install
-# or
-yarn install
-# or
 npm install
 ```
 

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "my-v0-project",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.2",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "npm@10.9.2",
   "devDependencies": {
     "@types/node": "^25.6.0"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@syncro/sdk",
   "version": "1.1.0",
   "description": "Official SDK for the SYNCRO Subscription Management Platform",
+  "packageManager": "npm@10.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
closes #480 

ci.yml and test.yml referenced pnpm for the client test job (pnpm/action-setup, cache: pnpm, pnpm-lock.yaml) but no pnpm lockfile exists — those jobs were broken. All CI jobs now use npm ci and cache against the existing package-lock.json files.

Changes:
- .github/workflows/ci.yml: replace pnpm setup/install/test with npm ci for the test-client job; also drop package.json from the SDK cache-dependency-path (only lockfiles belong there)
- .github/workflows/test.yml: same fix for the test-client job
- package.json (root, backend, client, sdk): add "packageManager": "npm@10.9.2" so corepack and tooling can enforce the chosen manager
- .npmrc: document the single-manager policy and authoritative lockfile paths
- client/README.md: remove yarn and duplicate npm from install options
- CONTRIBUTING.md: clarify npm-only requirement in dev-setup prerequisites


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
