### PR TITLE
feat(dashboard): surface cancellation guides with click-through analy…

### DIFF
--- a/client/components/modals/__tests__/cancellation-guide-modal.test.tsx
+++ b/client/components/modals/__tests__/cancellation-guide-modal.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import CancellationGuideModal from '../cancellation-guide-modal'
+import { mockCancellationGuide } from '@/lib/test-utils'
+
+// Mock supabase cancellation-guides lib
+vi.mock('@/lib/supabase/cancellation-guides', () => ({
+  fetchCancellationGuide: vi.fn(),
+  reportDifficulty: vi.fn(),
+  markAsCancelled: vi.fn(),
+}))
+
+// Mock audit-log
+vi.mock('@/lib/audit-log', () => ({
+  logCancellationGuideAction: vi.fn(),
+}))
+
+// Mock supabase browser client
+vi.mock('@/lib/supabase/browser-client', () => ({
+  getSupabaseBrowserClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-123' } } }),
+    },
+  })),
+}))
+
+import { fetchCancellationGuide, markAsCancelled } from '@/lib/supabase/cancellation-guides'
+import { logCancellationGuideAction } from '@/lib/audit-log'
+
+const mockSubscription = { id: '1', name: 'Netflix', icon: '📺', renewal_url: 'https://netflix.com' }
+
+const defaultProps = {
+  subscription: mockSubscription,
+  onClose: vi.fn(),
+  onCancelled: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CancellationGuideModal', () => {
+  describe('guide loaded state', () => {
+    it('logs guide_opened when guide loads successfully', async () => {
+      const guide = mockCancellationGuide({ service_name: 'Netflix', steps: ['Step 1', 'Step 2'] })
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(guide)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(logCancellationGuideAction).toHaveBeenCalledWith(
+          'user-123',
+          'guide_opened',
+          'Netflix',
+        )
+      })
+    })
+
+    it('logs direct_url_clicked when the cancellation page link is clicked', async () => {
+      const guide = mockCancellationGuide({
+        service_name: 'Netflix',
+        steps: ['Step 1'],
+        direct_url: 'https://netflix.com/cancel',
+      })
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(guide)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      const link = await screen.findByRole('link', { name: /go to cancellation page/i })
+      await userEvent.click(link)
+
+      await waitFor(() => {
+        expect(logCancellationGuideAction).toHaveBeenCalledWith(
+          'user-123',
+          'direct_url_clicked',
+          'Netflix',
+          { url: 'https://netflix.com/cancel' },
+        )
+      })
+    })
+
+    it('renders difficulty badge and estimated time', async () => {
+      const guide = mockCancellationGuide({ service_name: 'Netflix', difficulty: 'hard', estimated_time: '10 minutes', steps: ['Step 1'] })
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(guide)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      expect(await screen.findByText(/hard difficulty/i)).toBeInTheDocument()
+      expect(screen.getByText('10 minutes')).toBeInTheDocument()
+    })
+
+    it('renders warning note when present', async () => {
+      const guide = mockCancellationGuide({ service_name: 'Netflix', steps: ['Step 1'], warning_note: 'Watch out for fees' })
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(guide)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      expect(await screen.findByText('Watch out for fees')).toBeInTheDocument()
+    })
+  })
+
+  describe('fallback state (no guide)', () => {
+    it('shows fallback UI when no guide is available', async () => {
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(null)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      expect(await screen.findByText(/no guide available/i)).toBeInTheDocument()
+    })
+
+    it('does not log guide_opened when guide is null', async () => {
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(null)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      await screen.findByText(/no guide available/i)
+      expect(logCancellationGuideAction).not.toHaveBeenCalled()
+    })
+
+    it('shows account settings link in fallback state', async () => {
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(null)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      expect(await screen.findByRole('link', { name: /go to account settings/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('mark as cancelled', () => {
+    it('calls markAsCancelled and onCancelled when all steps are completed', async () => {
+      const guide = mockCancellationGuide({ service_name: 'Netflix', steps: ['Step 1'] })
+      vi.mocked(fetchCancellationGuide).mockResolvedValue(guide)
+      vi.mocked(markAsCancelled).mockResolvedValue(undefined)
+
+      render(<CancellationGuideModal {...defaultProps} />)
+
+      // Complete the single step
+      const step = await screen.findByText('Step 1')
+      await userEvent.click(step)
+
+      const markBtn = screen.getByRole('button', { name: /mark as cancelled/i })
+      await userEvent.click(markBtn)
+
+      await waitFor(() => {
+        expect(markAsCancelled).toHaveBeenCalledWith('1')
+        expect(defaultProps.onCancelled).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/client/components/modals/cancellation-guide-modal.tsx
+++ b/client/components/modals/cancellation-guide-modal.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react"
 import { X, ExternalLink, CheckCircle2, AlertTriangle, Clock, MessageSquare, Phone, Info } from "lucide-react"
 import { fetchCancellationGuide, reportDifficulty, markAsCancelled, type CancellationGuide } from "@/lib/supabase/cancellation-guides"
+import { logCancellationGuideAction } from "@/lib/audit-log"
+import { getSupabaseBrowserClient } from "@/lib/supabase/browser-client"
 
 interface CancellationGuideModalProps {
   subscription: any
@@ -31,6 +33,11 @@ export default function CancellationGuideModal({
         setGuide(data)
         if (data) {
           setCompletedSteps(new Array(data.steps.length).fill(false))
+          const supabase = getSupabaseBrowserClient()
+          const { data: { user } } = await supabase.auth.getUser()
+          if (user) {
+            logCancellationGuideAction(user.id, "guide_opened", subscription.name)
+          }
         }
       } catch (error) {
         console.error("Failed to load cancellation guide:", error)
@@ -177,6 +184,13 @@ export default function CancellationGuideModal({
                   href={guide.direct_url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={async () => {
+                    const supabase = getSupabaseBrowserClient()
+                    const { data: { user } } = await supabase.auth.getUser()
+                    if (user) {
+                      logCancellationGuideAction(user.id, "direct_url_clicked", subscription.name, { url: guide.direct_url })
+                    }
+                  }}
                   className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-[#1E2A35] text-white rounded-lg font-semibold hover:bg-[#2D3748] transition-colors"
                 >
                   Go to Cancellation Page

--- a/client/components/pages/subscriptions.tsx
+++ b/client/components/pages/subscriptions.tsx
@@ -538,6 +538,8 @@ export default function SubscriptionsPage({
                     darkMode={darkMode}
                     isDuplicate={duplicates.some((dup: any) => dup.subscriptions.some((s: any) => s.id === sub.id))}
                     unusedInfo={unusedSubscriptions.find((unused: any) => unused.id === sub.id)}
+                    onCancel={(s) => setSelectedSubForCancel(s)}
+                    guide={guides.find((g) => g.service_name.toLowerCase() === sub.name.toLowerCase())}
                     onPause={onPause}
                     onResume={onResume}
                     onCancelTrial={onCancelTrial}

--- a/client/lib/audit-log.ts
+++ b/client/lib/audit-log.ts
@@ -318,3 +318,18 @@ export function logTeamAction(
     details,
   })
 }
+
+export function logCancellationGuideAction(
+  userId: string,
+  action: "guide_opened" | "direct_url_clicked",
+  serviceName: string,
+  details?: Record<string, any>,
+): void {
+  auditLogger.log({
+    userId,
+    action,
+    resource: "cancellation_guide",
+    resourceId: serviceName,
+    details,
+  })
+}


### PR DESCRIPTION
…tics (#614)

- Add logCancellationGuideAction() helper to audit-log.ts Tracks 'guide_opened' and 'direct_url_clicked' events under resource 'cancellation_guide' via the existing AuditLogger pipeline.

- Wire analytics into CancellationGuideModal Fires guide_opened when a guide loads successfully; fires direct_url_clicked (with the target URL) when the user clicks 'Go to Cancellation Page'.

- Fix VirtualizedList path in SubscriptionsPage The >100-item virtualized render path was missing guide and onCancel props, so the difficulty badge and cancel flow were silently absent for large subscription lists.

- Add tests for cancellation guide surfaces Covers: guide_opened / direct_url_clicked analytics, fallback UI when no guide exists, and the mark-as-cancelled happy path.

Closes #614 

## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
