### PR TITLE
 Replace generic auth throws in Next API routes with typed HTTP respo…

### DIFF
--- a/client/app/api/analytics/route.ts
+++ b/client/app/api/analytics/route.ts
@@ -1,12 +1,12 @@
 import { type NextRequest } from "next/server"
 import { HttpStatus } from "@/lib/api/types"
 import { createClient } from "@/lib/supabase/server"
-import { createApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
+import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
 
 export const GET = createApiRoute(
   async (request: NextRequest, context, user) => {
     if (!user) {
-      throw new Error("User not authenticated")
+      throw ApiErrors.unauthorized("User not authenticated")
     }
 
     const supabase = await createClient()
@@ -18,7 +18,7 @@ export const GET = createApiRoute(
       .eq("status", "active")
 
     if (error) {
-      throw new Error(`Failed to fetch analytics: ${error.message}`)
+      throw ApiErrors.internalError(`Failed to fetch analytics: ${error.message}`)
     }
 
     const totalSpend =

--- a/client/app/api/subscriptions/[id]/pause/route.ts
+++ b/client/app/api/subscriptions/[id]/pause/route.ts
@@ -18,7 +18,7 @@ export async function POST(
 
   return createApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) throw new Error("User not authenticated")
+      if (!user) throw ApiErrors.unauthorized("User not authenticated")
       if (!id) throw ApiErrors.notFound("Subscription")
 
       const body = await validateRequestBody(req, pauseSchema)
@@ -58,7 +58,7 @@ export async function POST(
         .select()
         .single()
 
-      if (error) throw new Error(`Failed to pause subscription: ${error.message}`)
+      if (error) throw ApiErrors.internalError(`Failed to pause subscription: ${error.message}`)
 
       return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
     },

--- a/client/app/api/subscriptions/[id]/resume/route.ts
+++ b/client/app/api/subscriptions/[id]/resume/route.ts
@@ -12,7 +12,7 @@ export async function POST(
 
   return createApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) throw new Error("User not authenticated")
+      if (!user) throw ApiErrors.unauthorized("User not authenticated")
       if (!id) throw ApiErrors.notFound("Subscription")
 
       const supabase = await createClient()
@@ -43,7 +43,7 @@ export async function POST(
         .select()
         .single()
 
-      if (error) throw new Error(`Failed to resume subscription: ${error.message}`)
+      if (error) throw ApiErrors.internalError(`Failed to resume subscription: ${error.message}`)
 
       return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
     },

--- a/client/app/api/subscriptions/[id]/route.ts
+++ b/client/app/api/subscriptions/[id]/route.ts
@@ -28,7 +28,7 @@ export async function DELETE(
   return createApiRoute(
     async (req: NextRequest, context, user) => {
       if (!user) {
-        throw new Error("User not authenticated")
+        throw ApiErrors.unauthorized("User not authenticated")
       }
 
       if (!id) {
@@ -58,7 +58,7 @@ export async function DELETE(
         .eq("user_id", user.id)
 
       if (error) {
-        throw new Error(`Failed to delete subscription: ${error.message}`)
+        throw ApiErrors.internalError(`Failed to delete subscription: ${error.message}`)
       }
 
       return createSuccessResponse(
@@ -83,7 +83,7 @@ export async function PATCH(
   return createApiRoute(
     async (req: NextRequest, context, user) => {
       if (!user) {
-        throw new Error("User not authenticated")
+        throw ApiErrors.unauthorized("User not authenticated")
       }
 
       if (!id) {
@@ -127,7 +127,7 @@ export async function PATCH(
         .single()
 
       if (error) {
-        throw new Error(`Failed to update subscription: ${error.message}`)
+        throw ApiErrors.internalError(`Failed to update subscription: ${error.message}`)
       }
 
       return createSuccessResponse(

--- a/client/app/api/subscriptions/__tests__/route.test.ts
+++ b/client/app/api/subscriptions/__tests__/route.test.ts
@@ -53,6 +53,18 @@ describe("Subscriptions API Route", () => {
       expect(supabase.eq).toHaveBeenCalledWith("user_id", "user_123")
     })
 
+    it("should return 401 for unauthenticated requests", async () => {
+      vi.mocked(requireAuth).mockResolvedValue(null as any)
+
+      const request = new NextRequest("http://localhost/api/subscriptions")
+      const response = await GET(request)
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body.success).toBe(false)
+      expect(body.error.code).toBe("UNAUTHORIZED")
+    })
+
     it("should handle database errors", async () => {
       supabase.from.mockReturnThis()
       supabase.select.mockReturnThis()
@@ -106,6 +118,29 @@ describe("Subscriptions API Route", () => {
           name: "Disney+",
         })
       )
+    })
+
+    it("should return 401 for unauthenticated requests", async () => {
+      vi.mocked(requireAuth).mockResolvedValue(null as any)
+
+      const newSub = {
+        name: "Disney+",
+        category: "Entertainment",
+        price: 7.99,
+        status: "active",
+      }
+
+      const request = new NextRequest("http://localhost/api/subscriptions", {
+        method: "POST",
+        body: JSON.stringify(newSub),
+      })
+
+      const response = await POST(request)
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body.success).toBe(false)
+      expect(body.error.code).toBe("UNAUTHORIZED")
     })
 
     it("should validate the request body", async () => {

--- a/client/app/api/subscriptions/import/route.ts
+++ b/client/app/api/subscriptions/import/route.ts
@@ -9,7 +9,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { z } from "zod"
-import { RateLimiters } from "@/lib/api/index"
+import { RateLimiters, ApiErrors } from "@/lib/api/index"
 
 // ─── Validation (mirrors backend csv-import-service) ─────────────────────
 
@@ -205,7 +205,7 @@ export async function POST(request: NextRequest) {
 
     if (toInsert.length > 0) {
       const { error } = await supabase.from("subscriptions").insert(toInsert)
-      if (error) throw new Error(`Import failed: ${error.message}`)
+      if (error) throw ApiErrors.internalError(`Import failed: ${error.message}`)
     }
 
     const result = {

--- a/client/app/api/subscriptions/route.ts
+++ b/client/app/api/subscriptions/route.ts
@@ -23,7 +23,7 @@ const getSubscriptionsSchema = CommonSchemas.pagination.extend({
 export const GET = createApiRoute(
   async (request: NextRequest, context, user) => {
     if (!user) {
-      throw new Error("User not authenticated")
+      throw ApiErrors.unauthorized("User not authenticated")
     }
 
     // Validate query parameters
@@ -59,7 +59,7 @@ export const GET = createApiRoute(
     const { data, error, count } = await queryBuilder
 
     if (error) {
-      throw new Error(`Failed to fetch subscriptions: ${error.message}`)
+      throw ApiErrors.internalError(`Failed to fetch subscriptions: ${error.message}`)
     }
 
     const total = count || 0
@@ -90,7 +90,7 @@ export const GET = createApiRoute(
 export const POST = createApiRoute(
   async (request: NextRequest, context, user) => {
     if (!user) {
-      throw new Error("User not authenticated")
+      throw ApiErrors.unauthorized("User not authenticated")
     }
 
     // Validate request body
@@ -112,7 +112,7 @@ export const POST = createApiRoute(
       .single()
 
     if (error) {
-      throw new Error(`Failed to create subscription: ${error.message}`)
+      throw ApiErrors.internalError(`Failed to create subscription: ${error.message}`)
     }
 
     return createSuccessResponse(

--- a/client/app/api/tags/[id]/route.ts
+++ b/client/app/api/tags/[id]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
+import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { deleteTag } from "@/lib/supabase/tags"
 
@@ -11,7 +11,7 @@ export async function DELETE(
 
   return createApiRoute(
     async (_req, context, user) => {
-      if (!user) throw new Error("User not authenticated")
+      if (!user) throw ApiErrors.unauthorized("User not authenticated")
 
       await deleteTag(id, user.id)
       return createSuccessResponse({ deleted: true }, HttpStatus.OK, context.requestId)

--- a/client/app/api/tags/route.ts
+++ b/client/app/api/tags/route.ts
@@ -14,7 +14,7 @@ const createTagSchema = z.object({
 
 export const GET = createApiRoute(
   async (_req, context, user) => {
-    if (!user) throw new Error("User not authenticated")
+    if (!user) throw ApiErrors.unauthorized("User not authenticated")
 
     const tags = await fetchUserTags(user.id)
     return createSuccessResponse({ tags }, HttpStatus.OK, context.requestId)
@@ -24,7 +24,7 @@ export const GET = createApiRoute(
 
 export const POST = createApiRoute(
   async (request, context, user) => {
-    if (!user) throw new Error("User not authenticated")
+    if (!user) throw ApiErrors.unauthorized("User not authenticated")
 
     const { name, color } = await validateRequestBody(request as NextRequest, createTagSchema)
     const tag = await createTag(user.id, name, color)

--- a/client/app/api/webhooks/stripe/route.ts
+++ b/client/app/api/webhooks/stripe/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import Stripe from "stripe"
 import { createClient } from "@/lib/supabase/server"
 import { getStripeInstance } from "@/lib/stripe-config"
+import { ApiErrors } from "@/lib/api/index"
 
 export async function POST(request: NextRequest) {
   const stripe = getStripeInstance()
@@ -16,7 +17,7 @@ export async function POST(request: NextRequest) {
 
   try {
     if (!signature || !webhookSecret) {
-      throw new Error("Missing stripe-signature or webhook secret")
+      throw ApiErrors.validationError("Missing stripe-signature or webhook secret")
     }
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret)
   } catch (err) {

--- a/client/lib/api/README.md
+++ b/client/lib/api/README.md
@@ -232,6 +232,8 @@ All API responses follow a standard format:
 4. **Check ownership** for resource operations
 5. **Use typed responses** with TypeScript
 6. **Handle errors gracefully** - let the infrastructure handle formatting
+7. **Never throw generic `Error` objects** - always use `ApiErrors` for proper HTTP status codes and to avoid exposing stack traces
+8. **Use `ApiErrors.unauthorized()` for auth failures** instead of generic errors
 
 ## Testing
 


### PR DESCRIPTION
I've completed the task of replacing generic auth throws in Next API routes with typed HTTP responses. Here's a summary of the changes:

Files Modified
API Routes (replaced generic throw new Error() with ApiErrors):
client/app/api/subscriptions/route.ts - Auth and internal errors
client/app/api/tags/route.ts - Auth errors
c:/Users/HP/Desktop/SYNCRO/client/app/api/subscriptions/[id]/route.ts - Auth and internal errors
c:/Users/HP/Desktop/SYNCRO/client/app/api/subscriptions/[id]/pause/route.ts - Auth and internal errors
c:/Users/HP/Desktop/SYNCRO/client/app/api/subscriptions/[id]/resume/route.ts - Auth and internal errors
client/app/api/analytics/route.ts - Auth and internal errors
c:/Users/HP/Desktop/SYNCRO/client/app/api/tags/[id]/route.ts - Auth errors
client/app/api/subscriptions/import/route.ts - Internal errors
client/app/api/webhooks/stripe/route.ts - Validation errors
Tests:
client/app/api/subscriptions/__tests__/route.test.ts - Added unauthorized test cases for GET and POST endpoints
Documentation:
client/lib/api/README.md - Added security best practices about avoiding generic Error throws
Key Changes
Replaced throw new Error("User not authenticated") with throw ApiErrors.unauthorized("User not authenticated")
Replaced throw new Error("Failed to ...") with throw ApiErrors.internalError("Failed to ...")
Replaced throw new Error("Missing ...") with throw ApiErrors.validationError("Missing ...")
This ensures:

Consistent structured error responses with proper HTTP status codes (401 for unauthorized, 500 for internal errors, 400 for validation errors)
Stack traces are not exposed to clients
Error responses follow the standardized API error format with error codes

close #619 