### PR TITLE
Replace createApiRoute with createAuthenticatedApiRoute for enhanced security across multiple endpoints

### DIFF
--- a/client/API_SECURITY_QUICK_REFERENCE.md
+++ b/client/API_SECURITY_QUICK_REFERENCE.md
@@ -6,7 +6,7 @@
 
 Before merging any new API route, ensure:
 
-- [ ] Uses `createApiRoute` with `requireAuth: true` for protected endpoints
+- [ ] Uses `createAuthenticatedApiRoute` for protected endpoints
 - [ ] Explicitly verifies resource ownership (don't rely on implicit checks)
 - [ ] Applies appropriate rate limiting (`RateLimiters.standard` or `.strict`)
 - [ ] Uses `ApiErrors` for consistent error responses
@@ -20,13 +20,11 @@ Before merging any new API route, ensure:
 ### Template 1: Simple Protected Route (No Ownership)
 ```typescript
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) throw ApiErrors.unauthorized()
-    
     // Your logic here - user is authenticated
     const data = await fetchUserData(user.id)
     
@@ -37,7 +35,6 @@ export const GET = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )
@@ -46,7 +43,7 @@ export const GET = createApiRoute(
 ### Template 2: Resource Route with Ownership Check
 ```typescript
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { createClient } from "@/lib/supabase/server"
 
@@ -56,10 +53,8 @@ export async function DELETE(
 ) {
   const { id } = await params
   
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      if (!user) throw ApiErrors.unauthorized()
-      
       const supabase = await createClient()
       
       // ALWAYS verify ownership first
@@ -85,7 +80,6 @@ export async function DELETE(
       )
     },
     {
-      requireAuth: true,
       rateLimit: RateLimiters.standard,
     }
   )(request)
@@ -184,14 +178,10 @@ export async function PATCH(request, { params }) {
 ### ❌ DON'T: Forget Rate Limiting on Sensitive Operations
 ```typescript
 // VULNERABLE - No rate limiting
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request, context, user) => {
     await processPayment(user.id, amount)
     return createSuccessResponse({ success: true })
-  },
-  {
-    requireAuth: true,
-    // ❌ No rate limiting
   }
 )
 ```
@@ -199,13 +189,12 @@ export const POST = createApiRoute(
 ### ✅ DO: Apply Appropriate Rate Limiting
 ```typescript
 // SECURE - Rate limiting applied
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request, context, user) => {
     await processPayment(user.id, amount)
     return createSuccessResponse({ success: true })
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.strict, // ✅ Strict for payments
   }
 )
@@ -216,14 +205,12 @@ export const POST = createApiRoute(
 ### ❌ DON'T: Use Generic Error Messages
 ```typescript
 // INCONSISTENT
-if (!user) throw new Error("Not authenticated")
 if (!resource) throw new Error("Not found")
 ```
 
 ### ✅ DO: Use ApiErrors for Consistency
 ```typescript
 // CONSISTENT
-if (!user) throw ApiErrors.unauthorized()
 if (!resource) throw ApiErrors.notFound("Resource")
 if (user.id !== resource.user_id) throw ApiErrors.forbidden()
 ```

--- a/client/app/api/analytics/route.ts
+++ b/client/app/api/analytics/route.ts
@@ -1,14 +1,10 @@
 import { type NextRequest } from "next/server"
 import { HttpStatus } from "@/lib/api/types"
 import { createClient } from "@/lib/supabase/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
 
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) {
-      throw ApiErrors.unauthorized("User not authenticated")
-    }
-
     const supabase = await createClient()
 
     const { data: subscriptions, error } = await supabase
@@ -61,7 +57,6 @@ export const GET = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )

--- a/client/app/api/payments/paypal/capture/route.ts
+++ b/client/app/api/payments/paypal/capture/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, ApiErrors, RateLimiters, validateRequestBody } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, ApiErrors, RateLimiters, validateRequestBody } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { PaymentService } from "@/lib/payment-service"
 import { z } from "zod"
@@ -14,12 +14,8 @@ const captureSchema = z.object({
     planName: z.string().min(1, "Plan name is required"),
 })
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
     async (request: NextRequest, context, user) => {
-        if (!user) {
-            throw ApiErrors.unauthorized("User not authenticated")
-        }
-
         const validated = await validateRequestBody(request, captureSchema)
 
         const paymentService = new PaymentService({
@@ -57,7 +53,6 @@ export const POST = createApiRoute(
         )
     },
     {
-        requireAuth: true,
         rateLimit: RateLimiters.payment,
         idempotent: true,
     }

--- a/client/app/api/payments/refund/route.ts
+++ b/client/app/api/payments/refund/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { PaymentService } from "@/lib/payment-service"
@@ -10,12 +10,8 @@ const refundSchema = z.object({
   transactionId: z.string().min(1, "Transaction ID is required"),
 })
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) {
-      throw ApiErrors.unauthorized("User not authenticated")
-    }
-
     // Validate request body
     const body = await validateRequestBody(request, refundSchema)
 
@@ -60,7 +56,6 @@ export const POST = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.payment,
     idempotent: true,
   }

--- a/client/app/api/payments/route.ts
+++ b/client/app/api/payments/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { PaymentService } from "@/lib/payment-service"
@@ -23,12 +23,8 @@ const paymentSchema = z.object({
   })
 );
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) {
-      throw ApiErrors.unauthorized("User not authenticated");
-    }
-
     const body = await validateRequestBody(request, paymentSchema);
 
     const paymentService = new PaymentService({
@@ -67,7 +63,6 @@ export const POST = createApiRoute(
     );
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.payment,
     idempotent: true,
   },

--- a/client/app/api/subscriptions/[id]/notes/route.ts
+++ b/client/app/api/subscriptions/[id]/notes/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { updateSubscriptionNotes } from "@/lib/supabase/tags"
@@ -15,10 +15,8 @@ export async function PATCH(
 ) {
   const { id } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      if (!user) throw ApiErrors.unauthorized()
-
       const { notes } = await validateRequestBody(request, notesSchema)
 
       const supabase = await createClient()
@@ -41,6 +39,6 @@ export async function PATCH(
 
       return createSuccessResponse({ updated: true }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.standard },
+    { rateLimit: RateLimiters.standard },
   )(request)
 }

--- a/client/app/api/subscriptions/[id]/pause/route.ts
+++ b/client/app/api/subscriptions/[id]/pause/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest } from "next/server"
 import { z } from "zod"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { createClient } from "@/lib/supabase/server"
 import { checkOwnership } from "@/lib/api/auth"
@@ -16,9 +16,8 @@ export async function POST(
 ) {
   const { id } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) throw ApiErrors.unauthorized("User not authenticated")
       if (!id) throw ApiErrors.notFound("Subscription")
 
       const body = await validateRequestBody(req, pauseSchema)
@@ -62,6 +61,6 @@ export async function POST(
 
       return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.standard }
+    { rateLimit: RateLimiters.standard }
   )(request)
 }

--- a/client/app/api/subscriptions/[id]/resume/route.ts
+++ b/client/app/api/subscriptions/[id]/resume/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { createClient } from "@/lib/supabase/server"
 import { checkOwnership } from "@/lib/api/auth"
@@ -10,9 +10,8 @@ export async function POST(
 ) {
   const { id } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) throw ApiErrors.unauthorized("User not authenticated")
       if (!id) throw ApiErrors.notFound("Subscription")
 
       const supabase = await createClient()
@@ -47,6 +46,6 @@ export async function POST(
 
       return createSuccessResponse({ subscription: data }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.standard }
+    { rateLimit: RateLimiters.standard }
   )(request)
 }

--- a/client/app/api/subscriptions/[id]/route.ts
+++ b/client/app/api/subscriptions/[id]/route.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { createClient } from "@/lib/supabase/server"
 import { checkOwnership } from "@/lib/api/auth"
-import { ApiErrors, createApiRoute, createSuccessResponse, RateLimiters, validateRequestBody } from "@/lib/api/index"
+import { ApiErrors, createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, validateRequestBody } from "@/lib/api/index"
 
 // Validation schemas
 const updateSubscriptionSchema = z.object({
@@ -25,12 +25,8 @@ export async function DELETE(
 ) {
   const { id } = await params
   
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) {
-        throw ApiErrors.unauthorized("User not authenticated")
-      }
-
       if (!id) {
         throw ApiErrors.notFound("Subscription")
       }
@@ -68,7 +64,6 @@ export async function DELETE(
       )
     },
     {
-      requireAuth: true,
       rateLimit: RateLimiters.standard,
     }
   )(request)
@@ -80,12 +75,8 @@ export async function PATCH(
 ) {
   const { id } = await params
   
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (req: NextRequest, context, user) => {
-      if (!user) {
-        throw ApiErrors.unauthorized("User not authenticated")
-      }
-
       if (!id) {
         throw ApiErrors.notFound("Subscription")
       }
@@ -137,7 +128,6 @@ export async function PATCH(
       )
     },
     {
-      requireAuth: true,
       rateLimit: RateLimiters.standard,
     }
   )(request)

--- a/client/app/api/subscriptions/[id]/tags/[tagId]/route.ts
+++ b/client/app/api/subscriptions/[id]/tags/[tagId]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { removeTagFromSubscription } from "@/lib/supabase/tags"
 import { createClient } from "@/lib/supabase/server"
@@ -10,10 +10,8 @@ export async function DELETE(
 ) {
   const { id, tagId } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      if (!user) throw ApiErrors.unauthorized()
-
       const supabase = await createClient()
 
       // Verify subscription ownership
@@ -34,6 +32,6 @@ export async function DELETE(
 
       return createSuccessResponse({ removed: true }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.tagMutation },
+    { rateLimit: RateLimiters.tagMutation },
   )(request)
 }

--- a/client/app/api/subscriptions/[id]/tags/route.ts
+++ b/client/app/api/subscriptions/[id]/tags/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { addTagToSubscription } from "@/lib/supabase/tags"
@@ -15,10 +15,8 @@ export async function POST(
 ) {
   const { id } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      if (!user) throw ApiErrors.unauthorized()
-
       const { tag_id } = await validateRequestBody(request, bodySchema)
 
       const supabase = await createClient()
@@ -54,6 +52,6 @@ export async function POST(
 
       return createSuccessResponse({ assigned: true }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.tagMutation },
+    { rateLimit: RateLimiters.tagMutation },
   )(request)
 }

--- a/client/app/api/subscriptions/__tests__/route.test.ts
+++ b/client/app/api/subscriptions/__tests__/route.test.ts
@@ -9,10 +9,14 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }))
 
-vi.mock("@/lib/api/auth", () => ({
-  requireAuth: vi.fn(),
-  createRequestContext: vi.fn().mockReturnValue({ requestId: "test-id" }),
-}))
+vi.mock("@/lib/api/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/auth")>()
+  return {
+    ...actual,
+    requireAuth: vi.fn(),
+    createRequestContext: vi.fn().mockReturnValue({ requestId: "test-id" }),
+  }
+})
 
 describe("Subscriptions API Route", () => {
   let supabase: any

--- a/client/app/api/subscriptions/import/route.ts
+++ b/client/app/api/subscriptions/import/route.ts
@@ -9,7 +9,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { z } from "zod"
-import { ApiErrors, RateLimiters, createErrorResponse, validateCsrfToken } from "@/lib/api/index"
+import { ApiErrors, RateLimiters, createErrorResponse, getAuthenticatedUser, validateCsrfToken } from "@/lib/api/index"
 import { ApiException } from "@/lib/api/errors"
 import { applyRateLimitHeaders, type RateLimitHeaders } from "@/lib/api/rate-limit"
 
@@ -123,11 +123,8 @@ export async function POST(request: NextRequest) {
 
     rateLimitHeaders = RateLimiters.import(request)
 
+    const user = await getAuthenticatedUser(request)
     const supabase = await createClient()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    if (!user) return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 })
 
     const isCommit = request.nextUrl.searchParams.get("commit") === "true"
     const skipDupes = request.nextUrl.searchParams.get("skip_dupes") !== "false"
@@ -221,7 +218,7 @@ export async function POST(request: NextRequest) {
       const result = rowSchema.safeParse(dataToValidate)
 
       if (!result.success) {
-        const msg = result.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ")
+        const msg = result.error.issues.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ")
         return { row: rowNum, status: "error" as RowStatus, data: null, error: msg }
       }
 

--- a/client/app/api/subscriptions/route.ts
+++ b/client/app/api/subscriptions/route.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { createClient } from "@/lib/supabase/server"
 import { CommonSchemas, validateRequestBody } from "@/lib/api/validation"
-import { createApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
+import { ApiErrors, createAuthenticatedApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
 
 // Validation schemas
 const createSubscriptionSchema = z.object({
@@ -20,12 +20,8 @@ const getSubscriptionsSchema = CommonSchemas.pagination.extend({
   category: z.string().optional(),
 })
 
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) {
-      throw ApiErrors.unauthorized("User not authenticated")
-    }
-
     // Validate query parameters
     const url = new URL(request.url)
     const queryParams: Record<string, string> = {}
@@ -82,17 +78,12 @@ export const GET = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    if (!user) {
-      throw ApiErrors.unauthorized("User not authenticated")
-    }
-
     // Validate request body
     const body = await validateRequestBody(request, createSubscriptionSchema)
 
@@ -122,7 +113,6 @@ export const POST = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )

--- a/client/app/api/tags/[id]/route.ts
+++ b/client/app/api/tags/[id]/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { deleteTag } from "@/lib/supabase/tags"
 
@@ -9,13 +9,11 @@ export async function DELETE(
 ) {
   const { id } = await params
 
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      if (!user) throw ApiErrors.unauthorized("User not authenticated")
-
       await deleteTag(id, user.id)
       return createSuccessResponse({ deleted: true }, HttpStatus.OK, context.requestId)
     },
-    { requireAuth: true, rateLimit: RateLimiters.tagMutation },
+    { rateLimit: RateLimiters.tagMutation },
   )(request)
 }

--- a/client/app/api/tags/route.ts
+++ b/client/app/api/tags/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server"
-import { createApiRoute, createSuccessResponse, validateRequestBody, RateLimiters } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { fetchUserTags, createTag } from "@/lib/supabase/tags"
@@ -12,24 +12,20 @@ const createTagSchema = z.object({
     .default("#6366f1"),
 })
 
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (_req, context, user) => {
-    if (!user) throw ApiErrors.unauthorized("User not authenticated")
-
     const tags = await fetchUserTags(user.id)
     return createSuccessResponse({ tags }, HttpStatus.OK, context.requestId)
   },
-  { requireAuth: true, rateLimit: RateLimiters.standard },
+  { rateLimit: RateLimiters.standard },
 )
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request, context, user) => {
-    if (!user) throw ApiErrors.unauthorized("User not authenticated")
-
     const { name, color } = await validateRequestBody(request as NextRequest, createTagSchema)
     const tag = await createTag(user.id, name, color)
 
     return createSuccessResponse({ tag }, HttpStatus.CREATED, context.requestId)
   },
-  { requireAuth: true, rateLimit: RateLimiters.tagMutation },
+  { rateLimit: RateLimiters.tagMutation },
 )

--- a/client/lib/api/README.md
+++ b/client/lib/api/README.md
@@ -21,11 +21,11 @@ lib/api/
 ### Basic Protected Route
 
 ```typescript
-import { createApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { type NextRequest } from "next/server"
 
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
     // user is guaranteed to be authenticated
     // Your route logic here
@@ -37,7 +37,6 @@ export const GET = createApiRoute(
     )
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )
@@ -46,7 +45,7 @@ export const GET = createApiRoute(
 ### Route with Validation
 
 ```typescript
-import { createApiRoute, validateRequestBody, RateLimiters } from "@/lib/api"
+import { createAuthenticatedApiRoute, validateRequestBody, RateLimiters } from "@/lib/api/index"
 import { z } from "zod"
 import { type NextRequest } from "next/server"
 
@@ -55,7 +54,7 @@ const createSchema = z.object({
   email: z.string().email(),
 })
 
-export const POST = createApiRoute(
+export const POST = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
     const body = await validateRequestBody(request, createSchema)
     
@@ -65,7 +64,6 @@ export const POST = createApiRoute(
     return createSuccessResponse({ success: true })
   },
   {
-    requireAuth: true,
     rateLimit: RateLimiters.standard,
   }
 )
@@ -80,13 +78,12 @@ export async function DELETE(
 ) {
   const { id } = await params
   
-  return createApiRoute(
+  return createAuthenticatedApiRoute(
     async (req, context, user) => {
       // Use id here
       return createSuccessResponse({ deleted: id })
     },
     {
-      requireAuth: true,
       rateLimit: RateLimiters.standard,
     }
   )(request)
@@ -97,7 +94,7 @@ export async function DELETE(
 
 ### 1. Authentication & Authorization
 
-- **Automatic authentication**: Use `requireAuth: true` in route options
+- **Automatic authentication**: Use `createAuthenticatedApiRoute` for protected endpoints
 - **Role-based access**: Use `requireRole: ['admin', 'moderator']`
 - **User context**: Access authenticated user in route handler
 
@@ -117,7 +114,7 @@ checkOwnership(user.id, resourceUserId)
 - **Body, query, and params validation**
 
 ```typescript
-import { validateRequestBody, validateQueryParams, CommonSchemas } from "@/lib/api"
+import { validateRequestBody, validateQueryParams, CommonSchemas } from "@/lib/api/index"
 
 // Validate body
 const body = await validateRequestBody(request, schema)
@@ -147,7 +144,7 @@ throw ApiErrors.validationError("Invalid email", "email")
 - **Response headers**: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After` (429)
 
 ```typescript
-import { RateLimiters } from "@/lib/api"
+import { RateLimiters } from "@/lib/api/index"
 
 // High-risk mutations
 rateLimit: RateLimiters.payment
@@ -235,7 +232,7 @@ All API responses follow a standard format:
 
 ## Best Practices
 
-1. **Always use `createApiRoute`** for consistent error handling
+1. **Always use `createApiRoute`** for public endpoints and `createAuthenticatedApiRoute` for protected endpoints
 2. **Validate all inputs** with Zod schemas
 3. **Use appropriate rate limits** based on endpoint sensitivity
 4. **Check ownership** for resource operations
@@ -249,7 +246,7 @@ All API responses follow a standard format:
 The infrastructure is designed to be testable:
 
 ```typescript
-import { createApiRoute } from "@/lib/api"
+import { createApiRoute } from "@/lib/api/index"
 import { createMocks } from "node-mocks-http"
 
 // Mock request
@@ -286,13 +283,12 @@ export async function GET(request: NextRequest) {
 ### After
 
 ```typescript
-export const GET = createApiRoute(
+export const GET = createAuthenticatedApiRoute(
   async (request, context, user) => {
     // user is guaranteed, errors handled automatically
     // ... logic
     return createSuccessResponse({ data })
-  },
-  { requireAuth: true }
+  }
 )
 ```
 
@@ -303,4 +299,3 @@ export const GET = createApiRoute(
 3. **Monitoring**: Add metrics collection
 4. **Caching**: Implement response caching where appropriate
 5. **Database**: Use connection pooling and query optimization
-

--- a/client/lib/api/auth.test.ts
+++ b/client/lib/api/auth.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { requireRole, requireMinRole, withAuth, getAuthenticatedUser, UserRole, ROLE_HIERARCHY } from './auth'
+import {
+  assertAuthenticatedUser,
+  requireRole,
+  requireMinRole,
+  withAuth,
+  getAuthenticatedUser,
+  UserRole,
+  ROLE_HIERARCHY,
+} from './auth'
+import { createAuthenticatedApiRoute, createSuccessResponse } from './index'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 
@@ -58,6 +67,12 @@ describe('Auth Middleware', () => {
       await expect(getAuthenticatedUser(new NextRequest('http://localhost'))).rejects.toThrow(
         'Invalid or expired session'
       )
+    })
+  })
+
+  describe('assertAuthenticatedUser', () => {
+    it('throws the shared unauthorized error when a protected route has no user', () => {
+      expect(() => assertAuthenticatedUser(null)).toThrow('Invalid or expired session')
     })
   })
 
@@ -256,6 +271,43 @@ describe('Auth Middleware', () => {
       await expect(
         withAuth(handler, { requireRole: ['admin'] })(new NextRequest('http://localhost'))
       ).rejects.toThrow('Requires one of: admin')
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createAuthenticatedApiRoute', () => {
+    it('passes the authenticated user to the handler', async () => {
+      const mockUser = { id: '123', email: 'test@example.com' }
+      vi.mocked(createClient).mockResolvedValue(mockSupabaseWith({ user: mockUser }) as any)
+
+      const handler = vi.fn().mockResolvedValue(createSuccessResponse({ ok: true }))
+      const route = createAuthenticatedApiRoute(handler)
+      const request = new NextRequest('http://localhost')
+
+      const response = await route(request)
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(handler).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({ userId: '123', userEmail: 'test@example.com' }),
+        mockUser
+      )
+    })
+
+    it('returns the standard API error response when the session is missing', async () => {
+      vi.mocked(createClient).mockResolvedValue(mockSupabaseWith({ user: null }) as any)
+
+      const handler = vi.fn()
+      const route = createAuthenticatedApiRoute(handler)
+      const response = await route(new NextRequest('http://localhost'))
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body.success).toBe(false)
+      expect(body.error.code).toBe('UNAUTHORIZED')
+      expect(body.error.message).toBe('Invalid or expired session')
       expect(handler).not.toHaveBeenCalled()
     })
   })

--- a/client/lib/api/auth.ts
+++ b/client/lib/api/auth.ts
@@ -25,6 +25,21 @@ export async function getAuthenticatedUser(request: NextRequest) {
   return user
 }
 
+export type AuthenticatedUser = NonNullable<Awaited<ReturnType<typeof getAuthenticatedUser>>>
+
+/**
+ * Assert that route infrastructure supplied an authenticated user.
+ * This keeps auth failure responses consistent even when route handlers are
+ * tested with mocked auth functions.
+ */
+export function assertAuthenticatedUser(
+  user: Awaited<ReturnType<typeof getAuthenticatedUser>> | null | undefined
+): asserts user is AuthenticatedUser {
+  if (!user) {
+    throw ApiErrors.unauthorized('Invalid or expired session')
+  }
+}
+
 /**
  * Create request context from request
  */

--- a/client/lib/api/errors.ts
+++ b/client/lib/api/errors.ts
@@ -90,12 +90,13 @@ export const ApiErrors = {
  * Convert Zod validation errors to API errors
  */
 export function zodErrorToApiError(error: ZodError): ApiException {
-  const firstError = error.errors[0]
+  const issues = error.issues
+  const firstError = issues[0]
   const field = firstError?.path.join('.')
   const message = firstError?.message || 'Validation failed'
 
   return ApiErrors.validationError(message, field, {
-    errors: error.errors.map((e) => ({
+    errors: issues.map((e) => ({
       field: e.path.join('.'),
       message: e.message,
       code: e.code,
@@ -204,4 +205,3 @@ export function withErrorHandling<T extends unknown[]>(
     }
   }
 }
-

--- a/client/lib/api/index.ts
+++ b/client/lib/api/index.ts
@@ -32,7 +32,13 @@ export * from './csrf'
  */
 import { NextResponse, type NextRequest } from 'next/server'
 import { withErrorHandling, createSuccessResponse } from './errors'
-import { requireAuth, requireRole, createRequestContext, type UserRole } from './auth'
+import {
+  requireAuth,
+  requireRole,
+  createRequestContext,
+  type AuthenticatedUser,
+  type UserRole,
+} from './auth'
 import { type RequestContext, type ApiResponse } from './types'
 import { isMaintenanceMode } from './env'
 import { ApiErrors } from './errors'
@@ -53,6 +59,22 @@ type RouteOptions = {
   skipMaintenanceCheck?: boolean
   idempotent?: boolean
   skipCsrf?: boolean
+}
+
+type AuthenticatedRouteHandler = (
+  request: NextRequest,
+  context: RequestContext,
+  user: AuthenticatedUser
+) => Promise<NextResponse<ApiResponse>>
+
+type AuthenticatedRouteOptions = Omit<RouteOptions, 'requireAuth'>
+
+function assertRouteUser(
+  user: Awaited<ReturnType<typeof requireAuth>> | null | undefined
+): asserts user is AuthenticatedUser {
+  if (!user) {
+    throw ApiErrors.unauthorized('Invalid or expired session')
+  }
 }
 
 export function createApiRoute(
@@ -81,6 +103,7 @@ export function createApiRoute(
     let user: Awaited<ReturnType<typeof requireAuth>> | undefined
     if (options.requireAuth) {
       user = await requireAuth(request)
+      assertRouteUser(user)
       context.userId = user.id
       context.userEmail = user.email
 
@@ -158,4 +181,20 @@ export function createApiRoute(
 
     return response
   }, crypto.randomUUID())
+}
+
+export function createAuthenticatedApiRoute(
+  handler: AuthenticatedRouteHandler,
+  options: AuthenticatedRouteOptions = {}
+) {
+  return createApiRoute(
+    async (request, context, user) => {
+      assertRouteUser(user)
+      return handler(request, context, user)
+    },
+    {
+      ...options,
+      requireAuth: true,
+    }
+  )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "drips",
+  "name": "SYNCRO",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,


### PR DESCRIPTION
## Description

Adds a shared authenticated API route wrapper for Next route handlers. Protected routes can now use createAuthenticatedApiRoute, which centralizes session lookup, standardizes unauthenticated error shaping, and passes a non-optional authenticated user into handlers. This removes repeated if (!user) checks from protected route files and updates API docs/security guidance.

Also updates Zod v4 validation error handling to use issues, preserving consistent 400 validation responses.

---

## Related Issue

Closes #620 

---

## Test Plan

- [x] Tested locally
- [x] Verified expected behavior
- [x] No regressions introduced

---

## Screenshots (if applicable)
N/A
---

## Checklist

- [x] Code builds successfully
- [x] Tests pass
- [x] Follows project conventions
- [x] No sensitive data exposed
