### PR TITLE
feat: implement P1 issues #613 #608 #610 #609

### DIFF
--- a/client/__tests__/analytics-page.test.tsx
+++ b/client/__tests__/analytics-page.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Tests for #608 — Analytics empty states
+ *
+ * Covers:
+ * - Loading skeleton (aria-busy)
+ * - Empty state (no subscriptions) with CTA link
+ * - Error state with actionable copy and retry
+ * - Network vs server error copy distinction
+ * - Successful data render
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AnalyticsRoute from '@/app/dashboard/analytics/page';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('@/lib/api/analytics', () => ({
+  analyticsApi: {
+    getSummary: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/pages/analytics', () => ({
+  default: () => <div data-testid="analytics-page">Analytics Content</div>,
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className }: any) => <div data-testid="skeleton" className={className} />,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { analyticsApi } from '@/lib/api/analytics';
+const mockGetSummary = analyticsApi.getSummary as ReturnType<typeof vi.fn>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const emptySummary = {
+  total_monthly_spend: 0,
+  active_subscriptions: 0,
+  upcoming_renewals_count: 0,
+  monthly_trend: [],
+  category_breakdown: [],
+  top_subscriptions: [],
+  budget_status: { overall_limit: null, current_spend: 0, percentage: 0 },
+};
+
+const activeSummary = { ...emptySummary, active_subscriptions: 3 };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AnalyticsRoute — loading state', () => {
+  it('renders loading skeletons with aria-busy', async () => {
+    // Never resolves during this test
+    mockGetSummary.mockReturnValue(new Promise(() => {}));
+
+    render(<AnalyticsRoute />);
+
+    const container = screen.getByLabelText(/loading analytics/i);
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+});
+
+describe('AnalyticsRoute — empty state', () => {
+  beforeEach(() => {
+    mockGetSummary.mockResolvedValue(emptySummary);
+  });
+
+  it('renders empty state heading', async () => {
+    render(<AnalyticsRoute />);
+    expect(await screen.findByRole('heading', { name: /no analytics yet/i })).toBeInTheDocument();
+  });
+
+  it('renders CTA link to add subscription', async () => {
+    render(<AnalyticsRoute />);
+    const link = await screen.findByRole('link', { name: /add your first subscription/i });
+    expect(link).toHaveAttribute('href', '/dashboard?action=add');
+  });
+
+  it('empty state section has accessible label', async () => {
+    render(<AnalyticsRoute />);
+    await screen.findByRole('heading', { name: /no analytics yet/i });
+    expect(screen.getByRole('region', { name: /no analytics yet/i })).toBeInTheDocument();
+  });
+});
+
+describe('AnalyticsRoute — error state', () => {
+  it('renders generic error copy for server errors', async () => {
+    mockGetSummary.mockRejectedValue(new Error('500 Internal Server Error'));
+
+    render(<AnalyticsRoute />);
+
+    expect(await screen.findByText(/failed to load analytics data/i)).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renders network-specific error copy for TypeError network errors', async () => {
+    const networkErr = new TypeError('network request failed');
+    mockGetSummary.mockRejectedValue(networkErr);
+
+    render(<AnalyticsRoute />);
+
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it('retry button re-fetches data', async () => {
+    mockGetSummary
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(activeSummary);
+
+    render(<AnalyticsRoute />);
+    const user = userEvent.setup();
+
+    await screen.findByRole('alert');
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('analytics-page')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('AnalyticsRoute — data state', () => {
+  it('renders analytics content when data is available', async () => {
+    mockGetSummary.mockResolvedValue(activeSummary);
+
+    render(<AnalyticsRoute />);
+
+    expect(await screen.findByTestId('analytics-page')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /spending analytics/i })).toBeInTheDocument();
+  });
+});

--- a/client/__tests__/offline.test.tsx
+++ b/client/__tests__/offline.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for #609 — Offline experience
+ *
+ * Covers:
+ * - offline-cache.ts: save/load/timestamp/clear
+ * - OfflinePage: renders cached subscriptions, shows SW warning, retry button
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  saveSubscriptionsOffline,
+  loadOfflineSubscriptions,
+  getOfflineCacheTimestamp,
+  clearOfflineCache,
+  type OfflineSubscription,
+} from '@/lib/offline-cache';
+
+// ─── offline-cache.ts unit tests ─────────────────────────────────────────────
+
+describe('offline-cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const subs: OfflineSubscription[] = [
+    {
+      id: 'sub-1',
+      name: 'Netflix',
+      status: 'active',
+      billing_cycle: 'monthly',
+      next_renewal: '2025-12-15T00:00:00Z',
+      price: 15.99,
+      category: 'streaming',
+    },
+    {
+      id: 'sub-2',
+      name: 'Spotify',
+      status: 'active',
+      billing_cycle: 'monthly',
+      next_renewal: '2025-12-20T00:00:00Z',
+      price: 9.99,
+      category: 'music',
+    },
+  ];
+
+  it('saves and loads subscriptions', () => {
+    saveSubscriptionsOffline(subs);
+    const loaded = loadOfflineSubscriptions();
+    expect(loaded).toHaveLength(2);
+    expect(loaded[0].name).toBe('Netflix');
+    expect(loaded[1].name).toBe('Spotify');
+  });
+
+  it('returns empty array when nothing is cached', () => {
+    expect(loadOfflineSubscriptions()).toEqual([]);
+  });
+
+  it('saves a timestamp on write', () => {
+    const before = new Date().toISOString();
+    saveSubscriptionsOffline(subs);
+    const ts = getOfflineCacheTimestamp();
+    expect(ts).not.toBeNull();
+    expect(new Date(ts!).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime());
+  });
+
+  it('returns null timestamp when nothing is cached', () => {
+    expect(getOfflineCacheTimestamp()).toBeNull();
+  });
+
+  it('clears cache and timestamp', () => {
+    saveSubscriptionsOffline(subs);
+    clearOfflineCache();
+    expect(loadOfflineSubscriptions()).toEqual([]);
+    expect(getOfflineCacheTimestamp()).toBeNull();
+  });
+
+  it('handles corrupted localStorage gracefully', () => {
+    localStorage.setItem('syncro_offline_subscriptions', 'not-valid-json');
+    expect(loadOfflineSubscriptions()).toEqual([]);
+  });
+
+  it('overwrites previous cache on subsequent saves', () => {
+    saveSubscriptionsOffline(subs);
+    saveSubscriptionsOffline([subs[0]]);
+    expect(loadOfflineSubscriptions()).toHaveLength(1);
+  });
+});
+
+// ─── OfflinePage component tests ──────────────────────────────────────────────
+
+// Mock navigator.serviceWorker
+const mockGetRegistration = vi.fn();
+
+describe('OfflinePage', () => {
+  beforeEach(async () => {
+    localStorage.clear();
+
+    // Mock serviceWorker
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { getRegistration: mockGetRegistration },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function renderOfflinePage() {
+    const { default: OfflinePage } = await import('@/app/offline/page');
+    return render(<OfflinePage />);
+  }
+
+  it('shows "no cached data" message when cache is empty', async () => {
+    mockGetRegistration.mockResolvedValue(undefined);
+
+    await renderOfflinePage();
+
+    expect(
+      screen.getByText(/no cached data available/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders cached subscriptions from localStorage', async () => {
+    saveSubscriptionsOffline([
+      {
+        id: 'sub-1',
+        name: 'Netflix',
+        status: 'active',
+        billing_cycle: 'monthly',
+        next_renewal: '2025-12-15T00:00:00Z',
+        price: 15.99,
+        category: 'streaming',
+      },
+    ]);
+    mockGetRegistration.mockResolvedValue({ active: true });
+
+    await renderOfflinePage();
+
+    expect(await screen.findByText('Netflix')).toBeInTheDocument();
+    expect(screen.getByText(/active/i)).toBeInTheDocument();
+  });
+
+  it('shows service worker warning when SW is not registered', async () => {
+    mockGetRegistration.mockResolvedValue(undefined);
+
+    await renderOfflinePage();
+
+    expect(
+      await screen.findByRole('alert'),
+    ).toHaveTextContent(/service worker not registered/i);
+  });
+
+  it('does not show SW warning when SW is registered', async () => {
+    mockGetRegistration.mockResolvedValue({ active: true });
+
+    await renderOfflinePage();
+
+    // Give time for the async SW check
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText(/service worker not registered/i)).not.toBeInTheDocument();
+  });
+
+  it('shows retry button', async () => {
+    mockGetRegistration.mockResolvedValue(undefined);
+
+    await renderOfflinePage();
+
+    expect(screen.getByRole('button', { name: /retry connection/i })).toBeInTheDocument();
+  });
+
+  it('shows read-only note', async () => {
+    mockGetRegistration.mockResolvedValue(undefined);
+
+    await renderOfflinePage();
+
+    expect(screen.getByText(/read-only view/i)).toBeInTheDocument();
+  });
+
+  it('shows cache timestamp when available', async () => {
+    saveSubscriptionsOffline([
+      {
+        id: 'sub-1',
+        name: 'Spotify',
+        status: 'active',
+        billing_cycle: 'monthly',
+        next_renewal: null,
+        price: 9.99,
+        category: 'music',
+      },
+    ]);
+    mockGetRegistration.mockResolvedValue({ active: true });
+
+    await renderOfflinePage();
+
+    // The "Updated …" label should be present
+    expect(await screen.findByLabelText(/cache last updated/i)).toBeInTheDocument();
+  });
+});

--- a/client/__tests__/payment-timeline.test.tsx
+++ b/client/__tests__/payment-timeline.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * Tests for #610 — Payment timeline component
+ *
+ * Covers:
+ * - Loading skeleton
+ * - Empty state (no events)
+ * - Event ordering (most recent first)
+ * - On-chain event rendering (blockchain badge, explorer link)
+ * - Manual payment state rendering (status badge, notes)
+ * - Error state with retry
+ * - Pagination controls
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PaymentTimeline } from '@/components/ui/payment-timeline';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/renewal-history', () => ({
+  renewalHistoryApi: {
+    getHistory: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/providers/user-settings-provider', () => ({
+  useUserSettings: () => ({ settings: { currency: 'USD' } }),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className }: any) => <div data-testid="skeleton" className={className} />,
+}));
+
+vi.mock('@/lib/currency-utils', () => ({
+  formatCurrency: (amount: number, _currency: string) => `$${amount.toFixed(2)}`,
+}));
+
+import { renewalHistoryApi } from '@/lib/api/renewal-history';
+const mockGetHistory = renewalHistoryApi.getHistory as ReturnType<typeof vi.fn>;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const emptyResponse = {
+  subscriptionId: 'sub-1',
+  history: [],
+  total: 0,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+};
+
+const singlePageResponse = {
+  subscriptionId: 'sub-1',
+  history: [
+    {
+      id: 'evt-1',
+      date: '2025-03-01T10:00:00Z',
+      type: 'renewed',
+      status: 'success',
+      amount: 15.99,
+      currency: 'USD',
+      paymentMethod: 'stellar',
+    },
+    {
+      id: 'evt-2',
+      date: '2025-02-01T10:00:00Z',
+      type: 'failed',
+      status: 'failed',
+      notes: 'Insufficient balance',
+    },
+  ],
+  total: 2,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+};
+
+const onChainResponse = {
+  subscriptionId: 'sub-1',
+  history: [
+    {
+      id: 'evt-3',
+      date: '2025-04-01T10:00:00Z',
+      type: 'renewed',
+      status: 'success',
+      amount: 9.99,
+      currency: 'USD',
+      transactionHash: 'abc123txhash',
+      blockchainVerified: true,
+      explorerUrl: 'https://stellar.expert/explorer/public/tx/abc123txhash',
+    },
+  ],
+  total: 1,
+  page: 1,
+  limit: 20,
+  totalPages: 1,
+};
+
+const multiPageResponse = {
+  subscriptionId: 'sub-1',
+  history: [{ id: 'evt-4', date: '2025-05-01T10:00:00Z', type: 'renewed' }],
+  total: 25,
+  page: 1,
+  limit: 20,
+  totalPages: 2,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PaymentTimeline — loading state', () => {
+  it('renders loading skeletons while fetching', () => {
+    mockGetHistory.mockReturnValue(new Promise(() => {}));
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    const container = screen.getByLabelText(/loading payment history/i);
+    expect(container).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+});
+
+describe('PaymentTimeline — empty state', () => {
+  it('renders empty state when no events exist', async () => {
+    mockGetHistory.mockResolvedValue(emptyResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    expect(await screen.findByText(/no payment history yet/i)).toBeInTheDocument();
+  });
+});
+
+describe('PaymentTimeline — event rendering', () => {
+  beforeEach(() => {
+    mockGetHistory.mockResolvedValue(singlePageResponse);
+  });
+
+  it('renders all events', async () => {
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    expect(await screen.findByText('Renewed')).toBeInTheDocument();
+    expect(screen.getByText('Payment failed')).toBeInTheDocument();
+  });
+
+  it('renders status badges', async () => {
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText('Renewed');
+    expect(screen.getByText('success')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+  });
+
+  it('renders amount and payment method', async () => {
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText('Renewed');
+    expect(screen.getByText(/\$15\.99/)).toBeInTheDocument();
+    expect(screen.getByText(/stellar/i)).toBeInTheDocument();
+  });
+
+  it('renders notes for failed events', async () => {
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    expect(await screen.findByText(/insufficient balance/i)).toBeInTheDocument();
+  });
+
+  it('events are ordered most-recent first (API ordering)', async () => {
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText('Renewed');
+    const items = screen.getAllByRole('listitem');
+    // First item should be the March event (more recent)
+    expect(items[0]).toHaveTextContent('Renewed');
+    expect(items[1]).toHaveTextContent('Payment failed');
+  });
+});
+
+describe('PaymentTimeline — on-chain events', () => {
+  it('renders blockchain badge for on-chain events', async () => {
+    mockGetHistory.mockResolvedValue(onChainResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText('Renewed');
+    // BlockchainBadge renders "On-chain Confirmed" for blockchainVerified=true
+    expect(screen.getByText(/on-chain confirmed/i)).toBeInTheDocument();
+  });
+
+  it('renders explorer link for on-chain events', async () => {
+    mockGetHistory.mockResolvedValue(onChainResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    const link = await screen.findByRole('link', { name: /view on stellar explorer/i });
+    expect(link).toHaveAttribute('href', 'https://stellar.expert/explorer/public/tx/abc123txhash');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});
+
+describe('PaymentTimeline — error state', () => {
+  it('renders error message when fetch fails', async () => {
+    mockGetHistory.mockRejectedValue(new Error('Failed to load history (403)'));
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/failed to load history/i)).toBeInTheDocument();
+  });
+
+  it('retry button re-fetches data', async () => {
+    mockGetHistory
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(singlePageResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+    const user = userEvent.setup();
+
+    await screen.findByRole('alert');
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Renewed')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('PaymentTimeline — pagination', () => {
+  it('shows pagination controls when totalPages > 1', async () => {
+    mockGetHistory.mockResolvedValue(multiPageResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText(/page 1 of 2/i);
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
+  });
+
+  it('does not show pagination when only one page', async () => {
+    mockGetHistory.mockResolvedValue(singlePageResponse);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+
+    await screen.findByText('Renewed');
+    expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument();
+  });
+
+  it('navigates to next page on Next click', async () => {
+    const page2Response = { ...multiPageResponse, page: 2, totalPages: 2 };
+    mockGetHistory
+      .mockResolvedValueOnce(multiPageResponse)
+      .mockResolvedValueOnce(page2Response);
+
+    render(<PaymentTimeline subscriptionId="sub-1" />);
+    const user = userEvent.setup();
+
+    await screen.findByText(/page 1 of 2/i);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/page 2 of 2/i)).toBeInTheDocument();
+    });
+    expect(mockGetHistory).toHaveBeenCalledWith('sub-1', { page: 2, limit: 20 });
+  });
+});

--- a/client/__tests__/privacy-page.test.tsx
+++ b/client/__tests__/privacy-page.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for #613 — Privacy self-service flows
+ *
+ * Covers:
+ * - Export job state (pending → ready, pending → error)
+ * - Failure recovery (inline retry)
+ * - Delete modal confirmation UX (checkbox required, backdrop close blocked during request)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DataPrivacyPage from '@/app/settings/privacy/page';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+global.URL.createObjectURL = vi.fn(() => 'blob:mock');
+global.URL.revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.clearAllTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderPage() {
+  const user = userEvent.setup();
+  render(<DataPrivacyPage />);
+  return { user };
+}
+
+// ─── Export tests ─────────────────────────────────────────────────────────────
+
+describe('DataPrivacyPage — export flow', () => {
+  it('shows pending state while export job is in progress', async () => {
+    // POST /export returns a jobId; status endpoint returns "pending" indefinitely
+    let resolveStatus: (v: any) => void;
+    const statusPromise = new Promise((res) => { resolveStatus = res; });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ jobId: 'job-123' }),
+      } as any)
+      .mockReturnValue(statusPromise as any);
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /download export/i }));
+
+    expect(await screen.findByText(/preparing your export/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preparing export/i })).toBeDisabled();
+
+    // Resolve to avoid dangling promise
+    resolveStatus!({ ok: true, json: async () => ({ status: 'pending' }) });
+  });
+
+  it('shows success banner when job completes (no download URL)', async () => {
+    // status: ready with no downloadUrl — just shows the success banner
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ jobId: 'job-123' }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'ready' }),
+      } as any);
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /download export/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/your export is ready/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error banner and retry link when export fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /download export/i }));
+
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('shows error when export request returns non-ok status', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 } as any);
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /download export/i }));
+
+    expect(await screen.findByText(/export request failed/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Delete modal tests ───────────────────────────────────────────────────────
+
+describe('DataPrivacyPage — delete modal', () => {
+  it('opens modal when Delete Account is clicked', async () => {
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('keeps confirm button disabled until checkbox is checked', async () => {
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+
+    // The "Delete Account" button inside the modal
+    const confirmBtn = screen.getAllByRole('button', { name: /delete account/i }).find(
+      (b) => b.closest('[role="dialog"]'),
+    )!;
+    expect(confirmBtn).toBeDisabled();
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it('submits delete request and shows scheduled banner', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any);
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    await user.click(screen.getByRole('checkbox'));
+
+    const confirmBtn = screen.getAllByRole('button', { name: /delete account/i }).find(
+      (b) => b.closest('[role="dialog"]'),
+    )!;
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/account deletion has been scheduled/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows error alert when delete request fails', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 } as any);
+
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    await user.click(screen.getByRole('checkbox'));
+
+    const confirmBtn = screen.getAllByRole('button', { name: /delete account/i }).find(
+      (b) => b.closest('[role="dialog"]'),
+    )!;
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    // Modal stays open
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes modal on Cancel click', async () => {
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes modal on backdrop click', async () => {
+    const { user } = renderPage();
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+
+    const backdrop = screen.getByRole('dialog');
+    // Click the backdrop (the dialog element itself, not its children)
+    await act(async () => {
+      fireEvent.click(backdrop);
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/client/app/dashboard/analytics/page.tsx
+++ b/client/app/dashboard/analytics/page.tsx
@@ -2,10 +2,101 @@
 
 import { useEffect, useState } from "react"
 import AnalyticsPage from "@/components/pages/analytics"
-import { analyticsApi, AnalyticsSummary } from "@/lib/api/analytics"
+import { analyticsApi, type AnalyticsSummary } from "@/lib/api/analytics"
 import { useTheme } from "next-themes"
 import { Skeleton } from "@/components/ui/skeleton"
-import { BarChart3, AlertTriangle } from "lucide-react"
+import { BarChart3, AlertTriangle, PlusCircle } from "lucide-react"
+import Link from "next/link"
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function AnalyticsEmptyState({ darkMode }: { darkMode: boolean }) {
+  return (
+    <section
+      aria-labelledby="analytics-empty-heading"
+      className="flex flex-col items-center justify-center min-h-[40vh] p-8 text-center gap-4"
+    >
+      <BarChart3
+        className={`h-12 w-12 ${darkMode ? "text-gray-600" : "text-gray-300"}`}
+        aria-hidden="true"
+      />
+      <h2
+        id="analytics-empty-heading"
+        className={`text-xl font-semibold ${darkMode ? "text-white" : "text-gray-900"}`}
+      >
+        No analytics yet
+      </h2>
+      <p className={`text-sm max-w-sm ${darkMode ? "text-gray-400" : "text-gray-500"}`}>
+        Add your first subscription to start tracking spending trends and category breakdowns.
+      </p>
+      <Link
+        href="/dashboard?action=add"
+        className="inline-flex items-center gap-2 mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      >
+        <PlusCircle className="h-4 w-4" aria-hidden="true" />
+        Add your first subscription
+      </Link>
+    </section>
+  )
+}
+
+// ─── Error state ──────────────────────────────────────────────────────────────
+
+function AnalyticsErrorState({
+  message,
+  onRetry,
+  darkMode,
+}: {
+  message: string
+  onRetry: () => void
+  darkMode: boolean
+}) {
+  return (
+    <section
+      aria-labelledby="analytics-error-heading"
+      role="alert"
+      className="flex flex-col items-center justify-center min-h-[40vh] p-8 text-center gap-4"
+    >
+      <AlertTriangle className="h-10 w-10 text-red-500" aria-hidden="true" />
+      <h2
+        id="analytics-error-heading"
+        className={`text-xl font-semibold ${darkMode ? "text-white" : "text-gray-900"}`}
+      >
+        Couldn&apos;t load analytics
+      </h2>
+      <p className={`text-sm max-w-sm ${darkMode ? "text-red-400" : "text-red-600"}`}>
+        {message}
+      </p>
+      <button
+        onClick={onRetry}
+        className="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      >
+        Try again
+      </button>
+    </section>
+  )
+}
+
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+function AnalyticsLoadingSkeleton() {
+  return (
+    <div className="p-4 sm:p-8 space-y-8" aria-busy="true" aria-label="Loading analytics…">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+        <Skeleton className="h-28 w-full rounded-xl" />
+        <Skeleton className="h-28 w-full rounded-xl" />
+        <Skeleton className="h-28 w-full rounded-xl" />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8">
+        <Skeleton className="h-64 sm:h-80 w-full rounded-xl" />
+        <Skeleton className="h-64 sm:h-80 w-full rounded-xl" />
+      </div>
+      <Skeleton className="h-48 w-full rounded-xl" />
+    </div>
+  )
+}
+
+// ─── Route component ──────────────────────────────────────────────────────────
 
 export default function AnalyticsRoute() {
   const [summary, setSummary] = useState<AnalyticsSummary | null>(null)
@@ -22,7 +113,13 @@ export default function AnalyticsRoute() {
       setSummary(data)
     } catch (err) {
       console.error("Failed to fetch analytics:", err)
-      setError("Failed to load analytics data. Please try again later.")
+      const isNetworkError =
+        err instanceof TypeError && err.message.toLowerCase().includes("network")
+      setError(
+        isNetworkError
+          ? "Network error — check your connection and try again."
+          : "Failed to load analytics data. Please try again."
+      )
     } finally {
       setLoading(false)
     }
@@ -32,59 +129,33 @@ export default function AnalyticsRoute() {
     fetchAnalytics()
   }, [])
 
-  if (loading) {
-    return (
-      <div className="p-4 sm:p-8 space-y-8">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
-          <Skeleton className="h-28 w-full rounded-xl" />
-          <Skeleton className="h-28 w-full rounded-xl" />
-          <Skeleton className="h-28 w-full rounded-xl" />
-        </div>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8">
-          <Skeleton className="h-64 sm:h-80 w-full rounded-xl" />
-          <Skeleton className="h-64 sm:h-80 w-full rounded-xl" />
-        </div>
-        <Skeleton className="h-48 w-full rounded-xl" />
-      </div>
-    )
-  }
+  if (loading) return <AnalyticsLoadingSkeleton />
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[40vh] p-8 text-center gap-4">
-        <AlertTriangle className="h-10 w-10 text-red-500" aria-hidden="true" />
-        <p className={`text-base font-medium ${darkMode ? "text-red-400" : "text-red-600"}`}>{error}</p>
-        <button
-          onClick={fetchAnalytics}
-          className="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
-        >
-          Try again
-        </button>
-      </div>
+      <AnalyticsErrorState
+        message={error}
+        onRetry={fetchAnalytics}
+        darkMode={darkMode}
+      />
     )
   }
 
   if (!summary || summary.active_subscriptions === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[40vh] p-8 text-center gap-4">
-        <BarChart3 className={`h-12 w-12 ${darkMode ? "text-gray-600" : "text-gray-300"}`} aria-hidden="true" />
-        <h2 className={`text-xl font-semibold ${darkMode ? "text-white" : "text-gray-900"}`}>
-          No analytics yet
-        </h2>
-        <p className={`text-sm max-w-sm ${darkMode ? "text-gray-400" : "text-gray-500"}`}>
-          Add your first subscription to start tracking spending trends and category breakdowns.
-        </p>
-      </div>
-    )
+    return <AnalyticsEmptyState darkMode={darkMode} />
   }
 
   return (
     <div className="p-4 sm:p-8">
       <div className="mb-6 sm:mb-8">
-        <h1 className={`text-2xl sm:text-3xl font-bold ${darkMode ? "text-white" : "text-gray-900"}`}>
+        <h1
+          className={`text-2xl sm:text-3xl font-bold ${darkMode ? "text-white" : "text-gray-900"}`}
+        >
           Spending Analytics
         </h1>
-        <p className={`text-sm sm:text-base mt-1 ${darkMode ? "text-gray-400" : "text-gray-600"}`}>
+        <p
+          className={`text-sm sm:text-base mt-1 ${darkMode ? "text-gray-400" : "text-gray-600"}`}
+        >
           Track your subscription spend and stay within budget.
         </p>
       </div>

--- a/client/app/dashboard/subscriptions/[id]/page.tsx
+++ b/client/app/dashboard/subscriptions/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+import { PaymentTimeline } from '@/components/ui/payment-timeline';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function SubscriptionDetailPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/auth/login');
+
+  const { data: sub, error } = await supabase
+    .from('subscriptions')
+    .select('id, name, price, status, billing_cycle, next_renewal, category')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .single();
+
+  if (error || !sub) redirect('/dashboard');
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-10 px-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Dashboard
+        </Link>
+
+        {/* Subscription summary */}
+        <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
+          <h1 className="text-xl font-semibold text-gray-900 mb-1">{sub.name}</h1>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mt-3">
+            <div>
+              <dt className="text-gray-500">Status</dt>
+              <dd className="font-medium text-gray-900 capitalize">{sub.status ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Billing cycle</dt>
+              <dd className="font-medium text-gray-900 capitalize">{sub.billing_cycle ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Next renewal</dt>
+              <dd className="font-medium text-gray-900">
+                {sub.next_renewal
+                  ? new Date(sub.next_renewal).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+                  : '—'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Category</dt>
+              <dd className="font-medium text-gray-900">{sub.category ?? '—'}</dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* Payment timeline — client component */}
+        <PaymentTimeline subscriptionId={id} subscriptionName={sub.name} />
+      </div>
+    </main>
+  );
+}

--- a/client/app/offline/page.tsx
+++ b/client/app/offline/page.tsx
@@ -1,48 +1,162 @@
 'use client';
-import React from 'react';
+
+import { useEffect, useState } from 'react';
+import {
+  loadOfflineSubscriptions,
+  getOfflineCacheTimestamp,
+  type OfflineSubscription,
+} from '@/lib/offline-cache';
+
+// ─── Service worker verification ─────────────────────────────────────────────
+
+function useServiceWorkerStatus() {
+  const [registered, setRegistered] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) {
+      setRegistered(false);
+      return;
+    }
+    navigator.serviceWorker.getRegistration('/sw.js').then((reg) => {
+      setRegistered(!!reg);
+    });
+  }, []);
+
+  return registered;
+}
+
+// ─── Retry / resync ───────────────────────────────────────────────────────────
+
+function handleRetry() {
+  window.location.reload();
+}
+
+// ─── Status badge ─────────────────────────────────────────────────────────────
+
+const STATUS_CLASSES: Record<string, string> = {
+  active: 'text-green-400',
+  cancelled: 'text-red-400',
+  paused: 'text-yellow-400',
+  expired: 'text-gray-400',
+  trial: 'text-blue-400',
+};
+
+function formatRenewal(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function OfflinePage() {
+  const [subs, setSubs] = useState<OfflineSubscription[]>([]);
+  const [cacheTs, setCacheTs] = useState<string | null>(null);
+  const swRegistered = useServiceWorkerStatus();
+
+  useEffect(() => {
+    setSubs(loadOfflineSubscriptions());
+    setCacheTs(getOfflineCacheTimestamp());
+  }, []);
+
+  const cacheAge = cacheTs
+    ? new Date(cacheTs).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null;
+
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col items-center justify-center p-4">
       <div className="max-w-md w-full text-center">
+        {/* Icon + heading */}
         <div className="mb-8">
           <div className="w-16 h-16 bg-indigo-600 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            <svg
+              className="w-8 h-8 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold mb-2">You're Offline</h1>
-          <p className="text-gray-400 mb-6">Showing cached subscription data</p>
+          <h1 className="text-2xl font-bold mb-2">You&apos;re Offline</h1>
+          <p className="text-gray-400 text-sm">
+            {subs.length > 0
+              ? 'Showing your last cached subscriptions.'
+              : 'No cached data available. Connect to the internet to load your subscriptions.'}
+          </p>
         </div>
 
-        <div className="bg-gray-800 rounded-lg p-4 mb-6">
-          <h2 className="text-lg font-semibold mb-4">Cached Subscriptions</h2>
-          <div className="space-y-3">
-            {/* Placeholder for cached subscriptions - in a real implementation,
-                this would be populated from IndexedDB or localStorage */}
-            <div className="flex items-center justify-between p-3 bg-gray-700 rounded">
-              <div>
-                <p className="font-medium">Netflix</p>
-                <p className="text-sm text-gray-400">Renews: Dec 15, 2024</p>
-              </div>
-              <span className="text-green-400 text-sm">Active</span>
-            </div>
-            <div className="flex items-center justify-between p-3 bg-gray-700 rounded">
-              <div>
-                <p className="font-medium">Spotify</p>
-                <p className="text-sm text-gray-400">Renews: Dec 20, 2024</p>
-              </div>
-              <span className="text-green-400 text-sm">Active</span>
-            </div>
+        {/* Service worker status */}
+        {swRegistered === false && (
+          <div
+            role="alert"
+            className="mb-4 text-xs text-yellow-400 bg-yellow-900/30 border border-yellow-700 rounded-lg px-3 py-2"
+          >
+            Service worker not registered — offline caching may not be available.
           </div>
-        </div>
+        )}
 
+        {/* Cached subscriptions */}
+        {subs.length > 0 && (
+          <div className="bg-gray-800 rounded-lg p-4 mb-4 text-left">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-base font-semibold">Cached Subscriptions</h2>
+              {cacheAge && (
+                <span className="text-xs text-gray-500" aria-label={`Cache last updated ${cacheAge}`}>
+                  Updated {cacheAge}
+                </span>
+              )}
+            </div>
+
+            <ul className="space-y-2" aria-label="Cached subscriptions">
+              {subs.map((sub) => (
+                <li
+                  key={sub.id}
+                  className="flex items-center justify-between p-3 bg-gray-700 rounded"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium truncate">{sub.name}</p>
+                    <p className="text-xs text-gray-400">
+                      Renews: {formatRenewal(sub.next_renewal)}
+                    </p>
+                  </div>
+                  <span
+                    className={`text-sm font-medium capitalize flex-shrink-0 ml-3 ${STATUS_CLASSES[sub.status] ?? 'text-gray-400'}`}
+                    aria-label={`Status: ${sub.status}`}
+                  >
+                    {sub.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Retry / resync */}
         <button
-          onClick={() => window.location.reload()}
-          className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+          onClick={handleRetry}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900"
         >
-          Try Again
+          Retry Connection
         </button>
+
+        <p className="mt-3 text-xs text-gray-500">
+          Read-only view — changes will sync when you&apos;re back online.
+        </p>
       </div>
     </div>
   );

--- a/client/app/settings/privacy/page.tsx
+++ b/client/app/settings/privacy/page.tsx
@@ -1,49 +1,215 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-export default function DataPrivacyPage() {
-  // Export state
-  const [exporting, setExporting] = useState(false);
-  const [exportError, setExportError] = useState<string | null>(null);
+// ─── Types ────────────────────────────────────────────────────────────────────
 
-  // Delete modal state
+type ExportStatus = 'idle' | 'pending' | 'ready' | 'error';
+type DeleteStatus = 'idle' | 'scheduled' | 'error';
+
+interface JobState {
+  jobId: string | null;
+  status: ExportStatus;
+  downloadUrl: string | null;
+  error: string | null;
+  /** ISO timestamp of last poll */
+  lastChecked: string | null;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 3_000;
+const MAX_POLL_ATTEMPTS = 40; // 2 minutes
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function startExportJob(): Promise<{ jobId: string }> {
+  const res = await fetch(`${API_BASE}/api/compliance/export`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Export request failed (${res.status})`);
+  const json = await res.json().catch(() => ({}));
+  // If the backend returns a blob directly (legacy), handle it inline
+  if (res.headers.get('content-type')?.includes('application/zip')) {
+    const blob = await res.blob();
+    triggerDownload(blob, 'syncro-data-export.zip');
+    return { jobId: '__direct__' };
+  }
+  return { jobId: json.jobId ?? json.job_id ?? '__direct__' };
+}
+
+async function pollExportJob(jobId: string): Promise<{ status: string; downloadUrl?: string }> {
+  const res = await fetch(`${API_BASE}/api/compliance/export/${jobId}/status`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Status check failed (${res.status})`);
+  return res.json();
+}
+
+async function downloadExport(downloadUrl: string): Promise<void> {
+  const res = await fetch(downloadUrl, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Download failed (${res.status})`);
+  const blob = await res.blob();
+  triggerDownload(blob, 'syncro-data-export.zip');
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function DataPrivacyPage() {
+  // ── Export state ──────────────────────────────────────────────────────────
+  const [exportJob, setExportJob] = useState<JobState>({
+    jobId: null,
+    status: 'idle',
+    downloadUrl: null,
+    error: null,
+    lastChecked: null,
+  });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollAttemptsRef = useRef(0);
+
+  // ── Delete state ──────────────────────────────────────────────────────────
+  const [deleteStatus, setDeleteStatus] = useState<DeleteStatus>('idle');
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [reason, setReason] = useState('');
   const [confirmed, setConfirmed] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [deleteScheduled, setDeleteScheduled] = useState(false);
+
+  // ── Cleanup on unmount ────────────────────────────────────────────────────
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  // ── Export polling ────────────────────────────────────────────────────────
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    pollAttemptsRef.current = 0;
+  }, []);
+
+  const checkJobStatus = useCallback(
+    async (jobId: string) => {
+      pollAttemptsRef.current += 1;
+
+      if (pollAttemptsRef.current > MAX_POLL_ATTEMPTS) {
+        stopPolling();
+        setExportJob((prev) => ({
+          ...prev,
+          status: 'error',
+          error: 'Export is taking too long. Please try again.',
+        }));
+        return;
+      }
+
+      try {
+        const result = await pollExportJob(jobId);
+        const now = new Date().toISOString();
+
+        if (result.status === 'ready' || result.status === 'completed') {
+          stopPolling();
+          if (result.downloadUrl) {
+            await downloadExport(result.downloadUrl);
+          }
+          setExportJob((prev) => ({
+            ...prev,
+            status: 'ready',
+            downloadUrl: result.downloadUrl ?? null,
+            lastChecked: now,
+          }));
+        } else if (result.status === 'failed' || result.status === 'error') {
+          stopPolling();
+          setExportJob((prev) => ({
+            ...prev,
+            status: 'error',
+            error: 'Export failed on the server. Please try again.',
+            lastChecked: now,
+          }));
+        } else {
+          // still pending
+          setExportJob((prev) => ({ ...prev, lastChecked: now }));
+        }
+      } catch (err) {
+        stopPolling();
+        setExportJob((prev) => ({
+          ...prev,
+          status: 'error',
+          error: err instanceof Error ? err.message : 'Failed to check export status.',
+        }));
+      }
+    },
+    [stopPolling],
+  );
 
   const handleExport = async () => {
-    setExporting(true);
-    setExportError(null);
+    stopPolling();
+    setExportJob({ jobId: null, status: 'pending', downloadUrl: null, error: null, lastChecked: null });
+
     try {
-      const res = await fetch(`${API_BASE}/api/compliance/export`, {
-        credentials: 'include',
-      });
-      if (!res.ok) throw new Error(`Export failed (${res.status})`);
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'syncro-data-export.zip';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      const { jobId } = await startExportJob();
+
+      // Direct download (legacy backend) — already triggered inside startExportJob
+      if (jobId === '__direct__') {
+        setExportJob({ jobId: null, status: 'ready', downloadUrl: null, error: null, lastChecked: new Date().toISOString() });
+        return;
+      }
+
+      setExportJob((prev) => ({ ...prev, jobId }));
+      pollAttemptsRef.current = 0;
+
+      // Kick off polling
+      pollRef.current = setInterval(() => {
+        checkJobStatus(jobId);
+      }, POLL_INTERVAL_MS);
+
+      // Also check immediately
+      await checkJobStatus(jobId);
     } catch (err) {
-      setExportError(err instanceof Error ? err.message : 'Export failed');
-    } finally {
-      setExporting(false);
+      setExportJob({
+        jobId: null,
+        status: 'error',
+        downloadUrl: null,
+        error: err instanceof Error ? err.message : 'Export request failed.',
+        lastChecked: null,
+      });
     }
   };
 
+  const retryExport = () => handleExport();
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+  const openModal = () => {
+    setReason('');
+    setConfirmed(false);
+    setDeleteError(null);
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    if (deleting) return; // prevent accidental close mid-request
+    setModalOpen(false);
+  };
+
   const handleDelete = async () => {
-    if (!confirmed) return;
+    if (!confirmed || deleting) return;
     setDeleting(true);
     setDeleteError(null);
     try {
@@ -54,21 +220,18 @@ export default function DataPrivacyPage() {
         body: JSON.stringify({ reason: reason.trim() || undefined }),
       });
       if (!res.ok) throw new Error(`Request failed (${res.status})`);
-      setDeleteScheduled(true);
+      setDeleteStatus('scheduled');
       setModalOpen(false);
     } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Delete request failed');
+      setDeleteError(err instanceof Error ? err.message : 'Delete request failed. Please try again.');
     } finally {
       setDeleting(false);
     }
   };
 
-  const openModal = () => {
-    setReason('');
-    setConfirmed(false);
-    setDeleteError(null);
-    setModalOpen(true);
-  };
+  // ── Derived UI state ──────────────────────────────────────────────────────
+  const exportIsBusy = exportJob.status === 'pending';
+  const exportLabel = exportIsBusy ? 'Preparing export…' : 'Download Export (ZIP)';
 
   return (
     <main className="min-h-screen bg-gray-50 py-12 px-4">
@@ -78,7 +241,7 @@ export default function DataPrivacyPage() {
           href="/settings/security"
           className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 mb-8 transition-colors"
         >
-          <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
           Back to Security Settings
@@ -88,50 +251,86 @@ export default function DataPrivacyPage() {
         <p className="text-sm text-gray-500 mb-8">Manage your personal data and privacy preferences.</p>
 
         <div className="space-y-6">
-          {/* Section 1: Export */}
-          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
-            <h2 className="text-base font-semibold text-gray-900 mb-1">Export Your Data</h2>
+          {/* ── Section 1: Export ─────────────────────────────────────────── */}
+          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6" aria-labelledby="export-heading">
+            <h2 id="export-heading" className="text-base font-semibold text-gray-900 mb-1">Export Your Data</h2>
             <p className="text-sm text-gray-500 mb-4">
               Download a copy of all the data Syncro holds about your account, including subscriptions, billing
               history, and profile information.
             </p>
-            {exportError && (
-              <p className="text-sm text-red-600 mb-3">{exportError}</p>
+
+            {/* Job status banner */}
+            {exportJob.status === 'pending' && (
+              <div role="status" aria-live="polite" className="flex items-center gap-2 text-sm text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-lg px-4 py-3 mb-4">
+                <svg className="w-4 h-4 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                </svg>
+                Preparing your export — this may take a minute…
+              </div>
             )}
+
+            {exportJob.status === 'ready' && (
+              <div role="status" aria-live="polite" className="flex items-center gap-2 text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-3 mb-4">
+                <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+                Your export is ready — download started automatically.
+              </div>
+            )}
+
+            {exportJob.status === 'error' && (
+              <div role="alert" className="flex items-start gap-2 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3 mb-4">
+                <svg className="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                </svg>
+                <span>
+                  {exportJob.error}{' '}
+                  <button
+                    onClick={retryExport}
+                    className="underline font-medium hover:no-underline focus:outline-none focus:ring-2 focus:ring-red-400 rounded"
+                  >
+                    Try again
+                  </button>
+                </span>
+              </div>
+            )}
+
             <button
               onClick={handleExport}
-              disabled={exporting}
-              className="px-4 py-2 text-sm font-medium bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+              disabled={exportIsBusy}
+              aria-busy={exportIsBusy}
+              className="px-4 py-2 text-sm font-medium bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >
-              {exporting ? 'Preparing export…' : 'Download Export (ZIP)'}
+              {exportLabel}
             </button>
           </section>
 
-          {/* Section 2: Email Preferences */}
-          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
-            <h2 className="text-base font-semibold text-gray-900 mb-1">Email Preferences</h2>
+          {/* ── Section 2: Email Preferences ─────────────────────────────── */}
+          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6" aria-labelledby="email-prefs-heading">
+            <h2 id="email-prefs-heading" className="text-base font-semibold text-gray-900 mb-1">Email Preferences</h2>
             <p className="text-sm text-gray-500 mb-4">
               Control which emails Syncro sends you, including renewal reminders, digests, and marketing
               communications.
             </p>
             <Link
               href="/email-preferences"
-              className="inline-flex px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700"
+              className="inline-flex px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             >
               Manage Email Preferences
             </Link>
           </section>
 
-          {/* Section 3: Delete Account */}
-          <section className="bg-white rounded-2xl border border-red-200 shadow-sm p-6">
-            <h2 className="text-base font-semibold text-gray-900 mb-1">Delete Account</h2>
+          {/* ── Section 3: Delete Account ─────────────────────────────────── */}
+          <section className="bg-white rounded-2xl border border-red-200 shadow-sm p-6" aria-labelledby="delete-heading">
+            <h2 id="delete-heading" className="text-base font-semibold text-gray-900 mb-1">Delete Account</h2>
             <p className="text-sm text-gray-500 mb-4">
               Permanently delete your Syncro account. Your data will be removed after a 30-day grace period, during
               which you can cancel this request.
             </p>
 
-            {deleteScheduled && (
-              <div className="rounded-lg bg-yellow-50 border border-yellow-200 p-4 mb-4 text-sm text-yellow-800">
+            {deleteStatus === 'scheduled' && (
+              <div role="status" className="rounded-lg bg-yellow-50 border border-yellow-200 p-4 mb-4 text-sm text-yellow-800">
                 Your account deletion has been scheduled. You have 30 days to cancel this request before your data
                 is permanently removed.
               </div>
@@ -139,8 +338,8 @@ export default function DataPrivacyPage() {
 
             <button
               onClick={openModal}
-              disabled={deleteScheduled}
-              className="px-4 py-2 text-sm font-medium border border-red-300 text-red-600 rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors"
+              disabled={deleteStatus === 'scheduled'}
+              className="px-4 py-2 text-sm font-medium border border-red-300 text-red-600 rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
             >
               Delete Account
             </button>
@@ -149,24 +348,26 @@ export default function DataPrivacyPage() {
 
         {/* Footer links */}
         <p className="text-center text-xs text-gray-400 mt-8">
-          <Link href="/privacy" className="text-indigo-600 hover:underline">
-            Privacy Policy
-          </Link>
+          <Link href="/privacy" className="text-indigo-600 hover:underline">Privacy Policy</Link>
           {' · '}
-          <Link href="/terms" className="text-indigo-600 hover:underline">
-            Terms of Service
-          </Link>
+          <Link href="/terms" className="text-indigo-600 hover:underline">Terms of Service</Link>
         </p>
       </div>
 
-      {/* Delete confirmation modal */}
+      {/* ── Delete confirmation modal ──────────────────────────────────────── */}
       {modalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+          onClick={(e) => { if (e.target === e.currentTarget) closeModal(); }}
+        >
           <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">Delete Account</h3>
+            <h3 id="modal-title" className="text-lg font-semibold text-gray-900 mb-2">Delete Account</h3>
             <p className="text-sm text-gray-600 mb-4">
-              This action will begin a 30-day countdown before your account and all associated data are permanently
-              deleted. All active subscriptions will be cancelled immediately.
+              This will begin a <strong>30-day countdown</strong> before your account and all associated data are
+              permanently deleted. All active subscriptions will be cancelled immediately.
             </p>
 
             {/* Optional reason */}
@@ -178,31 +379,44 @@ export default function DataPrivacyPage() {
                 placeholder="Tell us why you're leaving…"
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
+                disabled={deleting}
               />
             </label>
 
-            {/* Confirmation checkbox */}
+            {/* Explicit confirmation checkbox — required before submit */}
             <label className="flex items-start gap-3 mb-5 cursor-pointer">
               <input
                 type="checkbox"
                 className="mt-0.5 w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
                 checked={confirmed}
                 onChange={(e) => setConfirmed(e.target.checked)}
+                disabled={deleting}
+                aria-required="true"
               />
               <span className="text-sm text-gray-700">
-                I understand this action will cancel my subscriptions and permanently delete my data after 30 days.
+                I understand this will cancel my subscriptions and permanently delete my data after 30 days.
               </span>
             </label>
 
             {deleteError && (
-              <p className="text-sm text-red-600 mb-4">{deleteError}</p>
+              <div role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-4">
+                {deleteError}{' '}
+                <button
+                  onClick={handleDelete}
+                  disabled={!confirmed || deleting}
+                  className="underline font-medium hover:no-underline focus:outline-none"
+                >
+                  Retry
+                </button>
+              </div>
             )}
 
             <div className="flex justify-end gap-3">
               <button
                 type="button"
-                onClick={() => setModalOpen(false)}
-                className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700"
+                onClick={closeModal}
+                disabled={deleting}
+                className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
               >
                 Cancel
               </button>
@@ -210,7 +424,8 @@ export default function DataPrivacyPage() {
                 type="button"
                 onClick={handleDelete}
                 disabled={!confirmed || deleting}
-                className="px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+                aria-busy={deleting}
+                className="px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
               >
                 {deleting ? 'Deleting…' : 'Delete Account'}
               </button>

--- a/client/components/dashboard-client.tsx
+++ b/client/components/dashboard-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import type { User } from "@supabase/supabase-js"
 import { SuggestionsPanel } from "@/components/app/SuggestionsPanel"
@@ -8,6 +8,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { AlertTriangle, Info } from "lucide-react"
 import { formatDate } from "@/lib/timezone-utils"
 import { formatCurrency } from "@/lib/currency-utils"
+import { saveSubscriptionsOffline } from "@/lib/offline-cache"
 
 interface Subscription {
   id: string
@@ -49,6 +50,23 @@ export default function DashboardClient({
   const [notifications] = useState(initialNotifications)
   // initialEmailAccounts reserved for future email account display
   const [gdprLoading, setGdprLoading] = useState<"export" | "delete" | null>(null)
+
+  // Persist subscriptions for offline reading
+  useEffect(() => {
+    if (subscriptions.length > 0) {
+      saveSubscriptionsOffline(
+        subscriptions.map((s) => ({
+          id: s.id,
+          name: s.name,
+          status: s.status,
+          billing_cycle: s.billing_cycle,
+          next_renewal: s.next_renewal ?? null,
+          price: Number(s.price),
+          category: s.category ?? null,
+        })),
+      )
+    }
+  }, [subscriptions])
   const [gdprMessage, setGdprMessage] = useState<string | null>(null)
 
   const handleSignOut = async () => {

--- a/client/components/ui/payment-timeline.tsx
+++ b/client/components/ui/payment-timeline.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { renewalHistoryApi, type RenewalEvent, type RenewalHistoryResponse } from '@/lib/api/renewal-history';
+import { BlockchainBadge } from '@/components/ui/blockchain-badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency } from '@/lib/currency-utils';
+import { useUserSettings } from '@/components/providers/user-settings-provider';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface PaymentTimelineProps {
+  subscriptionId: string;
+  subscriptionName?: string;
+  darkMode?: boolean;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const EVENT_LABELS: Record<string, string> = {
+  renewed: 'Renewed',
+  failed: 'Payment failed',
+  reminder_sent: 'Reminder sent',
+  cancelled: 'Cancelled',
+  paused: 'Paused',
+  resumed: 'Resumed',
+  trial_started: 'Trial started',
+  trial_ended: 'Trial ended',
+};
+
+const STATUS_CLASSES: Record<string, string> = {
+  success: 'bg-green-100 text-green-800',
+  failed: 'bg-red-100 text-red-800',
+  pending: 'bg-yellow-100 text-yellow-800',
+  skipped: 'bg-gray-100 text-gray-600',
+};
+
+const EVENT_DOT_CLASSES: Record<string, string> = {
+  renewed: 'bg-green-500',
+  failed: 'bg-red-500',
+  reminder_sent: 'bg-blue-400',
+  cancelled: 'bg-gray-500',
+  paused: 'bg-yellow-500',
+  resumed: 'bg-green-400',
+  trial_started: 'bg-indigo-400',
+  trial_ended: 'bg-indigo-600',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function TimelineEventRow({
+  event,
+  currency,
+  darkMode,
+}: {
+  event: RenewalEvent;
+  currency: string;
+  darkMode?: boolean;
+}) {
+  const dotClass = EVENT_DOT_CLASSES[event.type] ?? 'bg-gray-400';
+  const label = EVENT_LABELS[event.type] ?? event.type;
+  const isOnChain = !!event.transactionHash;
+
+  return (
+    <li className="relative flex gap-4">
+      {/* Timeline spine dot */}
+      <div className="flex flex-col items-center">
+        <span
+          className={`w-3 h-3 rounded-full flex-shrink-0 mt-1 ${dotClass}`}
+          aria-hidden="true"
+        />
+        <span className="flex-1 w-px bg-gray-200 dark:bg-gray-700 mt-1" aria-hidden="true" />
+      </div>
+
+      {/* Event content */}
+      <div className="pb-5 min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2 mb-0.5">
+          <span className={`text-sm font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+            {label}
+          </span>
+
+          {event.status && (
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CLASSES[event.status] ?? 'bg-gray-100 text-gray-600'}`}
+            >
+              {event.status}
+            </span>
+          )}
+
+          {isOnChain && (
+            <BlockchainBadge
+              status={event.blockchainVerified ? 'confirmed' : 'pending'}
+              transactionHash={event.transactionHash}
+              darkMode={darkMode}
+            />
+          )}
+        </div>
+
+        <p className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+          {formatDate(event.date)}
+          {event.amount != null && (
+            <> · {formatCurrency(event.amount, currency)}{event.currency ? ` ${event.currency}` : ''}</>
+          )}
+          {event.paymentMethod && <> · {event.paymentMethod}</>}
+        </p>
+
+        {event.notes && (
+          <p className={`text-xs mt-1 ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            {event.notes}
+          </p>
+        )}
+
+        {event.explorerUrl && (
+          <a
+            href={event.explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-indigo-500 hover:underline mt-0.5 inline-block focus:outline-none focus:ring-1 focus:ring-indigo-400 rounded"
+          >
+            View on Stellar Explorer ↗
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function TimelineSkeleton() {
+  return (
+    <div aria-busy="true" aria-label="Loading payment history…" className="space-y-4">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex gap-4">
+          <Skeleton className="w-3 h-3 rounded-full mt-1 flex-shrink-0" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-4 w-32 rounded" />
+            <Skeleton className="h-3 w-48 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TimelineEmpty({ darkMode }: { darkMode?: boolean }) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-10 text-center gap-2"
+      aria-labelledby="timeline-empty-heading"
+    >
+      <svg
+        className={`w-8 h-8 ${darkMode ? 'text-gray-600' : 'text-gray-300'}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <p
+        id="timeline-empty-heading"
+        className={`text-sm font-medium ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}
+      >
+        No payment history yet
+      </p>
+      <p className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+        Events will appear here once renewals are processed.
+      </p>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function PaymentTimeline({ subscriptionId, subscriptionName, darkMode }: PaymentTimelineProps) {
+  const { settings } = useUserSettings();
+  const currency = settings.currency ?? 'USD';
+
+  const [data, setData] = useState<RenewalHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(
+    async (p: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await renewalHistoryApi.getHistory(subscriptionId, { page: p, limit: 20 });
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load payment history.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [subscriptionId],
+  );
+
+  useEffect(() => {
+    load(page);
+  }, [load, page]);
+
+  const cardClass = `rounded-xl border p-5 ${darkMode ? 'bg-[#2D3748] border-[#374151]' : 'bg-white border-gray-200'}`;
+
+  return (
+    <section aria-labelledby="timeline-heading" className={cardClass}>
+      <div className="flex items-center justify-between mb-4">
+        <h2
+          id="timeline-heading"
+          className={`text-base font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}
+        >
+          {subscriptionName ? `${subscriptionName} — ` : ''}Payment History
+        </h2>
+        {data && data.total > 0 && (
+          <span className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            {data.total} event{data.total !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {loading && <TimelineSkeleton />}
+
+      {!loading && error && (
+        <div role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}{' '}
+          <button
+            onClick={() => load(page)}
+            className="underline font-medium hover:no-underline focus:outline-none"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && data && (
+        <>
+          {data.history.length === 0 ? (
+            <TimelineEmpty darkMode={darkMode} />
+          ) : (
+            <ol aria-label="Payment timeline" className="space-y-0">
+              {data.history.map((event) => (
+                <TimelineEventRow
+                  key={event.id}
+                  event={event}
+                  currency={currency}
+                  darkMode={darkMode}
+                />
+              ))}
+            </ol>
+          )}
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                Previous
+              </button>
+              <span className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                Page {page} of {data.totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page >= data.totalPages}
+                className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 disabled:opacity-40 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/client/lib/api/renewal-history.ts
+++ b/client/lib/api/renewal-history.ts
@@ -1,0 +1,64 @@
+import { createClient } from '../supabase/client';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+
+export type RenewalEventType =
+  | 'renewed'
+  | 'failed'
+  | 'reminder_sent'
+  | 'cancelled'
+  | 'paused'
+  | 'resumed'
+  | 'trial_started'
+  | 'trial_ended';
+
+export type RenewalStatus = 'success' | 'failed' | 'pending' | 'skipped';
+
+export interface RenewalEvent {
+  id: string;
+  date: string;
+  type: RenewalEventType;
+  status?: RenewalStatus;
+  amount?: number;
+  currency?: string;
+  paymentMethod?: string;
+  transactionHash?: string;
+  blockchainLedger?: number;
+  blockchainVerified?: boolean;
+  explorerUrl?: string;
+  channel?: string;
+  notes?: string;
+}
+
+export interface RenewalHistoryResponse {
+  subscriptionId: string;
+  history: RenewalEvent[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+async function getAuthHeader(): Promise<Record<string, string>> {
+  const supabase = createClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token
+    ? { Authorization: `Bearer ${session.access_token}` }
+    : {};
+}
+
+export const renewalHistoryApi = {
+  getHistory: async (
+    subscriptionId: string,
+    params: { page?: number; limit?: number } = {},
+  ): Promise<RenewalHistoryResponse> => {
+    const headers = await getAuthHeader();
+    const qs = new URLSearchParams();
+    if (params.page) qs.set('page', String(params.page));
+    if (params.limit) qs.set('limit', String(params.limit));
+    const url = `${BACKEND_URL}/api/subscriptions/${subscriptionId}/history${qs.toString() ? `?${qs}` : ''}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`Failed to load history (${res.status})`);
+    return res.json();
+  },
+};

--- a/client/lib/offline-cache.ts
+++ b/client/lib/offline-cache.ts
@@ -1,0 +1,54 @@
+/**
+ * Offline cache utilities.
+ *
+ * Persists a lightweight snapshot of subscription data to localStorage so the
+ * offline page can display real data without a network connection.
+ *
+ * Key: "syncro_offline_subscriptions"
+ * Value: JSON-serialised OfflineSubscription[]
+ */
+
+export interface OfflineSubscription {
+  id: string;
+  name: string;
+  status: string;
+  billing_cycle: string;
+  next_renewal: string | null;
+  price: number;
+  category: string | null;
+}
+
+const STORAGE_KEY = 'syncro_offline_subscriptions';
+const TIMESTAMP_KEY = 'syncro_offline_subscriptions_ts';
+
+export function saveSubscriptionsOffline(subs: OfflineSubscription[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(subs));
+    localStorage.setItem(TIMESTAMP_KEY, new Date().toISOString());
+  } catch {
+    // Storage quota exceeded or private browsing — silently ignore
+  }
+}
+
+export function loadOfflineSubscriptions(): OfflineSubscription[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as OfflineSubscription[];
+  } catch {
+    return [];
+  }
+}
+
+export function getOfflineCacheTimestamp(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(TIMESTAMP_KEY);
+}
+
+export function clearOfflineCache(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(TIMESTAMP_KEY);
+}


### PR DESCRIPTION
## Summary

Implements four P1 frontend issues:

### #613 — Privacy self-service flows
- Export job polling with `pending → ready → error` state machine, 2-min timeout, inline retry
- Delete modal with explicit checkbox confirmation, blocked backdrop-close during in-flight request, failure recovery
closes #613 

### #608 — Analytics empty states
- Loading skeleton with `aria-busy` and accessible label
- Empty state with CTA link to add first subscription
- Error state with network vs server error copy distinction and retry
closes #608 

### #610 — Subscription payment timeline
- `PaymentTimeline` client component with loading, empty, error, and paginated states
- On-chain events: blockchain badge + Stellar explorer link
- Manual payment states: status badges, notes, payment method
- Wired into `/dashboard/subscriptions/[id]` detail page
close #610  

### #609 — Offline experience
- Service worker registration verified at runtime
- Cached subscriptions rendered from `localStorage` via `offline-cache.ts`
- SW warning alert, retry button, read-only note, cache timestamp
closes #609 

## Tests
46 tests added/updated across 4 test files — all passing.

```
Test Files  4 passed (4)
Tests       46 passed (46)
```

## Checklist
- [x] Acceptance criteria met
- [x] Tests added and passing
- [x] No security regressions
