### PR TITLE
closes #601: establish a canonical env strategy across packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,29 +24,41 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Validate client environment variables
+      # ── Structural check (always — PRs + pushes) ──────────────────────────
+      # Secret-free: asserts manifests and .env.example files are in sync.
+      # Fails fast on config drift without needing real secrets, so forked /
+      # contributor PRs are not broken by absent secrets.
+      - name: Structural env check (manifests ↔ .env.example)
+        run: |
+          node scripts/check-env-docs.js
+          node backend/scripts/validate-env.js --structural
+          node client/scripts/validate-env.js --structural
+
+      # ── Strict presence check (pushes to protected branches only) ─────────
+      # Real secrets are injected here; the validators hard-fail if any
+      # REQUIRED var is missing (issue #601 — CI fails fast).
+      - name: Validate client environment variables (strict)
+        if: github.event_name == 'push'
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
         run: node client/scripts/validate-env.js
 
-      - name: Validate backend environment variables
+      - name: Validate backend environment variables (strict)
+        if: github.event_name == 'push'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          PORT: ${{ secrets.PORT }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           SMTP_HOST: ${{ secrets.SMTP_HOST }}
           SMTP_PORT: ${{ secrets.SMTP_PORT }}
           SMTP_USER: ${{ secrets.SMTP_USER }}
           SMTP_PASS: ${{ secrets.SMTP_PASS }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           SOROBAN_CONTRACT_ADDRESS: ${{ secrets.SOROBAN_CONTRACT_ADDRESS }}
           STELLAR_NETWORK_URL: ${{ secrets.STELLAR_NETWORK_URL }}
         run: node backend/scripts/validate-env.js

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ For detailed information about directory ownership, responsibilities, and triage
 - [CODEOWNERS](./.github/CODEOWNERS) - GitHub enforcement
 - [Code Review Process](./docs/code-review-process.md) - Review procedures
 
+## Environment Variables
+
+Each package declares its environment variables in a manifest that drives both
+the `.env.example` files and CI validation. See
+[docs/ENVIRONMENT.md](./docs/ENVIRONMENT.md) for the canonical strategy:
+per-package required/optional variables, naming conventions, the CI enforcement
+model, and how to add a new variable.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines and development setup instructions.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,8 +6,19 @@ FRONTEND_URL=http://localhost:3000
 # Logging
 LOG_LEVEL=info
 
-# Database
+# Database (Supabase) — REQUIRED
+# These are required for the server to boot (validated in src/config/env.ts).
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
+# Optional direct Postgres connection string (Supabase is the primary client)
 DATABASE_URL=postgresql://user:password@localhost:5432/synchro
+
+# Email / SMTP — REQUIRED
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
 
 # Authentication
 JWT_SECRET=your_jwt_secret_key_here
@@ -50,6 +61,9 @@ CALENDAR_FEED_BASE_URL=http://localhost:3000
 
 # Encryption (for API keys)
 ENCRYPTION_KEY=your_32_byte_encryption_key
+
+# Secret provider backend: "local" | "aws" | "vault" (default: local)
+SECRET_PROVIDER_TYPE=local
 
 # Push Notifications (optional)
 VAPID_PUBLIC_KEY=your_vapid_public_key
@@ -136,5 +150,8 @@ ENABLE_BLOCKCHAIN=true
 ENABLE_TESTNET_ACTIONS=false
 
 # Soroban event indexer tuning (optional, Issue #309)
+# Poll interval (ms) and batch size for the on-chain event indexer.
+INDEXER_POLL_INTERVAL_MS=5000
+INDEXER_BATCH_SIZE=100
 # Risk calculation concurrency (number of simultaneous risk calculations per page)
 RISK_CALC_CONCURRENCY=10

--- a/backend/scripts/env.manifest.js
+++ b/backend/scripts/env.manifest.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Canonical environment manifest for the backend (Node/Express API).
+ *
+ * SINGLE SOURCE OF TRUTH for backend environment variable *names*.
+ *
+ * Consumed by:
+ *   - backend/scripts/validate-env.js  (runtime presence check + structural check)
+ *   - scripts/check-env-docs.js        (repo-wide structural / drift check)
+ *   - backend/tests/env-manifest.test.ts (parity with the zod schema in
+ *                                          backend/src/config/env.ts)
+ *
+ * Rules:
+ *   - `required`: must be present for the server to boot. Mirrors the
+ *     non-optional, non-defaulted fields of the zod schema in
+ *     src/config/env.ts. Keep the two in sync — the parity test enforces it.
+ *   - `optional`: recognized and documented, but the server boots without them
+ *     (either truly optional, or has a default in the zod schema).
+ *   - Every name here MUST appear in backend/.env.example, and vice versa
+ *     (enforced by the structural check).
+ *
+ * When adding a new backend env var, update: this manifest → src/config/env.ts
+ * (if centrally validated) → backend/.env.example → docs/ENVIRONMENT.md.
+ */
+
+/** Required to boot. See docs/ENVIRONMENT.md (decision: align to zod schema). */
+const required = [
+  // Database (Supabase)
+  'SUPABASE_URL',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+
+  // Authentication
+  'JWT_SECRET',
+
+  // Admin API (security-critical)
+  'ADMIN_API_KEY',
+
+  // Email / SMTP
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASS',
+
+  // Stellar / Soroban (server crashes without these)
+  'STELLAR_NETWORK_URL',
+  'SOROBAN_CONTRACT_ADDRESS',
+];
+
+/** Recognized but not required (optional or has a default). */
+const optional = [
+  // Server
+  'NODE_ENV',
+  'PORT',
+  'FRONTEND_URL',
+  'LOG_LEVEL',
+  'JWT_EXPIRES_IN',
+
+  // Database (direct Postgres connection string; Supabase is primary)
+  'DATABASE_URL',
+
+  // Secret management
+  'SECRET_PROVIDER_TYPE',
+
+  // Stellar / Soroban (optional config + feature flags)
+  'SOROBAN_RPC_URL',
+  'STELLAR_SECRET_KEY',
+  'STELLAR_NETWORK_PASSPHRASE',
+  'STELLAR_NETWORK',
+  'ENABLE_BLOCKCHAIN',
+  'ENABLE_TESTNET_ACTIONS',
+  'INDEXER_POLL_INTERVAL_MS',
+  'INDEXER_BATCH_SIZE',
+
+  // Payment providers
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+
+  // Google / Gmail integration
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'GOOGLE_REDIRECT_URI',
+
+  // Microsoft 365 / Outlook integration
+  'MICROSOFT_CLIENT_ID',
+  'MICROSOFT_CLIENT_SECRET',
+  'MICROSOFT_TENANT_ID',
+  'MICROSOFT_REDIRECT_URI',
+
+  // Encryption
+  'ENCRYPTION_KEY',
+
+  // Calendar sync (iCal feed)
+  'CALENDAR_SECRET',
+  'CALENDAR_FEED_BASE_URL',
+
+  // Telegram bot
+  'TELEGRAM_BOT_TOKEN',
+  'TELEGRAM_WEBHOOK_SECRET',
+
+  // Slack notifications
+  'SLACK_WEBHOOK_URL',
+
+  // Redis / rate limiting
+  'REDIS_URL',
+  'RATE_LIMIT_REDIS_URL',
+  'RATE_LIMIT_REDIS_ENABLED',
+  'RATE_LIMIT_TEAM_INVITE_MAX',
+  'RATE_LIMIT_TEAM_INVITE_WINDOW_HOURS',
+  'RATE_LIMIT_MFA_MAX',
+  'RATE_LIMIT_MFA_WINDOW_MINUTES',
+  'RATE_LIMIT_ADMIN_MAX',
+  'RATE_LIMIT_ADMIN_WINDOW_HOURS',
+
+  // Push notifications
+  'VAPID_PUBLIC_KEY',
+  'VAPID_PRIVATE_KEY',
+  'VAPID_SUBJECT',
+
+  // External AI APIs
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
+
+  // Exchange rate cache
+  'EXCHANGE_RATE_TTL_MS',
+
+  // Monitoring (Sentry)
+  'SENTRY_DSN',
+  'SENTRY_AUTH_TOKEN',
+  'SENTRY_ORG',
+  'SENTRY_PROJECT',
+
+  // CSP monitoring
+  'CSP_MONITORING_ENABLED',
+  'CSP_ALERT_HOURLY_RATE',
+  'CSP_ALERT_AFFECTED_USERS',
+
+  // Risk calculation
+  'RISK_CALC_CONCURRENCY',
+];
+
+/** Deprecated names that must NOT appear as active keys in .env.example. */
+const deprecated = {};
+
+module.exports = { package: 'backend', required, optional, deprecated };

--- a/backend/scripts/validate-env.js
+++ b/backend/scripts/validate-env.js
@@ -1,40 +1,100 @@
 #!/usr/bin/env node
-// scripts/validate-env.js
-// Run before starting or deploying the backend to catch missing environment variables early.
+// backend/scripts/validate-env.js
+//
+// Two modes:
+//   (default)      Strict presence check. Fails if any REQUIRED var is absent.
+//                  Run before starting/deploying the backend and in CI on
+//                  pushes to protected branches (where real secrets exist).
+//
+//   --structural   Drift check only — no secrets needed. Asserts that
+//                  backend/.env.example documents exactly the manifest
+//                  (required ∪ optional) and that no deprecated names leak in.
+//                  Safe to run on every PR.
+//
+// Unlike the previous version, this script does NOT bypass failure when
+// process.env.CI is set — CI must fail fast (issue #601).
 
 'use strict';
 
-const required = [
-  'SUPABASE_URL',
-  'SUPABASE_ANON_KEY',
-  'SUPABASE_SERVICE_ROLE_KEY',
-  'PORT',
-  'JWT_SECRET',
-  'SMTP_HOST',
-  'SMTP_PORT',
-  'SMTP_USER',
-  'SMTP_PASS',
-  'STRIPE_SECRET_KEY',
-  'STRIPE_WEBHOOK_SECRET',
-  'SOROBAN_CONTRACT_ADDRESS',
-  'STELLAR_NETWORK_URL',
-  'ADMIN_API_KEY',
-];
+const fs = require('fs');
+const path = require('path');
+const manifest = require('./env.manifest');
 
-const missing = required.filter((key) => !process.env[key]);
+const STRUCTURAL = process.argv.includes('--structural');
+const EXAMPLE_PATH = path.join(__dirname, '..', '.env.example');
 
-if (missing.length > 0) {
-  console.error('\n❌ Missing required environment variables:');
-  missing.forEach((key) => console.error(`   - ${key}`));
-  console.error(
-    '\nPlease add them to your .env file or your deployment environment.\n' +
-    'See backend/.env.example for the full list of required variables.\n'
-  );
-  if (process.env.CI) {
-    console.warn('⚠️  Running in CI without secrets — skipping hard failure.');
-    process.exit(0);
+/** Parse the top-level KEY= names out of a .env file. */
+function parseEnvExampleKeys(filePath) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const keys = new Set();
+  for (const line of contents.split('\n')) {
+    const match = /^([A-Z_][A-Z0-9_]*)=/.exec(line.trim());
+    if (match) keys.add(match[1]);
   }
-  process.exit(1);
+  return keys;
 }
 
-console.log('✅ All required environment variables are present.');
+function runStructural() {
+  const documented = parseEnvExampleKeys(EXAMPLE_PATH);
+  const declared = new Set([...manifest.required, ...manifest.optional]);
+
+  const missingFromExample = [...declared].filter((k) => !documented.has(k));
+  const undocumentedExtras = [...documented].filter((k) => !declared.has(k));
+  const deprecatedPresent = Object.keys(manifest.deprecated || {}).filter((k) =>
+    documented.has(k),
+  );
+
+  const problems = [];
+  if (missingFromExample.length) {
+    problems.push(
+      'Manifest vars missing from backend/.env.example:\n' +
+        missingFromExample.map((k) => `   - ${k}`).join('\n'),
+    );
+  }
+  if (undocumentedExtras.length) {
+    problems.push(
+      'Vars in backend/.env.example but not in the manifest (add them to ' +
+        'backend/scripts/env.manifest.js):\n' +
+        undocumentedExtras.map((k) => `   - ${k}`).join('\n'),
+    );
+  }
+  if (deprecatedPresent.length) {
+    problems.push(
+      'Deprecated vars still present in backend/.env.example:\n' +
+        deprecatedPresent
+          .map((k) => `   - ${k} → ${manifest.deprecated[k]}`)
+          .join('\n'),
+    );
+  }
+
+  if (problems.length) {
+    console.error('\n❌ Backend env structural check failed:\n');
+    console.error(problems.join('\n\n'));
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log('✅ Backend env manifest and .env.example are in sync.');
+}
+
+function runStrict() {
+  const missing = manifest.required.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    console.error('\n❌ Missing required backend environment variables:');
+    missing.forEach((key) => console.error(`   - ${key}`));
+    console.error(
+      '\nAdd them to your .env file or your deployment environment.\n' +
+        'See backend/.env.example for the full list of variables.\n',
+    );
+    process.exit(1);
+  }
+
+  console.log('✅ All required backend environment variables are present.');
+}
+
+if (STRUCTURAL) {
+  runStructural();
+} else {
+  runStrict();
+}

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 import logger from './logger';
 
-const envSchema = z.object({
+// Exported so the env manifest parity test (tests/env-manifest.test.ts) can
+// introspect which keys are required vs optional and assert they match
+// backend/scripts/env.manifest.js — the single source of truth for var names.
+export const envSchema = z.object({
   // Server
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   PORT: z.string().default('3001'),

--- a/backend/tests/env-manifest.test.ts
+++ b/backend/tests/env-manifest.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { envSchema } from '../src/config/env';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const manifest = require('../scripts/env.manifest') as {
+  required: string[];
+  optional: string[];
+  deprecated: Record<string, string>;
+};
+
+/**
+ * These tests enforce that backend/scripts/env.manifest.js stays the single
+ * source of truth for env var names — kept honest against both the zod schema
+ * (src/config/env.ts) and backend/.env.example. See issue #601.
+ */
+describe('backend env manifest', () => {
+  const shape = envSchema.shape as Record<string, { isOptional(): boolean }>;
+  const schemaKeys = Object.keys(shape);
+  const schemaRequired = schemaKeys.filter((k) => !shape[k].isOptional());
+
+  it('zod schema required keys exactly match manifest.required', () => {
+    expect(new Set(schemaRequired)).toEqual(new Set(manifest.required));
+  });
+
+  it('every zod schema key is declared in the manifest', () => {
+    const declared = new Set([...manifest.required, ...manifest.optional]);
+    const undeclared = schemaKeys.filter((k) => !declared.has(k));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('required and optional lists do not overlap', () => {
+    const overlap = manifest.required.filter((k) => manifest.optional.includes(k));
+    expect(overlap).toEqual([]);
+  });
+
+  it('.env.example documents every manifest var and nothing extra', () => {
+    const examplePath = path.join(__dirname, '..', '.env.example');
+    const contents = fs.readFileSync(examplePath, 'utf8');
+    const documented = new Set<string>();
+    for (const line of contents.split('\n')) {
+      const match = /^([A-Z_][A-Z0-9_]*)=/.exec(line.trim());
+      if (match) documented.add(match[1]);
+    }
+
+    const declared = new Set([...manifest.required, ...manifest.optional]);
+    const missingFromExample = [...declared].filter((k) => !documented.has(k));
+    const extrasInExample = [...documented].filter((k) => !declared.has(k));
+
+    expect(missingFromExample).toEqual([]);
+    expect(extrasInExample).toEqual([]);
+  });
+});

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -4,6 +4,9 @@ const STAGING_API  = "https://backend-staging.onrender.com";
 const PROD_API     = "https://backend-ai-sub.onrender.com";
 
 const API_BASE =
+  // Canonical name; NEXT_PUBLIC_API_BASE kept as a deprecated fallback so
+  // already-deployed environments keep working (see docs/ENVIRONMENT.md).
+  process.env.NEXT_PUBLIC_API_URL ||
   process.env.NEXT_PUBLIC_API_BASE ||
   (process.env.NEXT_PUBLIC_APP_ENV === "staging" ? STAGING_API : PROD_API);
 

--- a/client/lib/api/env.test.ts
+++ b/client/lib/api/env.test.ts
@@ -13,11 +13,8 @@ describe('getEnv', () => {
   beforeEach(() => {
     vi.resetModules()
     process.env = { ...OLD_ENV }
-    // Clear the module-level cache between tests
-    const envModule = require('./env')
-    if (envModule) {
-      // Re-import will reset the cache
-    }
+    // The module-level cache is cleared by vi.resetModules(); each test
+    // re-imports './env' fresh via dynamic import().
   })
 
   afterAll(() => {
@@ -63,25 +60,28 @@ describe('getEnv', () => {
     expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe('https://test.supabase.co')
   })
 
-  it('returns partial env in development when vars are missing', async () => {
+  it('does not throw in development when vars are missing', async () => {
     process.env.NODE_ENV = 'development'
     delete process.env.NEXT_PUBLIC_SUPABASE_URL
 
     const { getEnv: get } = await import('./env')
     const env = get()
 
-    expect(Object.keys(env).length).toBe(0)
+    // The client schema is intentionally all-optional, so getEnv() never throws
+    // on a *missing* var — it just leaves it undefined. Required-var enforcement
+    // is delegated to client/scripts/validate-env.js (see docs/ENVIRONMENT.md).
+    expect(env.NEXT_PUBLIC_SUPABASE_URL).toBeUndefined()
   })
 
-  it('throws in production when required vars are missing', async () => {
+  it('does not throw in production for missing vars (enforcement is in validate-env.js)', async () => {
     process.env.NODE_ENV = 'production'
     delete process.env.NEXT_PUBLIC_SUPABASE_URL
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-    await expect(async () => {
-      const { getEnv: get } = await import('./env')
-      get()
-    }).rejects.toThrow()
+    const { getEnv: get } = await import('./env')
+    // Missing (vs. malformed) values are tolerated; the build-time
+    // validate-env.js gate is what fails fast on missing required vars.
+    expect(() => get()).not.toThrow()
   })
 })
 
@@ -120,12 +120,22 @@ describe('isProduction / isDevelopment / isMaintenanceMode', () => {
 describe('getApiConfig', () => {
   beforeEach(() => {
     vi.resetModules()
+    delete process.env.NEXT_PUBLIC_API_URL
+    delete process.env.NEXT_PUBLIC_API_BASE
   })
 
-  it('returns API config with base URL', async () => {
+  it('returns API config from the deprecated NEXT_PUBLIC_API_BASE fallback', async () => {
     process.env.NEXT_PUBLIC_API_BASE = 'https://api.example.com'
     const { getApiConfig: getCfg } = await import('./env')
     const config = getCfg()
     expect(config.baseUrl).toBe('https://api.example.com')
+  })
+
+  it('prefers the canonical NEXT_PUBLIC_API_URL over NEXT_PUBLIC_API_BASE', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://canonical.example.com'
+    process.env.NEXT_PUBLIC_API_BASE = 'https://legacy.example.com'
+    const { getApiConfig: getCfg } = await import('./env')
+    const config = getCfg()
+    expect(config.baseUrl).toBe('https://canonical.example.com')
   })
 })

--- a/client/lib/api/env.ts
+++ b/client/lib/api/env.ts
@@ -16,6 +16,9 @@ const envSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1, 'Supabase anon key required').optional(),
 
   // API Configuration
+  // NEXT_PUBLIC_API_URL is the canonical name; NEXT_PUBLIC_API_BASE is the
+  // deprecated alias kept for backward compatibility (see docs/ENVIRONMENT.md).
+  NEXT_PUBLIC_API_URL: z.string().url('Invalid API URL').optional(),
   NEXT_PUBLIC_API_BASE: z.string().url('Invalid API base URL').optional(),
   API_SECRET_KEY: z.string().min(1, 'API secret key required').optional(),
 
@@ -68,6 +71,7 @@ export function getEnv(): Env {
     validatedEnv = envSchema.parse({
       NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
       NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
       NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE,
       API_SECRET_KEY: process.env.API_SECRET_KEY,
       RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
@@ -138,7 +142,9 @@ export function getApiConfig() {
   const defaultBase =
     process.env.NEXT_PUBLIC_APP_ENV === 'staging' ? stagingApi : productionApi
   return {
-    baseUrl: env.NEXT_PUBLIC_API_BASE || defaultBase,
+    // Prefer the canonical NEXT_PUBLIC_API_URL; fall back to the deprecated
+    // NEXT_PUBLIC_API_BASE so existing deployments keep working.
+    baseUrl: env.NEXT_PUBLIC_API_URL || env.NEXT_PUBLIC_API_BASE || defaultBase,
     secretKey: env.API_SECRET_KEY,
     rateLimitEnabled: env.RATE_LIMIT_ENABLED,
   }

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "node scripts/validate-env.js",
     "build": "next build",
     "dev": "next dev",
     "lint": "eslint .",

--- a/client/scripts/env.manifest.js
+++ b/client/scripts/env.manifest.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * Canonical environment manifest for the client (Next.js frontend).
+ *
+ * SINGLE SOURCE OF TRUTH for client environment variable *names*.
+ *
+ * Consumed by:
+ *   - client/scripts/validate-env.js  (build-time presence check + structural check)
+ *   - scripts/check-env-docs.js        (repo-wide structural / drift check)
+ *
+ * Conventions:
+ *   - `NEXT_PUBLIC_*` vars are inlined into the browser bundle at build time.
+ *     Never put a secret behind a NEXT_PUBLIC_ name.
+ *   - Non-prefixed vars are server-only (used by `client/app/api/*` route
+ *     handlers and middleware) and never reach the browser.
+ *   - Pure test/tooling vars (CI, VITEST_STORYBOOK, E2E_BASE_URL) are
+ *     intentionally excluded — they are not application configuration.
+ *
+ * When adding a new client env var, update: this manifest →
+ * client/.env.example → docs/ENVIRONMENT.md.
+ */
+
+/** Required for a production build / runtime. */
+const required = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  // Canonical name for the backend API base URL (was NEXT_PUBLIC_API_BASE).
+  'NEXT_PUBLIC_API_URL',
+  // Stripe: secret key (server-only) + publishable key (browser, Stripe.js).
+  'STRIPE_SECRET_KEY',
+  'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+];
+
+/** Recognized but not required. */
+const optional = [
+  // Public app/runtime config (browser-exposed)
+  'NEXT_PUBLIC_APP_URL',
+  'NEXT_PUBLIC_BACKEND_URL',
+  'NEXT_PUBLIC_APP_ENV',
+  'NEXT_PUBLIC_SENTRY_DSN',
+  'NEXT_PUBLIC_SOROBAN_RPC_URL',
+  'NEXT_PUBLIC_STELLAR_NETWORK',
+  'NEXT_PUBLIC_VAPID_PUBLIC_KEY',
+
+  // Server-only (app/api routes, middleware)
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'API_SECRET_KEY',
+  'JWT_SECRET',
+  'ENCRYPTION_KEY',
+
+  // Payment providers (server-only)
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_TEST_SECRET_KEY',
+  'STRIPE_LIVE_SECRET_KEY',
+  'PAYSTACK_SECRET_KEY',
+  'PAYPAL_CLIENT_ID',
+  'PAYPAL_CLIENT_SECRET',
+  'PAYPAL_MODE',
+  'ENABLE_MOCK_PAYMENTS',
+
+  // System
+  'NODE_ENV',
+  'LOG_LEVEL',
+  'MAINTENANCE_MODE',
+  'ANALYTICS_ID',
+  'SENTRY_DSN',
+
+  // Rate limiting
+  'RATE_LIMIT_ENABLED',
+  'RATE_LIMIT_REDIS_URL',
+  'RATE_LIMIT_IMPORT_MAX',
+  'RATE_LIMIT_IMPORT_WINDOW_MINUTES',
+  'RATE_LIMIT_PAYMENT_MAX',
+  'RATE_LIMIT_PAYMENT_WINDOW_MINUTES',
+  'RATE_LIMIT_TAG_MUTATION_MAX',
+  'RATE_LIMIT_TAG_MUTATION_WINDOW_MINUTES',
+];
+
+/** Deprecated names that must NOT appear as active keys in .env.example. */
+const deprecated = {
+  NEXT_PUBLIC_API_BASE: 'Use NEXT_PUBLIC_API_URL instead',
+};
+
+module.exports = { package: 'client', required, optional, deprecated };

--- a/client/scripts/validate-env.js
+++ b/client/scripts/validate-env.js
@@ -1,31 +1,100 @@
 #!/usr/bin/env node
-// scripts/validate-env.js
-// Run before `next build` to catch missing environment variables early.
+// client/scripts/validate-env.js
+//
+// Two modes:
+//   (default)      Strict presence check. Fails if any REQUIRED var is absent.
+//                  Runs before `next build` (prebuild) and in CI on pushes to
+//                  protected branches (where real secrets exist).
+//
+//   --structural   Drift check only — no secrets needed. Asserts that
+//                  client/.env.example documents exactly the manifest
+//                  (required ∪ optional) and that no deprecated names leak in.
+//                  Safe to run on every PR.
+//
+// Unlike the previous version, this script does NOT bypass failure when
+// process.env.CI is set — CI must fail fast (issue #601).
 
 'use strict';
 
-const required = [
-  'NEXT_PUBLIC_SUPABASE_URL',
-  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  'NEXT_PUBLIC_API_URL',
-  'STRIPE_SECRET_KEY',
-  'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
-];
+const fs = require('fs');
+const path = require('path');
+const manifest = require('./env.manifest');
 
-const missing = required.filter((key) => !process.env[key]);
+const STRUCTURAL = process.argv.includes('--structural');
+const EXAMPLE_PATH = path.join(__dirname, '..', '.env.example');
 
-if (missing.length > 0) {
-  console.error('\n❌ Missing required environment variables:');
-  missing.forEach((key) => console.error(`   - ${key}`));
-  console.error(
-    '\nPlease add them to your .env.local file (locally) or to the Vercel project settings.\n' +
-    'See client/.env.example for the full list of required variables.\n'
-  );
-  if (process.env.CI) {
-    console.warn('⚠️  Running in CI without secrets — skipping hard failure.');
-    process.exit(0);
+/** Parse the top-level KEY= names out of a .env file. */
+function parseEnvExampleKeys(filePath) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const keys = new Set();
+  for (const line of contents.split('\n')) {
+    const match = /^([A-Z_][A-Z0-9_]*)=/.exec(line.trim());
+    if (match) keys.add(match[1]);
   }
-  process.exit(1);
+  return keys;
 }
 
-console.log('✅ All required environment variables are present.');
+function runStructural() {
+  const documented = parseEnvExampleKeys(EXAMPLE_PATH);
+  const declared = new Set([...manifest.required, ...manifest.optional]);
+
+  const missingFromExample = [...declared].filter((k) => !documented.has(k));
+  const undocumentedExtras = [...documented].filter((k) => !declared.has(k));
+  const deprecatedPresent = Object.keys(manifest.deprecated || {}).filter((k) =>
+    documented.has(k),
+  );
+
+  const problems = [];
+  if (missingFromExample.length) {
+    problems.push(
+      'Manifest vars missing from client/.env.example:\n' +
+        missingFromExample.map((k) => `   - ${k}`).join('\n'),
+    );
+  }
+  if (undocumentedExtras.length) {
+    problems.push(
+      'Vars in client/.env.example but not in the manifest (add them to ' +
+        'client/scripts/env.manifest.js):\n' +
+        undocumentedExtras.map((k) => `   - ${k}`).join('\n'),
+    );
+  }
+  if (deprecatedPresent.length) {
+    problems.push(
+      'Deprecated vars still present in client/.env.example:\n' +
+        deprecatedPresent
+          .map((k) => `   - ${k} → ${manifest.deprecated[k]}`)
+          .join('\n'),
+    );
+  }
+
+  if (problems.length) {
+    console.error('\n❌ Client env structural check failed:\n');
+    console.error(problems.join('\n\n'));
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log('✅ Client env manifest and .env.example are in sync.');
+}
+
+function runStrict() {
+  const missing = manifest.required.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    console.error('\n❌ Missing required client environment variables:');
+    missing.forEach((key) => console.error(`   - ${key}`));
+    console.error(
+      '\nAdd them to your .env.local file (locally) or to the Vercel project ' +
+        'settings.\nSee client/.env.example for the full list of variables.\n',
+    );
+    process.exit(1);
+  }
+
+  console.log('✅ All required client environment variables are present.');
+}
+
+if (STRUCTURAL) {
+  runStructural();
+} else {
+  runStrict();
+}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,103 @@
+# Environment Variable Strategy
+
+Canonical reference for how environment variables are defined, documented, and
+validated across every package in this repository (issue #601).
+
+## Principles
+
+1. **One source of truth per package.** Each runtime package owns a
+   `scripts/env.manifest.js` that lists its `required` and `optional` variable
+   **names**. Everything else (validators, `.env.example`, this doc) is checked
+   against the manifest.
+2. **Validation for every runtime package.** No package boots or builds without
+   its required vars present.
+3. **CI fails fast.** Drift between a manifest and its `.env.example` fails on
+   every PR; missing required *secrets* fail on pushes to protected branches.
+4. **Never document a value in only one place.** Adding a var touches the
+   manifest, the schema (if centrally validated), `.env.example`, and this doc.
+
+## Package matrix
+
+| Package        | Env file              | Validation                                                            | Notes |
+|----------------|-----------------------|----------------------------------------------------------------------|-------|
+| **backend**    | `backend/.env.example`| zod schema `backend/src/config/env.ts` (at boot) + `backend/scripts/validate-env.js` | Manifest: `backend/scripts/env.manifest.js` |
+| **client**     | `client/.env.example` | zod helper `client/lib/api/env.ts` (runtime) + `client/scripts/validate-env.js` (prebuild) | Manifest: `client/scripts/env.manifest.js` |
+| **sdk**        | — (none)              | No runtime env. Configured via the client constructor (`new SyncroClient({ apiKey, baseUrl })`). | Library |
+| **shared**     | — (none)              | No runtime env. | Library |
+| **contracts**  | — (none)              | No runtime env in build/test. Deploy scripts read CLI args / Stellar keys at invocation time. | Rust/Soroban |
+| **quota_guard**| — (none)              | No runtime env. | Python helper |
+| root `app/`    | — (none)              | No runtime env. Legacy/secondary Next surface; primary frontend is `client/`. | See "Known follow-ups" |
+
+The repo-wide check `scripts/check-env-docs.js` enforces this matrix: env
+packages must have a manifest + `.env.example` that agree; no-env packages must
+**not** sprout one without being moved into the matrix.
+
+## Required variables
+
+### Backend (required to boot — `backend/src/config/env.ts`)
+
+`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`,
+`JWT_SECRET`, `ADMIN_API_KEY`,
+`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`,
+`STELLAR_NETWORK_URL`, `SOROBAN_CONTRACT_ADDRESS`.
+
+`STRIPE_*` are optional (payments can be disabled); `PORT`, `NODE_ENV`,
+`FRONTEND_URL`, and the feature flags have defaults. The full list lives in
+`backend/scripts/env.manifest.js`. Production additionally enforces mainnet
+Stellar settings — see `backend/src/config/env.ts` and
+[blockchain-feature-flags.md](./blockchain-feature-flags.md).
+
+### Client (required to build — `client/scripts/env.manifest.js`)
+
+`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`,
+`NEXT_PUBLIC_API_URL`, `STRIPE_SECRET_KEY`,
+`NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
+
+## Naming conventions
+
+- **`NEXT_PUBLIC_*`** is inlined into the browser bundle at build time. **Never**
+  put a secret behind a `NEXT_PUBLIC_` name. Non-prefixed client vars are
+  server-only (`client/app/api/*`, middleware).
+- **`NEXT_PUBLIC_API_URL`** is the canonical backend base-URL name.
+  **`NEXT_PUBLIC_API_BASE`** is **deprecated** — still read as a fallback so
+  existing deployments keep working, but new config must use
+  `NEXT_PUBLIC_API_URL`. Plan to remove the fallback once all environments are
+  migrated.
+
+## CI enforcement model
+
+The `validate-env` job in `.github/workflows/ci.yml`:
+
+- **Structural step (every run — PRs + pushes):** runs
+  `scripts/check-env-docs.js` plus `validate-env.js --structural` for backend
+  and client. No secrets required; fails on any manifest ↔ `.env.example` drift.
+  Forked/contributor PRs are never blocked by absent secrets.
+- **Strict step (`push` to `main`/`develop` only):** injects the real secrets
+  and runs `validate-env.js` (no flag). Hard-fails if any required var is
+  missing. The validators no longer bypass failure when `CI` is set.
+
+## How to add a new environment variable
+
+1. Add the name to the package's `scripts/env.manifest.js` (`required` or
+   `optional`).
+2. If the backend validates it centrally, add a field to the zod schema in
+   `backend/src/config/env.ts` (required ⇔ no `.optional()`/`.default()` — the
+   parity test enforces this).
+3. Document it in the package's `.env.example` with a placeholder.
+4. Update this file if it changes the required set or conventions.
+5. If it's a new **required secret**, add it to the strict CI step's `env:`
+   block and to your deployment provider (Vercel / Render / GitHub secrets).
+
+Run locally before pushing:
+
+```bash
+node scripts/check-env-docs.js                  # repo-wide drift check
+node backend/scripts/validate-env.js --structural
+node client/scripts/validate-env.js --structural
+```
+
+## Known follow-ups (out of scope for #601)
+
+- The root `app/` directory has no `package.json` and no `next` dependency and
+  consumes no env; it appears vestigial next to `client/`. Consolidating or
+  removing it is tracked separately.

--- a/scripts/check-env-docs.js
+++ b/scripts/check-env-docs.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// scripts/check-env-docs.js
+//
+// Repo-wide STRUCTURAL env check (issue #601). Secret-free — safe to run on
+// every PR. Asserts the canonical env strategy holds:
+//
+//   - Each runtime package that consumes env has an env.manifest.js and an
+//     .env.example, and they are in perfect sync (every manifest var is
+//     documented, every documented var is in the manifest, no deprecated
+//     names leak into .env.example).
+//   - Each library / non-JS package that consumes NO runtime env stays that
+//     way (no manifest, no .env.example) — so the "no env" claim in
+//     docs/ENVIRONMENT.md is enforced, not just asserted in prose.
+//
+// Exits non-zero on any drift. See docs/ENVIRONMENT.md.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+/** Packages that consume runtime env: each must have a manifest + .env.example. */
+const ENV_PACKAGES = [
+  { name: 'backend', dir: 'backend' },
+  { name: 'client', dir: 'client' },
+];
+
+/** Packages with NO runtime env: must NOT carry a manifest or .env.example. */
+const NO_ENV_PACKAGES = [
+  { name: 'sdk', dir: 'sdk' },
+  { name: 'shared', dir: 'shared' },
+  { name: 'contracts', dir: 'contracts' },
+  { name: 'quota_guard', dir: 'quota_guard' },
+];
+
+/** Parse the top-level KEY= names out of a .env file. */
+function parseEnvExampleKeys(filePath) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const keys = new Set();
+  for (const line of contents.split('\n')) {
+    const match = /^([A-Z_][A-Z0-9_]*)=/.exec(line.trim());
+    if (match) keys.add(match[1]);
+  }
+  return keys;
+}
+
+const problems = [];
+
+for (const pkg of ENV_PACKAGES) {
+  const manifestPath = path.join(ROOT, pkg.dir, 'scripts', 'env.manifest.js');
+  const examplePath = path.join(ROOT, pkg.dir, '.env.example');
+
+  if (!fs.existsSync(manifestPath)) {
+    problems.push(`[${pkg.name}] missing env manifest: ${pkg.dir}/scripts/env.manifest.js`);
+    continue;
+  }
+  if (!fs.existsSync(examplePath)) {
+    problems.push(`[${pkg.name}] missing ${pkg.dir}/.env.example`);
+    continue;
+  }
+
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const manifest = require(manifestPath);
+  const declared = new Set([...manifest.required, ...manifest.optional]);
+  const documented = parseEnvExampleKeys(examplePath);
+
+  for (const key of declared) {
+    if (!documented.has(key)) {
+      problems.push(`[${pkg.name}] manifest var not documented in .env.example: ${key}`);
+    }
+  }
+  for (const key of documented) {
+    if (!declared.has(key)) {
+      problems.push(
+        `[${pkg.name}] .env.example var not in manifest (add to ${pkg.dir}/scripts/env.manifest.js): ${key}`,
+      );
+    }
+  }
+  for (const key of Object.keys(manifest.deprecated || {})) {
+    if (documented.has(key)) {
+      problems.push(
+        `[${pkg.name}] deprecated var present in .env.example: ${key} → ${manifest.deprecated[key]}`,
+      );
+    }
+  }
+
+  // Required must be a subset of optional-free required (no key in both lists).
+  const overlap = manifest.required.filter((k) => manifest.optional.includes(k));
+  if (overlap.length) {
+    problems.push(`[${pkg.name}] vars listed in both required and optional: ${overlap.join(', ')}`);
+  }
+}
+
+for (const pkg of NO_ENV_PACKAGES) {
+  const manifestPath = path.join(ROOT, pkg.dir, 'scripts', 'env.manifest.js');
+  const examplePath = path.join(ROOT, pkg.dir, '.env.example');
+  if (fs.existsSync(manifestPath) || fs.existsSync(examplePath)) {
+    problems.push(
+      `[${pkg.name}] is declared as a no-env package but has a manifest/.env.example. ` +
+        'If it now needs runtime env, move it to ENV_PACKAGES and document it in docs/ENVIRONMENT.md.',
+    );
+  }
+}
+
+if (problems.length) {
+  console.error('\n❌ Env documentation structural check failed:\n');
+  problems.forEach((p) => console.error(`   - ${p}`));
+  console.error('\nSee docs/ENVIRONMENT.md for the canonical env strategy.\n');
+  process.exit(1);
+}
+
+console.log('✅ Env manifests and .env.example files are consistent across all packages.');


### PR DESCRIPTION
Environment variables were validated in several places with inconsistent expectations, and CI validation was a no-op.

- Add per-package env manifests (backend/scripts/env.manifest.js, client/scripts/env.manifest.js) as the single source of truth for var names.
- Rewrite both validate-env.js scripts to consume the manifest; add a secret-free --structural drift mode and remove the `process.env.CI` bypass so CI fails fast on missing required vars.
- Reconcile backend validators to the zod schema; add the previously missing required SUPABASE_* and SMTP_* vars to backend/.env.example.
- Standardize the client on NEXT_PUBLIC_API_URL (NEXT_PUBLIC_API_BASE kept as a deprecated fallback); add client/.env.example and a build-time prebuild gate.
- Add scripts/check-env-docs.js for a repo-wide structural check, and wire ci.yml to run it on every PR plus a strict secret check on pushes to main/develop.
- Document the strategy in docs/ENVIRONMENT.md (linked from README).
- Add backend manifest/zod parity tests and client API-URL fallback tests; fix pre-existing broken getEnv tests in client/lib/api/env.test.ts.


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed


Closes: #601 