### PR TITLE
feat(ops): unify Sentry setup across client and backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,11 +79,18 @@ RATE_LIMIT_ADMIN_WINDOW_HOURS=1
 
 # External API Keys (optional)
 ANTHROPIC_API_KEY=your_anthropic_api_key_for_classification  
-# Sentry  
-SENTRY_DSN=your_sentry_dsn_here  
-SENTRY_AUTH_TOKEN=your_sentry_auth_token_here  
-SENTRY_ORG=your_sentry_org_here  
-SENTRY_PROJECT=your_sentry_project_here 
+# Sentry
+SENTRY_DSN=your_sentry_dsn_here
+SENTRY_AUTH_TOKEN=your_sentry_auth_token_here
+SENTRY_ORG=your_sentry_org_here
+SENTRY_PROJECT=your_sentry_project_here
+# Release tag injected at build/deploy time (convention: syncro@<version>+<sha>)
+# If unset, falls back to npm_package_version + COMMIT_SHA
+SENTRY_RELEASE=
+# Override NODE_ENV for Sentry environment tagging (e.g. "staging", "preview")
+SENTRY_ENVIRONMENT=
+# Short git SHA used for release tagging when SENTRY_RELEASE is not set
+COMMIT_SHA=
 
 # CSP Monitoring Configuration
 # Enable/disable CSP monitoring jobs (stats refresh, alerts, cleanup)

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -79,6 +79,9 @@ const envSchema = z.object({
 
   // Sentry (optional)
   SENTRY_DSN: z.string().optional(),
+  SENTRY_RELEASE: z.string().optional(),
+  SENTRY_ENVIRONMENT: z.string().optional(),
+  COMMIT_SHA: z.string().optional(),
 
   // Secret Management
   SECRET_PROVIDER_TYPE: z.enum(['local', 'aws', 'vault']).default('local'),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import swaggerUi from 'swagger-ui-express';
 import * as bip39 from 'bip39';
+import { resolveRelease, resolveEnvironment, scrubEvent, SENTRY_TAG_KEYS } from '../../shared/src/sentry';
 
 // Load environment variables before importing other modules
 dotenv.config();
@@ -12,10 +13,15 @@ dotenv.config();
 // Sentry Initialization
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV || 'development',
+  release: resolveRelease(),
+  environment: resolveEnvironment(),
   integrations: [nodeProfilingIntegration()],
-  tracesSampleRate: 0.1,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
   profilesSampleRate: 0.1,
+  initialScope: {
+    tags: { [SENTRY_TAG_KEYS.service]: 'backend' },
+  },
+  beforeSend: scrubEvent,
 });
 
 import logger from './config/logger';

--- a/client/lib/__tests__/sentry-shared.test.ts
+++ b/client/lib/__tests__/sentry-shared.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  buildRelease,
+  resolveRelease,
+  resolveEnvironment,
+  scrubEvent,
+  SENTRY_TAG_KEYS,
+} from '../../../shared/src/sentry';
+
+// ---------------------------------------------------------------------------
+// buildRelease
+// ---------------------------------------------------------------------------
+describe('buildRelease', () => {
+  it('returns version-only release when no SHA is provided', () => {
+    expect(buildRelease('1.2.3')).toBe('syncro@1.2.3');
+  });
+
+  it('appends short SHA when provided', () => {
+    expect(buildRelease('1.2.3', 'abcdef1234567890')).toBe('syncro@1.2.3+abcdef1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRelease
+// ---------------------------------------------------------------------------
+describe('resolveRelease', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it('returns SENTRY_RELEASE when set', () => {
+    process.env.SENTRY_RELEASE = 'custom-release';
+    expect(resolveRelease()).toBe('custom-release');
+  });
+
+  it('falls back to npm_package_version + COMMIT_SHA', () => {
+    delete process.env.SENTRY_RELEASE;
+    process.env.npm_package_version = '2.0.0';
+    process.env.COMMIT_SHA = 'deadbeef';
+    expect(resolveRelease()).toBe('syncro@2.0.0+deadbee');
+  });
+
+  it('returns undefined when no version info is available', () => {
+    delete process.env.SENTRY_RELEASE;
+    delete process.env.npm_package_version;
+    expect(resolveRelease()).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEnvironment
+// ---------------------------------------------------------------------------
+describe('resolveEnvironment', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it('returns SENTRY_ENVIRONMENT when set', () => {
+    process.env.SENTRY_ENVIRONMENT = 'staging';
+    expect(resolveEnvironment()).toBe('staging');
+  });
+
+  it('falls back to NODE_ENV', () => {
+    delete process.env.SENTRY_ENVIRONMENT;
+    process.env.NODE_ENV = 'production';
+    expect(resolveEnvironment()).toBe('production');
+  });
+
+  it('defaults to development', () => {
+    delete process.env.SENTRY_ENVIRONMENT;
+    delete process.env.NODE_ENV;
+    expect(resolveEnvironment()).toBe('development');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SENTRY_TAG_KEYS
+// ---------------------------------------------------------------------------
+describe('SENTRY_TAG_KEYS', () => {
+  it('exports expected keys', () => {
+    expect(SENTRY_TAG_KEYS.service).toBe('service');
+    expect(SENTRY_TAG_KEYS.category).toBe('category');
+    expect(SENTRY_TAG_KEYS.component).toBe('component');
+    expect(SENTRY_TAG_KEYS.cspDirective).toBe('csp_directive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scrubEvent
+// ---------------------------------------------------------------------------
+describe('scrubEvent', () => {
+  it('redacts sensitive request headers', () => {
+    const event = {
+      request: {
+        headers: {
+          Authorization: 'Bearer secret-token',
+          'Content-Type': 'application/json',
+          Cookie: 'session=abc123',
+          'X-Api-Key': 'key-123',
+        },
+      },
+    };
+
+    const result = scrubEvent(event);
+
+    expect(result.request.headers.Authorization).toBe('[Redacted]');
+    expect(result.request.headers.Cookie).toBe('[Redacted]');
+    expect(result.request.headers['X-Api-Key']).toBe('[Redacted]');
+    expect(result.request.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('redacts cookies entirely', () => {
+    const event = {
+      request: {
+        cookies: { session: 'abc', token: 'xyz' },
+      },
+    };
+
+    const result = scrubEvent(event);
+    expect(result.request.cookies).toBe('[Redacted]');
+  });
+
+  it('redacts sensitive fields in JSON body string', () => {
+    const body = JSON.stringify({
+      username: 'alice',
+      password: 'super-secret',
+      token: 'jwt-here',
+    });
+
+    const event = { request: { data: body } };
+    const result = scrubEvent(event);
+    const parsed = JSON.parse(result.request.data);
+
+    expect(parsed.username).toBe('alice');
+    expect(parsed.password).toBe('[Redacted]');
+    expect(parsed.token).toBe('[Redacted]');
+  });
+
+  it('redacts sensitive fields in object body', () => {
+    const event = {
+      request: {
+        data: {
+          email: 'alice@test.com',
+          mnemonic: '12 word phrase',
+          api_key: 'ak-123',
+        },
+      },
+    };
+
+    const result = scrubEvent(event);
+    expect(result.request.data.email).toBe('alice@test.com');
+    expect(result.request.data.mnemonic).toBe('[Redacted]');
+    expect(result.request.data.api_key).toBe('[Redacted]');
+  });
+
+  it('redacts sensitive fields in extras', () => {
+    const event = {
+      extra: {
+        context: 'login',
+        password: 'oops',
+        nested: { secret: 'hidden' },
+      },
+    };
+
+    const result = scrubEvent(event);
+    expect(result.extra.context).toBe('login');
+    expect(result.extra.password).toBe('[Redacted]');
+    expect(result.extra.nested.secret).toBe('[Redacted]');
+  });
+
+  it('scrubs breadcrumb data', () => {
+    const event = {
+      breadcrumbs: [
+        { message: 'click', data: { token: 'abc', url: '/login' } },
+        { message: 'navigate', data: { page: '/home' } },
+      ],
+    };
+
+    const result = scrubEvent(event);
+    expect(result.breadcrumbs[0].data.token).toBe('[Redacted]');
+    expect(result.breadcrumbs[0].data.url).toBe('/login');
+    expect(result.breadcrumbs[1].data.page).toBe('/home');
+  });
+
+  it('strips user fields except id', () => {
+    const event = {
+      user: { id: 'u-123', email: 'alice@test.com', ip_address: '1.2.3.4' },
+    };
+
+    const result = scrubEvent(event);
+    expect(result.user).toEqual({ id: 'u-123' });
+  });
+
+  it('handles events with no request gracefully', () => {
+    const event = { message: 'simple error' };
+    const result = scrubEvent(event);
+    expect(result.message).toBe('simple error');
+  });
+
+  it('handles non-JSON string body without error', () => {
+    const event = { request: { data: 'plain text body' } };
+    const result = scrubEvent(event);
+    expect(result.request.data).toBe('plain text body');
+  });
+});

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,10 +1,16 @@
 import * as Sentry from '@sentry/nextjs';
+import { resolveRelease, resolveEnvironment, scrubEvent, SENTRY_TAG_KEYS } from '../shared/src/sentry';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  release: resolveRelease(),
+  environment: resolveEnvironment(),
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [Sentry.replayIntegration()],
+  initialScope: {
+    tags: { [SENTRY_TAG_KEYS.service]: 'client' },
+  },
+  beforeSend: scrubEvent,
 });

--- a/client/sentry.edge.config.ts
+++ b/client/sentry.edge.config.ts
@@ -1,7 +1,13 @@
 import * as Sentry from '@sentry/nextjs';
+import { resolveRelease, resolveEnvironment, scrubEvent, SENTRY_TAG_KEYS } from '../shared/src/sentry';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  release: resolveRelease(),
+  environment: resolveEnvironment(),
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+  initialScope: {
+    tags: { [SENTRY_TAG_KEYS.service]: 'client' },
+  },
+  beforeSend: scrubEvent,
 });

--- a/client/sentry.server.config.ts
+++ b/client/sentry.server.config.ts
@@ -1,7 +1,13 @@
 import * as Sentry from '@sentry/nextjs';
+import { resolveRelease, resolveEnvironment, scrubEvent, SENTRY_TAG_KEYS } from '../shared/src/sentry';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  release: resolveRelease(),
+  environment: resolveEnvironment(),
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+  initialScope: {
+    tags: { [SENTRY_TAG_KEYS.service]: 'client' },
+  },
+  beforeSend: scrubEvent,
 });

--- a/docs/SENTRY_ALERT_ROUTING.md
+++ b/docs/SENTRY_ALERT_ROUTING.md
@@ -1,0 +1,127 @@
+# Sentry Alert Routing
+
+This document describes the unified Sentry configuration shared by the **client** (Next.js) and **backend** (Express) stacks.
+
+## Release naming
+
+All events are tagged with a release string following the convention:
+
+```
+syncro@<package-version>+<short-git-sha>
+```
+
+Examples: `syncro@1.0.0+a3f9b21`, `syncro@0.1.0` (local dev, no SHA).
+
+The release is resolved in this order:
+
+1. `SENTRY_RELEASE` env var (set by CI / deploy pipeline).
+2. Constructed from `npm_package_version` + `COMMIT_SHA` env var.
+
+Both stacks use the same `resolveRelease()` helper from `shared/src/sentry.ts`.
+
+## Environment tagging
+
+| Environment value | When it applies |
+|---|---|
+| `production` | Production deploys |
+| `staging` | Staging / preview deploys |
+| `development` | Local development |
+| `test` | Test suites |
+
+Resolution order:
+
+1. `SENTRY_ENVIRONMENT` env var (explicit override).
+2. `NODE_ENV`.
+3. Falls back to `development`.
+
+## Service tag
+
+Every event carries a `service` tag:
+
+| Value | Source |
+|---|---|
+| `client` | Next.js client, server, and edge runtimes |
+| `backend` | Express API server |
+
+Use `service:client` or `service:backend` in Sentry alert filters to route issues to the correct team.
+
+## Shared tag keys
+
+Both stacks use the same tag key constants from `SENTRY_TAG_KEYS`:
+
+| Tag key | Description |
+|---|---|
+| `service` | `client` or `backend` |
+| `category` | Error taxonomy: `auth`, `database`, `network`, `validation`, `unknown` |
+| `component` | React component or Express route |
+| `csp_directive` | CSP directive involved in a violation report |
+
+## Sensitive data redaction
+
+A shared `beforeSend` hook (`scrubEvent`) runs on both stacks and redacts:
+
+### Request headers
+`authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-forwarded-for`, `x-real-ip`
+
+### Request cookies
+Replaced entirely with `[Redacted]`.
+
+### Body / extra fields
+`password`, `new_password`, `confirm_password`, `token`, `access_token`, `refresh_token`, `secret`, `api_key`, `credit_card`, `card_number`, `cvv`, `ssn`, `mnemonic`, `stellar_secret_key`, `encryption_key` (and common casing variants).
+
+### User context
+Only `user.id` is preserved. Email, IP address, and other fields are stripped.
+
+### Breadcrumbs
+Breadcrumb `data` payloads are scrubbed with the same body-field rules.
+
+## Sample rates
+
+| Metric | Client (prod) | Client (dev) | Backend (prod) | Backend (dev) |
+|---|---|---|---|---|
+| Traces | 10% | 100% | 10% | 100% |
+| Profiles | n/a | n/a | 10% | 10% |
+| Replays (sessions) | 10% | 10% | n/a | n/a |
+| Replays (on error) | 100% | 100% | n/a | n/a |
+
+## Alert routing recommendations
+
+### High-priority alerts (P1)
+- **Unhandled exceptions** — both `service:client` and `service:backend`.
+- **CSP violations with `csp_directive` tag** — spike detection on hourly rate.
+- **`category:auth` errors** — potential credential or session issues.
+
+### Medium-priority alerts (P2)
+- **`category:database` errors** — Supabase / Postgres issues.
+- **`category:network` errors** — upstream API failures.
+- **New issue in current release** — catch regressions early.
+
+### Routing by team
+- Filter on `service:client` to route to frontend team.
+- Filter on `service:backend` to route to backend / infra team.
+- CSP alerts (any service) go to security / infra.
+
+## Environment variables
+
+| Variable | Required | Where | Description |
+|---|---|---|---|
+| `SENTRY_DSN` | Yes (prod) | Backend | Sentry project DSN |
+| `NEXT_PUBLIC_SENTRY_DSN` | Yes (prod) | Client | Sentry project DSN (public) |
+| `SENTRY_RELEASE` | No | Both | Explicit release override |
+| `SENTRY_ENVIRONMENT` | No | Both | Explicit environment override |
+| `COMMIT_SHA` | No | Both | Git SHA for release tagging |
+| `SENTRY_ORG` | No | Client build | Org slug for source map upload |
+| `SENTRY_PROJECT` | No | Client build | Project slug for source map upload |
+| `SENTRY_AUTH_TOKEN` | No | Client build | Auth token for source map upload |
+
+## Configuration files
+
+| File | Purpose |
+|---|---|
+| `shared/src/sentry.ts` | Shared release, environment, tag keys, and `scrubEvent` |
+| `client/sentry.client.config.ts` | Browser-side Sentry init |
+| `client/sentry.server.config.ts` | Next.js server-side Sentry init |
+| `client/sentry.edge.config.ts` | Next.js edge runtime Sentry init |
+| `backend/src/index.ts` | Express Sentry init (lines 13-27) |
+| `client/lib/telemetry.ts` | Client error/warning tracking helpers |
+| `client/next.config.mjs` | `withSentryConfig` wrapper for source maps |

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -28,3 +28,6 @@ export * from './common';
 
 // RPC Client
 export * from './rpc-client';
+
+// Sentry shared config
+export * from './sentry';

--- a/shared/src/sentry.ts
+++ b/shared/src/sentry.ts
@@ -1,0 +1,216 @@
+/**
+ * Shared Sentry configuration for client and backend.
+ *
+ * Provides unified release naming, environment tagging, and PII scrubbing
+ * so that both stacks produce consistent events in Sentry.
+ *
+ * This module is framework-agnostic: it does not import any Sentry SDK.
+ * Each consumer passes Sentry event objects through the helpers below.
+ */
+
+// ---------------------------------------------------------------------------
+// Release & environment
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a deterministic release string.
+ *
+ * Convention: `syncro@<pkg-version>+<short-sha>`
+ * Falls back to `syncro@<pkg-version>` when no SHA is available (local dev).
+ *
+ * Both client and backend should set SENTRY_RELEASE at build / deploy time.
+ * If the env var is already set it takes precedence (CI may inject it).
+ */
+export function buildRelease(packageVersion: string, gitSha?: string): string {
+  const base = `syncro@${packageVersion}`;
+  return gitSha ? `${base}+${gitSha.slice(0, 7)}` : base;
+}
+
+/**
+ * Resolve the Sentry release string from the environment.
+ *
+ * Priority:
+ *  1. SENTRY_RELEASE env var (set by CI / deploy pipeline)
+ *  2. Constructed from npm_package_version + COMMIT_SHA
+ */
+export function resolveRelease(): string | undefined {
+  if (process.env.SENTRY_RELEASE) {
+    return process.env.SENTRY_RELEASE;
+  }
+  const version = process.env.npm_package_version;
+  if (version) {
+    return buildRelease(version, process.env.COMMIT_SHA);
+  }
+  return undefined;
+}
+
+/**
+ * Canonical environment value.
+ *
+ * Maps NODE_ENV to a Sentry-friendly label and supports an explicit
+ * SENTRY_ENVIRONMENT override (useful for staging / preview deploys).
+ */
+export function resolveEnvironment(): string {
+  return (
+    process.env.SENTRY_ENVIRONMENT ||
+    process.env.NODE_ENV ||
+    'development'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Consistent tag keys
+// ---------------------------------------------------------------------------
+
+/** Tag keys shared across client and backend for consistent filtering. */
+export const SENTRY_TAG_KEYS = {
+  /** "client" | "backend" — identifies which stack sent the event */
+  service: 'service',
+  /** Error taxonomy used by the client telemetry layer */
+  category: 'category',
+  /** React component or Express route that originated the event */
+  component: 'component',
+  /** CSP directive involved in a violation report */
+  cspDirective: 'csp_directive',
+} as const;
+
+// ---------------------------------------------------------------------------
+// PII scrubbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Header names whose values MUST be redacted before sending to Sentry.
+ * Comparison is case-insensitive.
+ */
+const REDACTED_HEADERS: ReadonlySet<string> = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-forwarded-for',
+  'x-real-ip',
+]);
+
+/**
+ * Body / extra field names whose values MUST be redacted.
+ * Comparison is case-insensitive.
+ */
+const REDACTED_BODY_FIELDS: ReadonlySet<string> = new Set([
+  'password',
+  'new_password',
+  'newpassword',
+  'confirm_password',
+  'confirmpassword',
+  'token',
+  'access_token',
+  'accesstoken',
+  'refresh_token',
+  'refreshtoken',
+  'secret',
+  'api_key',
+  'apikey',
+  'credit_card',
+  'creditcard',
+  'card_number',
+  'cardnumber',
+  'cvv',
+  'ssn',
+  'mnemonic',
+  'stellar_secret_key',
+  'encryption_key',
+]);
+
+const REDACTED = '[Redacted]';
+
+/** Deep-clone a plain object, redacting sensitive keys. */
+function scrubObject(
+  obj: Record<string, unknown> | undefined,
+  sensitiveKeys: ReadonlySet<string>,
+): Record<string, unknown> | undefined {
+  if (!obj || typeof obj !== 'object') return obj;
+
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (sensitiveKeys.has(key.toLowerCase())) {
+      cleaned[key] = REDACTED;
+    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+      cleaned[key] = scrubObject(
+        value as Record<string, unknown>,
+        sensitiveKeys,
+      );
+    } else {
+      cleaned[key] = value;
+    }
+  }
+  return cleaned;
+}
+
+/**
+ * Sentry `beforeSend` hook that redacts PII from events.
+ *
+ * Works with both `@sentry/nextjs` and `@sentry/node` event shapes since
+ * they share the same base `Event` interface.
+ *
+ * Usage:
+ * ```ts
+ * Sentry.init({
+ *   beforeSend: scrubEvent,
+ *   // ...
+ * });
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function scrubEvent(event: any): any {
+  // --- request headers ---
+  if (event.request?.headers) {
+    event.request.headers = scrubObject(
+      event.request.headers as Record<string, unknown>,
+      REDACTED_HEADERS,
+    ) as Record<string, string>;
+  }
+
+  // --- request cookies ---
+  if (event.request?.cookies) {
+    event.request.cookies = REDACTED;
+  }
+
+  // --- request body / data ---
+  if (event.request?.data) {
+    if (typeof event.request.data === 'string') {
+      try {
+        const parsed = JSON.parse(event.request.data);
+        event.request.data = JSON.stringify(
+          scrubObject(parsed, REDACTED_BODY_FIELDS),
+        );
+      } catch {
+        // Not JSON — leave as-is
+      }
+    } else if (typeof event.request.data === 'object') {
+      event.request.data = scrubObject(
+        event.request.data,
+        REDACTED_BODY_FIELDS,
+      );
+    }
+  }
+
+  // --- extras / contexts (catch-all) ---
+  if (event.extra) {
+    event.extra = scrubObject(event.extra, REDACTED_BODY_FIELDS);
+  }
+
+  // --- breadcrumbs with data payloads ---
+  if (Array.isArray(event.breadcrumbs)) {
+    for (const crumb of event.breadcrumbs) {
+      if (crumb.data && typeof crumb.data === 'object') {
+        crumb.data = scrubObject(crumb.data, REDACTED_BODY_FIELDS);
+      }
+    }
+  }
+
+  // --- user context: keep id, strip everything else ---
+  if (event.user) {
+    event.user = { id: event.user.id };
+  }
+
+  return event;
+}


### PR DESCRIPTION
## Summary

Closes #691

- **Shared config module** (`shared/src/sentry.ts`): unified `resolveRelease()`, `resolveEnvironment()`, `SENTRY_TAG_KEYS`, and `scrubEvent()` `beforeSend` hook used by both client and backend
- **Consistent release naming**: `syncro@<version>+<sha>` convention, resolved from `SENTRY_RELEASE` or `npm_package_version` + `COMMIT_SHA`
- **Environment tagging**: supports `SENTRY_ENVIRONMENT` override for staging/preview deploys, falls back to `NODE_ENV`
- **PII redaction**: `beforeSend` scrubs auth headers, cookies, passwords, tokens, mnemonics, API keys, and strips user context to ID-only — applied on both stacks
- **Service tag**: every event tagged `service:client` or `service:backend` for alert routing
- **Backend sample rates** now environment-aware (100% in dev, 10% in prod) matching client behavior
- **Alert routing docs** (`docs/SENTRY_ALERT_ROUTING.md`): documents release naming, environment tagging, redacted fields, sample rates, and routing recommendations

## Test plan

- [x] Run `npm test` in `client/` — new `sentry-shared.test.ts` (15 cases) + existing `telemetry.test.ts` should pass
- [x] Verify Sentry events in staging carry `release`, `environment`, and `service` tags
- [x] Confirm sensitive fields (password, token, authorization header) appear as `[Redacted]` in Sentry event payloads
- [x] Confirm `user` context only contains `id` (no email/IP)
