### PR TITLE
docs: add API changelog, deprecation policy, and SDK release notes (#…

### DIFF
--- a/docs/api-changelog.md
+++ b/docs/api-changelog.md
@@ -1,0 +1,63 @@
+# API Changelog
+
+All notable API changes are documented here. Entries are grouped by backend version and tagged as **breaking** or **non-breaking**.
+
+A change is **breaking** if it removes or renames an endpoint, removes or renames a required/optional field, changes a field's type, or alters authentication requirements. Everything else is **non-breaking**.
+
+---
+
+## [Unreleased]
+
+_Changes staged for the next release._
+
+---
+
+## [1.1.0] — 2026-05-29
+
+### Non-breaking
+
+- `GET /api/subscriptions` — added optional `tag` query parameter for filtering by custom tag.
+- `POST /api/subscriptions` — `notes` field is now accepted (string, max 1000 chars).
+- `GET /api/analytics/spend` — new endpoint returning monthly spend aggregates per currency.
+- Webhook events: added `subscription.paused` and `subscription.resumed` event types.
+- `GET /api/health` — response now includes `db_latency_ms` field.
+
+### Breaking
+
+_None._
+
+---
+
+## [1.0.0] — 2026-04-01
+
+Initial stable release.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/subscriptions` | Create a subscription |
+| `GET` | `/api/subscriptions` | List subscriptions (paginated) |
+| `GET` | `/api/subscriptions/:id` | Get a subscription |
+| `PATCH` | `/api/subscriptions/:id` | Update a subscription |
+| `DELETE` | `/api/subscriptions/:id` | Delete a subscription |
+| `POST` | `/api/webhooks` | Register a webhook |
+| `GET` | `/api/webhooks` | List webhooks |
+| `DELETE` | `/api/webhooks/:id` | Delete a webhook |
+| `GET` | `/api/health` | Health check |
+| `GET` | `/api/analytics/spend` | Spend analytics |
+
+### Authentication
+
+All routes require a bearer token (`Authorization: Bearer <token>`) or an API key (`x-api-key` header). See [authentication.mdx](./authentication.mdx).
+
+---
+
+## How to Add an Entry
+
+When opening a PR that changes the API:
+
+1. Add an entry under `[Unreleased]` in this file.
+2. Tag it `**breaking**` or `**non-breaking**`.
+3. For breaking changes, also update [deprecation-policy.md](./deprecation-policy.md) if a migration window applies.
+4. On release, move `[Unreleased]` entries to a new versioned section.

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -1,0 +1,70 @@
+# Deprecation Policy
+
+This document defines how Syncro communicates and manages API and SDK deprecations.
+
+---
+
+## Deprecation Windows
+
+| Change type | Minimum notice | Removal eligible after |
+|-------------|---------------|------------------------|
+| Non-breaking removal (optional field, additive endpoint) | 1 release cycle (~4 weeks) | Next minor version |
+| Breaking change (required field, endpoint rename/removal) | 2 release cycles (~8 weeks) | Next major version |
+| Authentication scheme change | 3 release cycles (~12 weeks) | Next major version |
+| SDK major version drop | 2 release cycles (~8 weeks) | After successor SDK reaches stable |
+
+A **release cycle** is approximately 4 weeks. Dates are announced in [api-changelog.md](./api-changelog.md) and the [sdk/CHANGELOG.md](../sdk/CHANGELOG.md).
+
+---
+
+## Process
+
+### 1. Announce
+
+When a feature is scheduled for removal:
+
+- Add a `Deprecated` entry to [api-changelog.md](./api-changelog.md) under `[Unreleased]`.
+- Add a `### Deprecated` section to [sdk/CHANGELOG.md](../sdk/CHANGELOG.md) for the next SDK release.
+- Set the `sunset` response header on deprecated endpoints:
+  ```
+  Sunset: Sat, 01 Aug 2026 00:00:00 GMT
+  Deprecation: true
+  ```
+- Log a deprecation warning in the SDK when the deprecated method is called.
+
+### 2. Migrate
+
+Provide a migration path in the changelog entry. Example:
+
+> **Deprecated:** `GET /api/subscriptions?filter=` — use `?status=` instead. Removed in v2.0.0.
+
+### 3. Remove
+
+- Removal only happens in a **major** version bump for breaking changes.
+- Non-breaking removals may happen in a minor version after the notice window.
+- The removal entry moves from `Deprecated` to `Removed` in the changelog.
+
+---
+
+## Currently Deprecated
+
+_Nothing is currently deprecated._
+
+When items are deprecated, they will be listed here with their sunset date and migration path.
+
+---
+
+## SDK Compatibility Matrix
+
+| SDK version | Backend version | Support status |
+|-------------|----------------|----------------|
+| `@syncro/sdk` v1.1.x | `synchro` v1.0.x – v1.1.x | ✅ Active |
+| `@syncro/sdk` v1.0.x | `synchro` v1.0.x | ⚠️ Security fixes only |
+
+SDK versions receive security fixes for one major version behind the current stable release.
+
+---
+
+## Questions
+
+Open an issue or contact the backend team (see [CODEOWNERS](../.github/CODEOWNERS)).

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,67 @@
+# @syncro/sdk Changelog
+
+All notable changes to the SDK are documented here.
+
+Each release notes the minimum compatible backend version (`synchro`). If your backend is older than the listed minimum, upgrade the backend before upgrading the SDK.
+
+---
+
+## [Unreleased]
+
+_Changes staged for the next release._
+
+---
+
+## [1.1.0] — 2026-05-29
+
+**Requires backend:** `synchro` ≥ 1.0.0
+
+### Added
+
+- `listSubscriptions({ tag })` — filter by custom tag (maps to `GET /api/subscriptions?tag=`).
+- `createSubscription({ notes })` — optional `notes` field now forwarded to the API.
+- `getSpendAnalytics()` — new method wrapping `GET /api/analytics/spend`.
+- Webhook event types `subscription.paused` and `subscription.resumed` are now included in the `WebhookEvent` union type.
+- `SyncroSDK.healthCheck()` — response type now includes `db_latency_ms: number`.
+
+### Changed
+
+- Logger output now includes the SDK version in every log line for easier debugging.
+
+### Fixed
+
+- Retry logic no longer retries on `400 Bad Request` responses (only `429` and `5xx`).
+
+---
+
+## [1.0.0] — 2026-04-01
+
+**Requires backend:** `synchro` ≥ 1.0.0
+
+Initial stable release.
+
+### Added
+
+- `SyncroSDK` class with configurable `apiKey`, `baseUrl`, `timeout`, and `retries`.
+- `createSubscription(payload)` — `POST /api/subscriptions`
+- `listSubscriptions(filters?)` — `GET /api/subscriptions`
+- `getSubscription(id)` — `GET /api/subscriptions/:id`
+- `updateSubscription(id, patch)` — `PATCH /api/subscriptions/:id`
+- `deleteSubscription(id)` — `DELETE /api/subscriptions/:id`
+- `createWebhook(payload)` — `POST /api/webhooks`
+- `listWebhooks()` — `GET /api/webhooks`
+- `deleteWebhook(id)` — `DELETE /api/webhooks/:id`
+- `healthCheck()` — `GET /api/health`
+- `SyncroError` class with `statusCode` and `message` fields.
+- Exponential backoff retry on `429` and `5xx` responses (configurable via `retries`).
+- Structured logger (opt-in via `logger` config option).
+- Batch operations helper with configurable concurrency limit.
+
+---
+
+## How to Add an Entry
+
+1. Add changes under `[Unreleased]` using the sections `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`.
+2. Always note the minimum compatible backend version.
+3. For breaking changes, also update [docs/deprecation-policy.md](../docs/deprecation-policy.md).
+4. On release, rename `[Unreleased]` to the new version with today's date.


### PR DESCRIPTION
docs: API changelog, deprecation policy, and SDK release notes (#118)
  
  Prevents backend/SDK drift by establishing a clear paper trail for all API
  contract changes.
  
  What's added:
  
  - docs/api-changelog.md — versioned log of breaking and non-breaking API
  changes, with contributor instructions for adding entries on every PR
  - docs/deprecation-policy.md — defines deprecation windows by change type (1–3
  release cycles), the Sunset header convention, removal process, and SDK
  compatibility matrix
  - sdk/CHANGELOG.md — SDK release notes for v1.0.0 and v1.1.0, each referencing
  the minimum compatible backend (synchro) version
  
  Acceptance criteria:
  
  - ✅ Breaking and non-breaking API changes are logged
  - ✅ Deprecation windows are documented
  - ✅ SDK release notes reference backend versions
closes #712