### PR TITLE
feat(backend): wire Telegram notification delivery (#477)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,8 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 
 # Telegram Bot
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+# Secret token sent by Telegram in X-Telegram-Bot-Api-Secret-Token header (set via setWebhook)
+TELEGRAM_WEBHOOK_SECRET=your_telegram_webhook_secret
 
 # Encryption (for API keys)
 ENCRYPTION_KEY=your_32_byte_encryption_key

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -64,6 +64,7 @@ const envSchema = z.object({
 
   // Telegram (optional)
   TELEGRAM_BOT_TOKEN: z.string().optional(),
+  TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
 
   // Sentry (optional)
   SENTRY_DSN: z.string().optional(),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,6 +53,8 @@ import { adminAuth } from './middleware/admin';
 import { createAdminLimiter, RateLimiterFactory } from './middleware/rate-limit-factory';
 import { scheduleAutoResume } from './jobs/auto-resume';
 import giftCardLedgerRoutes from './routes/gift-card-ledger';
+import telegramWebhookRoutes from './routes/telegram-webhook';
+import { telegramCommandService } from './services/telegram-command-service';
 import { errorHandler } from './middleware/errorHandler';
 import { swaggerSpec } from './swagger';
 
@@ -128,6 +130,7 @@ app.use('/api/mfa', mfaRoutes);
 app.use('/api/notifications/push', pushNotificationRoutes);
 app.use('/api/exchange-rates', createExchangeRatesRouter(exchangeRateService));
 app.use('/api/gift-card-ledger', giftCardLedgerRoutes);
+app.use('/api/telegram', telegramWebhookRoutes);
 
 app.get('/api/reminders/status', (req, res) => {
   const status = schedulerService.getStatus();
@@ -274,12 +277,18 @@ const server = app.listen(PORT, async () => {
   }
 
   scheduleAutoResume();
+
+  telegramCommandService.init();
+  if (process.env.TELEGRAM_BOT_TOKEN && !process.env.TELEGRAM_WEBHOOK_SECRET) {
+    logger.warn('[Telegram] TELEGRAM_WEBHOOK_SECRET not set — webhook origin is unverified');
+  }
 });
 
 // Graceful shutdown
 const shutdown = () => {
   logger.info('Shutting down gracefully');
   schedulerService.stop();
+  telegramCommandService.stop();
   eventListener.stop();
   server.close(() => {
     logger.info('Server closed');

--- a/backend/src/routes/telegram-webhook.ts
+++ b/backend/src/routes/telegram-webhook.ts
@@ -1,9 +1,31 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { supabase } from '../config/database';
 import logger from '../config/logger';
 import { telegramBotService } from '../services/telegram-bot-service';
 
 const router = Router();
+
+/**
+ * Validate the X-Telegram-Bot-Api-Secret-Token header.
+ * Rejects requests that don't carry the configured secret.
+ * If TELEGRAM_WEBHOOK_SECRET is not set the check is skipped (dev/test).
+ */
+function validateWebhookSecret(req: Request, res: Response, next: NextFunction): void {
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (!secret) {
+    next();
+    return;
+  }
+  const header = req.headers['x-telegram-bot-api-secret-token'];
+  if (header !== secret) {
+    logger.warn('[TelegramWebhook] Invalid or missing secret token', {
+      ip: req.ip,
+    });
+    res.sendStatus(403);
+    return;
+  }
+  next();
+}
 
 interface TelegramUpdate {
     update_id: number;
@@ -34,7 +56,7 @@ interface TelegramUpdate {
  * Webhook endpoint for Telegram bot updates
  * Handles /start command to connect user accounts
  */
-router.post('/webhook', async (req: Request, res: Response) => {
+router.post('/webhook', validateWebhookSecret, async (req: Request, res: Response) => {
     try {
         const update: TelegramUpdate = req.body;
 

--- a/backend/tests/telegram-webhook-secret.test.ts
+++ b/backend/tests/telegram-webhook-secret.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for Telegram webhook secret-token validation middleware (#477)
+ */
+
+import request from 'supertest';
+import express, { type Express } from 'express';
+
+jest.mock('../src/config/database', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({ single: async () => ({ data: null, error: { code: 'PGRST116' } }) }),
+      }),
+      insert: async () => ({ error: null }),
+      update: () => ({ eq: () => ({ error: null }) }),
+      delete: () => ({ eq: async () => ({ error: null }) }),
+    }),
+  },
+  trackDbRequest: () => () => {},
+}));
+
+jest.mock('../src/services/telegram-bot-service', () => ({
+  telegramBotService: {
+    isConfigured: () => false,
+    sendSimpleMessage: jest.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+jest.mock('../src/config/logger', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+// Import after mocks are set up
+import telegramWebhookRoutes from '../src/routes/telegram-webhook';
+
+const minimalUpdate = { update_id: 1 };
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/telegram', telegramWebhookRoutes);
+  return app;
+}
+
+const app = buildApp();
+
+describe('Telegram webhook secret validation', () => {
+  const originalSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    } else {
+      process.env.TELEGRAM_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it('returns 403 when secret is configured and header is missing', async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'my-secret';
+    const res = await request(app).post('/api/telegram/webhook').send(minimalUpdate);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when secret is configured and header is wrong', async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'my-secret';
+    const res = await request(app)
+      .post('/api/telegram/webhook')
+      .set('x-telegram-bot-api-secret-token', 'wrong-secret')
+      .send(minimalUpdate);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 when secret is configured and header matches', async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'my-secret';
+    const res = await request(app)
+      .post('/api/telegram/webhook')
+      .set('x-telegram-bot-api-secret-token', 'my-secret')
+      .send(minimalUpdate);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 when no secret is configured (dev mode)', async () => {
+    delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    const res = await request(app).post('/api/telegram/webhook').send(minimalUpdate);
+    expect(res.status).toBe(200);
+  });
+
+  it('GET /webhook health check is always accessible', async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'my-secret';
+    const res = await request(app).get('/api/telegram/webhook');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
The TelegramBotService and reminder-engine integration were already implemented but the service was never reachable — the webhook route was unmounted, the command service was never initialised, and the webhook had no origin validation.

Changes:
- backend/src/config/env.ts Add TELEGRAM_WEBHOOK_SECRET to the Zod env schema (optional).

- backend/.env.example Document TELEGRAM_WEBHOOK_SECRET alongside TELEGRAM_BOT_TOKEN.

- backend/src/routes/telegram-webhook.ts Add validateWebhookSecret middleware that checks the X-Telegram-Bot-Api-Secret-Token header against the env var. Skipped when the var is unset (dev/test). Applied to POST /webhook.

- backend/src/index.ts Mount /api/telegram router. Call telegramCommandService.init() on startup so the /subs command handler is registered. Call telegramCommandService.stop() in graceful shutdown. Warn at startup when bot token is set but webhook secret is not.

- backend/tests/telegram-webhook-secret.test.ts (new) Tests: 403 on missing/wrong secret, 200 on correct secret, 200 when no secret configured, GET health check always accessible.

Closes #477


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
