### PR TITLE
fix(598): unify Next.js config and add verification tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,27 @@ jobs:
           fi
           echo "✅ Backend lockfile is committed"
 
+      - name: Verify exactly one Next.js config exists (client/next.config.mjs)
+        run: |
+          count=$(find . -maxdepth 1 -name "next.config.*" | wc -l)
+          if [ "$count" -ne 0 ]; then
+            echo "❌ Stale root-level next.config.* file(s) detected:"
+            find . -maxdepth 1 -name "next.config.*"
+            echo "Only client/next.config.mjs should exist."
+            exit 1
+          fi
+          if [ ! -f "client/next.config.mjs" ]; then
+            echo "❌ client/next.config.mjs is missing."
+            exit 1
+          fi
+          client_count=$(find client -maxdepth 1 -name "next.config.*" | wc -l)
+          if [ "$client_count" -ne 1 ]; then
+            echo "❌ Expected exactly 1 Next.js config under client/, found $client_count:"
+            find client -maxdepth 1 -name "next.config.*"
+            exit 1
+          fi
+          echo "✅ Exactly one Next.js config found: client/next.config.mjs"
+
       - name: Install client dependencies and verify lockfile
         working-directory: client
         run: |

--- a/client/__tests__/next-config.test.ts
+++ b/client/__tests__/next-config.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #598 — Unified Next.js config verification
+ *
+ * Asserts:
+ *  1. Only one Next.js config file exists (client/next.config.mjs).
+ *  2. No stale root-level next.config.* files remain.
+ *  3. The active config contains the required feature declarations.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+// __dirname = client/__tests__
+const repoRoot = path.resolve(__dirname, '../..');
+const clientDir = path.resolve(__dirname, '..');
+const activeConfig = path.join(clientDir, 'next.config.mjs');
+
+describe('Next.js config unification (#598)', () => {
+  it('client/next.config.mjs exists', () => {
+    expect(fs.existsSync(activeConfig)).toBe(true);
+  });
+
+  it('no stale root-level next.config.* files exist', () => {
+    const stale = fs.readdirSync(repoRoot).filter((f) => /^next\.config\..+/.test(f));
+    expect(stale).toHaveLength(0);
+  });
+
+  it('exactly one next.config.* file exists under client/', () => {
+    const configs = fs.readdirSync(clientDir).filter((f) => /^next\.config\..+/.test(f));
+    expect(configs).toEqual(['next.config.mjs']);
+  });
+
+  describe('active config content', () => {
+    let src: string;
+
+    beforeAll(() => {
+      src = fs.readFileSync(activeConfig, 'utf8');
+    });
+
+    it('wraps config with withSentryConfig', () => {
+      expect(src).toContain('withSentryConfig');
+    });
+
+    it('declares images.remotePatterns', () => {
+      expect(src).toContain('remotePatterns');
+    });
+
+    it('declares custom headers for sw.js and manifest.json', () => {
+      expect(src).toContain('/sw.js');
+      expect(src).toContain('/manifest.json');
+    });
+
+    it('enables reactCompiler experimental flag', () => {
+      expect(src).toContain('reactCompiler');
+    });
+
+    it('conditionally integrates bundle analyzer via ANALYZE env var', () => {
+      expect(src).toContain('ANALYZE');
+      expect(src).toContain('bundle-analyzer');
+    });
+
+    it('uses ESM export (export default)', () => {
+      expect(src).toContain('export default');
+      expect(src).not.toContain('module.exports');
+    });
+  });
+});

--- a/docs/repo-issue-backlog-2026-05.md
+++ b/docs/repo-issue-backlog-2026-05.md
@@ -47,3 +47,23 @@ The repo had a bundle-size CI workflow but it was rudimentary — it measured th
 - `client/next.config.mjs` — conditional bundle analyzer integration
 - `.github/workflows/bundle-size.yml` — CI workflow
 - `client/__tests__/lib/check-bundle-size.test.ts` — unit tests
+
+## #598 — [P0] Unify conflicting Next.js configuration files
+
+**Scope:** architecture
+**Priority:** P0
+
+**Summary:**
+The repo contained three conflicting Next.js config files: a root-level `next.config.js` (stale CJS, no Sentry/images/headers), a root-level `next.config.ts` (empty placeholder), and `client/next.config.mjs` (the complete, production config). Next.js picks up the first config it finds, so the stale root-level files could silently override the real config.
+
+**Resolution:**
+- Deleted `next.config.js` (root) — stale CJS config with only bundle-analyzer and reactStrictMode
+- Deleted `next.config.ts` (root) — empty placeholder with no configuration
+- Retained `client/next.config.mjs` as the sole active config (Sentry, images, headers, reactCompiler, bundle analyzer)
+- Added CI verification step to `.github/workflows/ci.yml` (`validate-dependencies` job) that asserts no root-level `next.config.*` exists and exactly one config (`next.config.mjs`) exists under `client/`
+- Added `client/__tests__/next-config.test.ts` with 9 tests verifying the unified config shape (file existence, no stale configs, Sentry wrapping, images, headers, reactCompiler, bundle analyzer, ESM export)
+
+**Key files:**
+- `client/next.config.mjs` — sole active Next.js config
+- `.github/workflows/ci.yml` — CI enforcement step
+- `client/__tests__/next-config.test.ts` — test coverage

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,0 @@
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYZE === 'true',
-  openAnalyzer: true, // 👈 IMPORTANT
-});
-
-module.exports = withBundleAnalyzer({
-  reactStrictMode: true,
-});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "drips",
+  "name": "SYNCRO",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,


### PR DESCRIPTION
This PR resolves #598 by removing stale root-level Next.js configs and keeping only `client/next.config.mjs` as the active config. It adds CI verification and dedicated tests to ensure no stale config files exist and the active config contains the expected production settings.