### PR TITLE
fix(auth): use user_roles table as authoritative RBAC source (#475)

### DIFF
--- a/client/lib/api/auth.test.ts
+++ b/client/lib/api/auth.test.ts
@@ -7,266 +7,261 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }))
 
+// Helper: build a mock Supabase client
+function mockSupabaseWith({
+  user = null as any,
+  authError = null as any,
+  userRoleRow = null as any,
+  userRoleError = null as any,
+  profileRow = null as any,
+} = {}) {
+  // user_roles query chain
+  const userRolesSingle = vi.fn().mockResolvedValue({ data: userRoleRow, error: userRoleError })
+  const userRolesEq = vi.fn().mockReturnValue({ single: userRolesSingle })
+  const userRolesSelect = vi.fn().mockReturnValue({ eq: userRolesEq })
+
+  // profiles query chain
+  const profilesSingle = vi.fn().mockResolvedValue({ data: profileRow, error: null })
+  const profilesEq = vi.fn().mockReturnValue({ single: profilesSingle })
+  const profilesSelect = vi.fn().mockReturnValue({ eq: profilesEq })
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user }, error: authError }),
+    },
+    from: vi.fn((table: string) => {
+      if (table === 'user_roles') return { select: userRolesSelect }
+      if (table === 'profiles') return { select: profilesSelect }
+      return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: null, error: null }) }) }) }
+    }),
+  }
+}
+
 describe('Auth Middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('getAuthenticatedUser', () => {
-    it('should return user when authenticated', async () => {
+    it('returns user when authenticated', async () => {
       const mockUser = { id: '123', email: 'test@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(mockSupabaseWith({ user: mockUser }) as any)
 
-      const request = new NextRequest('http://localhost')
-      const user = await getAuthenticatedUser(request)
-
+      const user = await getAuthenticatedUser(new NextRequest('http://localhost'))
       expect(user).toEqual(mockUser)
     })
 
-    it('should throw when not authenticated', async () => {
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: new Error('Not authenticated') }),
-        },
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+    it('throws when not authenticated', async () => {
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: null, authError: new Error('Not authenticated') }) as any
+      )
+      await expect(getAuthenticatedUser(new NextRequest('http://localhost'))).rejects.toThrow(
+        'Invalid or expired session'
+      )
+    })
+  })
 
-      const request = new NextRequest('http://localhost')
-      await expect(getAuthenticatedUser(request)).rejects.toThrow('Invalid or expired session')
+  describe('getUserRole — authoritative source', () => {
+    it('reads role from user_roles table (primary source)', async () => {
+      const mockUser = { id: '123', email: 'admin@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'admin' } }) as any
+      )
+
+      const result = await requireRole(new NextRequest('http://localhost'), ['admin'])
+      expect(result.role).toBe('admin')
+    })
+
+    it('falls back to profiles.role when user_roles has no row', async () => {
+      const mockUser = { id: '123', email: 'member@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({
+          user: mockUser,
+          userRoleRow: null,
+          userRoleError: { code: 'PGRST116' },
+          profileRow: { role: 'member' },
+        }) as any
+      )
+
+      const result = await requireRole(new NextRequest('http://localhost'), ['member'])
+      expect(result.role).toBe('member')
+    })
+
+    it('defaults to user role when neither table has a row', async () => {
+      const mockUser = { id: '123', email: 'new@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({
+          user: mockUser,
+          userRoleRow: null,
+          userRoleError: { code: 'PGRST116' },
+          profileRow: null,
+        }) as any
+      )
+
+      const result = await requireRole(new NextRequest('http://localhost'), ['user'])
+      expect(result.role).toBe('user')
     })
   })
 
   describe('requireRole', () => {
-    it('should allow user with correct role from database', async () => {
+    it('allows user with correct role', async () => {
       const mockUser = { id: '123', email: 'admin@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'admin' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      const result = await requireRole(request, ['admin', 'owner'])
-
+      const result = await requireRole(new NextRequest('http://localhost'), ['admin', 'owner'])
       expect(result.user).toEqual(mockUser)
       expect(result.role).toBe('admin')
     })
 
-    it('should deny user with incorrect role', async () => {
-      const mockUser = { id: '123', email: 'user@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'viewer' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+    it('returns 403 for user with insufficient role', async () => {
+      const mockUser = { id: '123', email: 'viewer@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'viewer' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      await expect(requireRole(request, ['admin', 'owner'])).rejects.toThrow('Requires one of: admin, owner')
+      await expect(
+        requireRole(new NextRequest('http://localhost'), ['admin', 'owner'])
+      ).rejects.toThrow('Requires one of: admin, owner')
     })
 
-    it('should default to user role when profile not found', async () => {
-      const mockUser = { id: '123', email: 'newuser@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: null, error: new Error('Not found') }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
-
-      const request = new NextRequest('http://localhost')
-      const result = await requireRole(request, ['user'])
-
-      expect(result.role).toBe('user')
-    })
-
-    it('should support multiple allowed roles', async () => {
+    it('supports multiple allowed roles', async () => {
       const mockUser = { id: '123', email: 'member@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'member' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'member' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      const result = await requireRole(request, ['admin', 'member', 'owner'])
-
+      const result = await requireRole(new NextRequest('http://localhost'), ['admin', 'member', 'owner'])
       expect(result.role).toBe('member')
     })
   })
 
   describe('requireMinRole', () => {
-    it('should allow user with exact minimum role', async () => {
+    it('allows user with exact minimum role', async () => {
       const mockUser = { id: '123', email: 'admin@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'admin' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      const result = await requireMinRole(request, 'admin')
-
+      const result = await requireMinRole(new NextRequest('http://localhost'), 'admin')
       expect(result.role).toBe('admin')
     })
 
-    it('should allow user with higher role than minimum', async () => {
+    it('allows user with higher role than minimum', async () => {
       const mockUser = { id: '123', email: 'owner@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'owner' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'owner' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      const result = await requireMinRole(request, 'member')
-
+      const result = await requireMinRole(new NextRequest('http://localhost'), 'member')
       expect(result.role).toBe('owner')
     })
 
-    it('should deny user with lower role than minimum', async () => {
+    it('returns 403 for user below minimum role', async () => {
       const mockUser = { id: '123', email: 'viewer@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'viewer' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'viewer' } }) as any
+      )
 
-      const request = new NextRequest('http://localhost')
-      await expect(requireMinRole(request, 'admin')).rejects.toThrow('Requires admin role or higher')
+      await expect(requireMinRole(new NextRequest('http://localhost'), 'admin')).rejects.toThrow(
+        'Requires admin role or higher'
+      )
+    })
+  })
+
+  describe('Route type coverage (admin, team, subscription)', () => {
+    // Route type 1: admin route — requires owner
+    it('admin/settings: allows owner, denies admin', async () => {
+      const mockUser = { id: '1', email: 'owner@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'owner' } }) as any
+      )
+      const result = await requireRole(new NextRequest('http://localhost'), ['owner'])
+      expect(result.role).toBe('owner')
+
+      const adminUser = { id: '2', email: 'admin@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: adminUser, userRoleRow: { role: 'admin' } }) as any
+      )
+      await expect(requireRole(new NextRequest('http://localhost'), ['owner'])).rejects.toThrow()
+    })
+
+    // Route type 2: team route — requires member or above
+    it('team/members: allows member, denies viewer', async () => {
+      const memberUser = { id: '3', email: 'member@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: memberUser, userRoleRow: { role: 'member' } }) as any
+      )
+      const result = await requireRole(new NextRequest('http://localhost'), ['member', 'admin', 'owner'])
+      expect(result.role).toBe('member')
+
+      const viewerUser = { id: '4', email: 'viewer@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: viewerUser, userRoleRow: { role: 'viewer' } }) as any
+      )
+      await expect(
+        requireRole(new NextRequest('http://localhost'), ['member', 'admin', 'owner'])
+      ).rejects.toThrow()
+    })
+
+    // Route type 3: admin/users — requires admin or owner
+    it('admin/users: allows admin, denies member', async () => {
+      const adminUser = { id: '5', email: 'admin@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: adminUser, userRoleRow: { role: 'admin' } }) as any
+      )
+      const result = await requireRole(new NextRequest('http://localhost'), ['admin', 'owner'])
+      expect(result.role).toBe('admin')
+
+      const memberUser = { id: '6', email: 'member@example.com' }
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: memberUser, userRoleRow: { role: 'member' } }) as any
+      )
+      await expect(
+        requireRole(new NextRequest('http://localhost'), ['admin', 'owner'])
+      ).rejects.toThrow()
     })
   })
 
   describe('withAuth', () => {
-    it('should pass user to handler when authenticated', async () => {
+    it('passes user to handler when authenticated', async () => {
       const mockUser = { id: '123', email: 'test@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(mockSupabaseWith({ user: mockUser }) as any)
 
       const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true }))
-      const wrapped = withAuth(handler)
+      await withAuth(handler)(new NextRequest('http://localhost'))
 
-      const request = new NextRequest('http://localhost')
-      await wrapped(request)
-
-      expect(handler).toHaveBeenCalledWith(request, mockUser)
+      expect(handler).toHaveBeenCalledWith(new NextRequest('http://localhost'), mockUser)
     })
 
-    it('should enforce role when requireRole option provided', async () => {
+    it('enforces role when requireRole option provided', async () => {
       const mockUser = { id: '123', email: 'admin@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'admin' } }) as any
+      )
 
       const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true }))
-      const wrapped = withAuth(handler, { requireRole: ['admin'] })
-
-      const request = new NextRequest('http://localhost')
-      await wrapped(request)
-
+      await withAuth(handler, { requireRole: ['admin'] })(new NextRequest('http://localhost'))
       expect(handler).toHaveBeenCalled()
     })
 
-    it('should reject when role requirement not met', async () => {
+    it('rejects when role requirement not met', async () => {
       const mockUser = { id: '123', email: 'user@example.com' }
-      const mockSupabase = {
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: mockUser }, error: null }),
-        },
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { role: 'user' }, error: null }),
-            }),
-          }),
-        }),
-      }
-      vi.mocked(createClient).mockResolvedValue(mockSupabase as any)
+      vi.mocked(createClient).mockResolvedValue(
+        mockSupabaseWith({ user: mockUser, userRoleRow: { role: 'user' } }) as any
+      )
 
       const handler = vi.fn()
-      const wrapped = withAuth(handler, { requireRole: ['admin'] })
-
-      const request = new NextRequest('http://localhost')
-      await expect(wrapped(request)).rejects.toThrow('Requires one of: admin')
+      await expect(
+        withAuth(handler, { requireRole: ['admin'] })(new NextRequest('http://localhost'))
+      ).rejects.toThrow('Requires one of: admin')
       expect(handler).not.toHaveBeenCalled()
     })
   })
 
   describe('ROLE_HIERARCHY', () => {
-    it('should have correct hierarchy order', () => {
+    it('has correct hierarchy order', () => {
       expect(ROLE_HIERARCHY.owner).toBeGreaterThan(ROLE_HIERARCHY.admin)
       expect(ROLE_HIERARCHY.admin).toBeGreaterThan(ROLE_HIERARCHY.member)
       expect(ROLE_HIERARCHY.member).toBeGreaterThan(ROLE_HIERARCHY.viewer)

--- a/client/lib/api/auth.ts
+++ b/client/lib/api/auth.ts
@@ -65,18 +65,26 @@ export const ROLE_HIERARCHY: Record<UserRole, number> = {
 
 async function getUserRole(userId: string): Promise<UserRole> {
   const supabase = await createClient()
-  
-  const { data, error } = await supabase
+
+  // Primary: authoritative user_roles table (replaces user_metadata.role)
+  const { data: roleRow, error: roleError } = await supabase
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', userId)
+    .single()
+
+  if (!roleError && roleRow?.role) {
+    return roleRow.role as UserRole
+  }
+
+  // Fallback: profiles.role for users not yet in user_roles
+  const { data: profile } = await supabase
     .from('profiles')
     .select('role')
     .eq('id', userId)
     .single()
 
-  if (error || !data?.role) {
-    return 'user'
-  }
-
-  return data.role as UserRole
+  return (profile?.role as UserRole) || 'user'
 }
 
 export async function requireRole(


### PR DESCRIPTION
The getUserRole helper was reading from profiles.role, which the 021_create_user_roles_table migration explicitly marks as replaced. Role checks were therefore brittle and inconsistent with the backend RoleService.

Changes:
- client/lib/api/auth.ts getUserRole now queries user_roles (primary) with a fallback to profiles.role for users not yet migrated, then defaults to 'user'. No changes to requireRole, requireMinRole, withAuth, or ROLE_HIERARCHY — the public API is unchanged.

- client/lib/api/auth.test.ts Replaced single-table mock with a two-table mock helper that independently controls user_roles and profiles responses. Added tests for: user_roles primary read, profiles fallback, neither-table default, and allow/deny coverage for 3 route types (admin/settings owner-only, team/members member+, admin/users admin+).

Closes #475


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
