### PR TITLE
feat: Add payment channel management, reminder jitter, and blinding f…

### DIFF
--- a/backend/src/routes/compliance.ts
+++ b/backend/src/routes/compliance.ts
@@ -105,6 +105,7 @@ router.get('/export', authenticate, exportRateLimit, async (req: AuthenticatedRe
     archive.append(JSON.stringify(data.emailAccounts, null, 2), { name: 'email_accounts.json' });
     archive.append(JSON.stringify(data.teams, null, 2), { name: 'teams.json' });
     archive.append(JSON.stringify(data.blockchainLogs, null, 2), { name: 'blockchain_logs.json' });
+    archive.append(JSON.stringify(data.blindingFactors, null, 2), { name: 'blinding_factors.json' });
 
     const readme = [
       'Syncro — Personal Data Export',
@@ -121,6 +122,7 @@ router.get('/export', authenticate, exportRateLimit, async (req: AuthenticatedRe
       '  email_accounts.json — Connected email accounts',
       '  teams.json          — Team membership records',
       '  blockchain_logs.json — On-chain contract events and renewal approvals',
+      '  blinding_factors.json — Pedersen commitment blinding factors for audit data',
       '',
       'For questions or deletion requests, contact support.',
     ].join('\n');

--- a/backend/src/schemas/user-preferences.ts
+++ b/backend/src/schemas/user-preferences.ts
@@ -12,6 +12,7 @@ export const userPreferencesUpdateSchema = z.object({
     .min(1, 'At least one reminder timing is required')
     .max(10, 'Maximum 10 reminder timings allowed')
     .optional(),
+  reminder_jitter_level: z.enum(['off', 'low', 'medium', 'high']).optional(),
   email_opt_ins: z
     .object({
       marketing: z.boolean().optional(),

--- a/backend/src/services/compliance-service.ts
+++ b/backend/src/services/compliance-service.ts
@@ -15,6 +15,7 @@ export interface UserExportData {
     contractEvents: any[];
     renewalApprovals: any[];
   };
+  blindingFactors: any[];
 }
 
 interface TokenVerificationResult {
@@ -86,6 +87,7 @@ export class ComplianceService {
       teamsResult,
       contractEventsResult,
       renewalApprovalsResult,
+      blindingFactorsResult,
     ] = await Promise.all([
       supabase.from('profiles').select('*').eq('id', userId).single(),
       supabase.from('subscriptions').select('*').eq('user_id', userId),
@@ -96,6 +98,7 @@ export class ComplianceService {
       supabase.from('team_members').select('*').eq('user_id', userId),
       supabase.from('contract_events').select('*').eq('user_id', userId),
       supabase.from('renewal_approvals').select('*').eq('user_id', userId),
+      supabase.from('commitment_blinding_factors').select('*').eq('user_id', userId),
     ]);
 
     return {
@@ -110,6 +113,7 @@ export class ComplianceService {
         contractEvents: contractEventsResult.data || [],
         renewalApprovals: renewalApprovalsResult.data || [],
       },
+      blindingFactors: blindingFactorsResult.data || [],
     };
   }
 

--- a/backend/src/services/reminder-engine.ts
+++ b/backend/src/services/reminder-engine.ts
@@ -128,21 +128,46 @@ export class ReminderEngine {
       throw preferencesError;
     }
 
-    const prefsByUser = new Map<string, { reminder_timing?: number[] }>();
-    (preferences ?? []).forEach((pref: { user_id: string; reminder_timing?: number[] }) => {
+    const prefsByUser = new Map<string, { reminder_timing?: number[]; reminder_jitter_level?: string }>();
+    (preferences ?? []).forEach((pref: { user_id: string; reminder_timing?: number[]; reminder_jitter_level?: string }) => {
       prefsByUser.set(pref.user_id, pref);
     });
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
+    const jitterLevels: Record<string, number> = {
+      off: 0,
+      low: 2,
+      medium: 6,
+      high: 12
+    };
+
     for (const subscription of activeSubscriptions) {
-      const timing = prefsByUser.get(subscription.user_id)?.reminder_timing ?? daysBefore;
+      const userPref = prefsByUser.get(subscription.user_id);
+      const timing = userPref?.reminder_timing ?? daysBefore;
+      const jitterLevel = userPref?.reminder_jitter_level ?? 'off';
+      const maxJitter = jitterLevels[jitterLevel] || 0;
       const renewalDate = new Date(subscription.active_until as string);
 
       for (const day of timing) {
-        const reminderDate = subDays(renewalDate, day);
+        // Calculate base reminder date
+        let reminderDate = subDays(renewalDate, day);
         reminderDate.setHours(0, 0, 0, 0);
+
+        let jitterOffsetHours = 0;
+        if (maxJitter > 0) {
+          // Generate random jitter between -maxJitter and +maxJitter
+          jitterOffsetHours = (Math.random() * 2 * maxJitter) - maxJitter;
+          // Apply jitter
+          reminderDate = new Date(reminderDate.getTime() + jitterOffsetHours * 60 * 60 * 1000);
+          // Ensure reminder is not after renewal date
+          if (reminderDate > renewalDate) {
+            reminderDate = new Date(renewalDate);
+            // Recalculate offset to be the maximum possible before renewal
+            jitterOffsetHours = (renewalDate.getTime() - subDays(renewalDate, day).setHours(0,0,0,0)) / (60*60*1000);
+          }
+        }
 
         if (reminderDate >= today) {
           rows.push({
@@ -151,6 +176,7 @@ export class ReminderEngine {
             reminder_date: reminderDate.toISOString().split('T')[0],
             reminder_type: 'renewal',
             days_before: day,
+            jitter_offset_hours: maxJitter > 0 ? jitterOffsetHours : null,
             status: 'pending',
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),

--- a/backend/src/services/user-preference-service.ts
+++ b/backend/src/services/user-preference-service.ts
@@ -4,29 +4,30 @@ import { UserPreferences, PartialUserPreferences } from '../types/reminder';
 
 export class UserPreferenceService {
     private readonly defaultPreferences: Omit<UserPreferences, 'user_id' | 'updated_at'> = {
-        notification_channels: ['email'],
-        reminder_timing: [7, 3, 1],
-        email_opt_ins: {
-            marketing: false,
-            reminders: true,
-            updates: true,
-        },
-        automation_flags: {
-            auto_renew: false,
-            auto_retry: true,
-        },
-        risk_notification_threshold: 'HIGH',
-        quiet_hours_enabled: false,
-        quiet_hours_start: '22:00',
-        quiet_hours_end: '08:00',
-        quiet_hours_timezone: 'UTC',
-        critical_alerts_only: true,
-        currency: 'USD',
-        timezone: 'UTC',
-        locale: 'en-US',
-        calendar_sync_enabled: false,
-        calendar_export_reminders: true,
-    };
+    notification_channels: ['email'],
+    reminder_timing: [7, 3, 1],
+    reminder_jitter_level: 'off', // default to no jitter
+    email_opt_ins: {
+      marketing: false,
+      reminders: true,
+      updates: true,
+    },
+    automation_flags: {
+      auto_renew: false,
+      auto_retry: true,
+    },
+    risk_notification_threshold: 'HIGH',
+    quiet_hours_enabled: false,
+    quiet_hours_start: '22:00',
+    quiet_hours_end: '08:00',
+    quiet_hours_timezone: 'UTC',
+    critical_alerts_only: true,
+    currency: 'USD',
+    timezone: 'UTC',
+    locale: 'en-US',
+    calendar_sync_enabled: false,
+    calendar_export_reminders: true,
+  };
 
     /**
      * Get user preferences, returning defaults if not found

--- a/backend/src/types/reminder.ts
+++ b/backend/src/types/reminder.ts
@@ -6,6 +6,7 @@ export interface ReminderSchedule {
   reminder_type: 'renewal' | 'trial_expiry' | 'cancellation';
   days_before: number;
   status: 'pending' | 'sent' | 'failed' | 'cancelled';
+  jitter_offset_hours?: number; // ±N hours, stored for audit
   created_at: string;
   updated_at: string;
 }
@@ -105,6 +106,7 @@ export interface UserPreferences {
   user_id: string;
   notification_channels: ('email' | 'push' | 'telegram' | 'slack')[];
   reminder_timing: number[]; // days before
+  reminder_jitter_level: 'off' | 'low' | 'medium' | 'high'; // low=±2h, medium=±6h, high=±12h
   email_opt_ins: {
     marketing: boolean;
     reminders: boolean;

--- a/client/app/settings/privacy/channels/page.tsx
+++ b/client/app/settings/privacy/channels/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getChannels, PaymentChannel } from '@/lib/payment-channel';
+import { ChannelCard } from '@/components/channels/ChannelCard';
+import { ChannelDetail } from '@/components/channels/ChannelDetail';
+import { OpenChannelModal } from '@/components/channels/OpenChannelModal';
+import { Button } from '@/components/ui/button';
+
+export default function ChannelsPage() {
+  const [channels, setChannels] = useState<PaymentChannel[]>([]);
+  const [selectedChannel, setSelectedChannel] = useState<PaymentChannel | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadChannels = async () => {
+    try {
+      const data = await getChannels();
+      setChannels(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadChannels();
+    // Poll for updates every 10 seconds
+    const interval = setInterval(loadChannels, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleChannelOpened = (channel: PaymentChannel) => {
+    setChannels((prev) => [...prev, channel]);
+  };
+
+  const handleChannelUpdate = (updated: PaymentChannel) => {
+    setChannels((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    setSelectedChannel(updated);
+  };
+
+  const hasLowBalance = channels.some((c) => parseFloat(c.balance) < 10);
+  const hasExpiring = channels.some((c) => c.expiry && new Date(c.expiry) < new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <Link
+              href="/settings/privacy"
+              className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 mb-4 transition-colors"
+            >
+              <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+              Back to Privacy & Data
+            </Link>
+            <h1 className="text-2xl font-semibold text-gray-900 mb-1">Payment Channels</h1>
+            <p className="text-sm text-gray-500">Open, monitor, and manage your payment channels.</p>
+          </div>
+          <Button onClick={() => setIsModalOpen(true)}>Open Channel</Button>
+        </div>
+
+        {(hasLowBalance || hasExpiring) && (
+          <div className="mb-6 space-y-3">
+            {hasLowBalance && (
+              <div className="flex items-start gap-2 text-sm text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-3">
+                <svg className="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                </svg>
+                <span>One or more channels have low balances. Consider topping up to avoid service interruptions.</span>
+              </div>
+            )}
+            {hasExpiring && (
+              <div className="flex items-start gap-2 text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded-lg px-4 py-3">
+                <svg className="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>One or more channels are expiring soon. Close or renew them to avoid disputes.</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {selectedChannel ? (
+          <ChannelDetail
+            channel={selectedChannel}
+            onBack={() => setSelectedChannel(null)}
+            onUpdate={handleChannelUpdate}
+          />
+        ) : (
+          <>
+            {isLoading ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                {[1, 2].map((i) => (
+                  <div key={i} className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 animate-pulse">
+                    <div className="h-6 bg-gray-200 rounded w-1/2 mb-2" />
+                    <div className="h-4 bg-gray-200 rounded w-1/3 mb-6" />
+                    <div className="h-8 bg-gray-200 rounded w-1/4 mb-2" />
+                    <div className="h-4 bg-gray-200 rounded w-2/3" />
+                  </div>
+                ))}
+              </div>
+            ) : channels.length === 0 ? (
+              <div className="text-center py-12">
+                <h3 className="text-lg font-medium text-gray-900 mb-2">No channels yet</h3>
+                <p className="text-sm text-gray-500 mb-6">Open a payment channel to get started.</p>
+                <Button onClick={() => setIsModalOpen(true)}>Open Channel</Button>
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                {channels.map((channel) => (
+                  <ChannelCard
+                    key={channel.id}
+                    channel={channel}
+                    onSelect={setSelectedChannel}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <OpenChannelModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onChannelOpened={handleChannelOpened}
+      />
+    </main>
+  );
+}

--- a/client/app/settings/privacy/page.tsx
+++ b/client/app/settings/privacy/page.tsx
@@ -9,6 +9,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 type ExportStatus = 'idle' | 'pending' | 'ready' | 'error';
 type DeleteStatus = 'idle' | 'scheduled' | 'error';
+type JitterLevel = 'off' | 'low' | 'medium' | 'high';
 
 interface JobState {
   jobId: string | null;
@@ -68,6 +69,25 @@ function triggerDownload(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+async function fetchUserPreferences(): Promise<{ reminder_jitter_level?: JitterLevel }> {
+  const res = await fetch(`${API_BASE}/api/user-preferences`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch user preferences');
+  const json = await res.json();
+  return json.data;
+}
+
+async function updateUserPreferences(updates: { reminder_jitter_level: JitterLevel }): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/user-preferences`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  });
+  if (!res.ok) throw new Error('Failed to update user preferences');
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function DataPrivacyPage() {
@@ -90,12 +110,42 @@ export default function DataPrivacyPage() {
   const [confirmed, setConfirmed] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  // ── Jitter state ──────────────────────────────────────────────────────────
+  const [jitterLevel, setJitterLevel] = useState<JitterLevel>('off');
+  const [jitterLoading, setJitterLoading] = useState(false);
+  const [jitterError, setJitterError] = useState<string | null>(null);
+
   // ── Cleanup on unmount ────────────────────────────────────────────────────
   useEffect(() => {
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
     };
   }, []);
+
+  // ── Load jitter preference ───────────────────────────────────────────────────
+  useEffect(() => {
+    fetchUserPreferences()
+      .then(prefs => {
+        if (prefs.reminder_jitter_level) {
+          setJitterLevel(prefs.reminder_jitter_level);
+        }
+      })
+      .catch(err => console.error(err));
+  }, []);
+
+  // ── Handle jitter change ──────────────────────────────────────────────────
+  const handleJitterChange = async (newLevel: JitterLevel) => {
+    setJitterLoading(true);
+    setJitterError(null);
+    try {
+      await updateUserPreferences({ reminder_jitter_level: newLevel });
+      setJitterLevel(newLevel);
+    } catch (err) {
+      setJitterError(err instanceof Error ? err.message : 'Failed to update preference');
+    } finally {
+      setJitterLoading(false);
+    }
+  };
 
   // ── Export polling ────────────────────────────────────────────────────────
   const stopPolling = useCallback(() => {
@@ -145,7 +195,7 @@ export default function DataPrivacyPage() {
           }));
         } else {
           // still pending
-          setExportJob((prev) => ({ ...prev, lastChecked: now }));
+          setExportJob((prev) => ({ ...prev, lastChecked: now });
         }
       } catch (err) {
         stopPolling();
@@ -233,6 +283,13 @@ export default function DataPrivacyPage() {
   const exportIsBusy = exportJob.status === 'pending';
   const exportLabel = exportIsBusy ? 'Preparing export…' : 'Download Export (ZIP)';
 
+  const jitterOptions: { value: JitterLevel; label: string; description: string }[] = [
+    { value: 'off', label: 'Off', description: 'No jitter — reminders sent exactly on schedule' },
+    { value: 'low', label: 'Low', description: '± 2 hours' },
+    { value: 'medium', label: 'Medium', description: '± 6 hours' },
+    { value: 'high', label: 'High', description: '± 12 hours' },
+  ];
+
   return (
     <main className="min-h-screen bg-gray-50 py-12 px-4">
       <div className="max-w-2xl mx-auto">
@@ -251,7 +308,41 @@ export default function DataPrivacyPage() {
         <p className="text-sm text-gray-500 mb-8">Manage your personal data and privacy preferences.</p>
 
         <div className="space-y-6">
-          {/* ── Section 1: Export ─────────────────────────────────────────── */}
+          {/* ── Section: Reminder Jitter ────────────────────────────────────────── */}
+          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6" aria-labelledby="jitter-heading">
+            <h2 id="jitter-heading" className="text-base font-semibold text-gray-900 mb-1">Reminder Timing Jitter</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Add random jitter to subscription renewal reminders to prevent network observers from correlating reminders with gift card purchases.
+            </p>
+
+            {jitterError && (
+              <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-4">
+                {jitterError}
+              </div>
+            )}
+
+            <div className="space-y-3">
+              {jitterOptions.map(option => (
+                <label key={option.value} className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="jitter"
+                    value={option.value}
+                    checked={jitterLevel === option.value}
+                    onChange={() => handleJitterChange(option.value)}
+                    disabled={jitterLoading}
+                    className="mt-0.5 w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-gray-900">{option.label}</div>
+                    <div className="text-xs text-gray-500">{option.description}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          {/* ── Section: Export ─────────────────────────────────────────── */}
           <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6" aria-labelledby="export-heading">
             <h2 id="export-heading" className="text-base font-semibold text-gray-900 mb-1">Export Your Data</h2>
             <p className="text-sm text-gray-500 mb-4">
@@ -306,7 +397,7 @@ export default function DataPrivacyPage() {
             </button>
           </section>
 
-          {/* ── Section 2: Email Preferences ─────────────────────────────── */}
+          {/* ── Section: Email Preferences ─────────────────────────────── */}
           <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6" aria-labelledby="email-prefs-heading">
             <h2 id="email-prefs-heading" className="text-base font-semibold text-gray-900 mb-1">Email Preferences</h2>
             <p className="text-sm text-gray-500 mb-4">
@@ -321,7 +412,7 @@ export default function DataPrivacyPage() {
             </Link>
           </section>
 
-          {/* ── Section 3: Delete Account ─────────────────────────────────── */}
+          {/* ── Section: Delete Account ─────────────────────────────────── */}
           <section className="bg-white rounded-2xl border border-red-200 shadow-sm p-6" aria-labelledby="delete-heading">
             <h2 id="delete-heading" className="text-base font-semibold text-gray-900 mb-1">Delete Account</h2>
             <p className="text-sm text-gray-500 mb-4">

--- a/client/components/channels/ChannelCard.tsx
+++ b/client/components/channels/ChannelCard.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { PaymentChannel } from '@/lib/payment-channel';
+
+interface ChannelCardProps {
+  channel: PaymentChannel;
+  onSelect: (channel: PaymentChannel) => void;
+}
+
+export function ChannelCard({ channel, onSelect }: ChannelCardProps) {
+  const getStateColor = (state: string) => {
+    switch (state) {
+      case 'active':
+        return 'bg-green-100 text-green-800';
+      case 'closing':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'closed':
+        return 'bg-gray-100 text-gray-800';
+      case 'dispute':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const isLowBalance = parseFloat(channel.balance) < 10;
+
+  return (
+    <div
+      onClick={() => onSelect(channel)}
+      className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 hover:shadow-md transition-shadow cursor-pointer"
+    >
+      <div className="flex justify-between items-start mb-4">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">{channel.counterparty}</h3>
+          <p className="text-sm text-gray-500">ID: {channel.id.slice(0, 8)}...</p>
+        </div>
+        <span className={`px-3 py-1 rounded-full text-xs font-medium ${getStateColor(channel.state)}`}>
+          {channel.state}
+        </span>
+      </div>
+      <div className="mb-4">
+        <p className="text-sm text-gray-500">Balance</p>
+        <p className="text-2xl font-bold text-gray-900">${channel.balance}</p>
+        {isLowBalance && (
+          <div className="flex items-center gap-2 text-sm text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-lg px-3 py-2 mt-2">
+            <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+            Low balance - consider topping up
+          </div>
+        )}
+      </div>
+      <div className="text-sm text-gray-500">
+        Last updated: {new Date(channel.lastUpdated).toLocaleString()}
+      </div>
+      {channel.expiry && (
+        <div className="flex items-center gap-2 text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded-lg px-3 py-2 mt-2">
+          <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Expires: {new Date(channel.expiry).toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/channels/ChannelDetail.tsx
+++ b/client/components/channels/ChannelDetail.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { PaymentChannel, topUpChannel, closeChannel } from '@/lib/payment-channel';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ChannelDetailProps {
+  channel: PaymentChannel;
+  onBack: () => void;
+  onUpdate: (channel: PaymentChannel) => void;
+}
+
+export function ChannelDetail({ channel, onBack, onUpdate }: ChannelDetailProps) {
+  const [topUpAmount, setTopUpAmount] = useState('');
+  const [isTopUpLoading, setIsTopUpLoading] = useState(false);
+  const [isCloseLoading, setIsCloseLoading] = useState(false);
+
+  const handleTopUp = async () => {
+    if (!topUpAmount || parseFloat(topUpAmount) <= 0) return;
+    setIsTopUpLoading(true);
+    try {
+      const updated = await topUpChannel(channel.id, topUpAmount);
+      onUpdate(updated);
+      setTopUpAmount('');
+    } catch (err) {
+      console.error(err);
+      alert('Failed to top up channel');
+    } finally {
+      setIsTopUpLoading(false);
+    }
+  };
+
+  const handleClose = async (unilateral: boolean = false) => {
+    setIsCloseLoading(true);
+    try {
+      const updated = await closeChannel(channel.id, unilateral);
+      onUpdate(updated);
+    } catch (err) {
+      console.error(err);
+      alert('Failed to close channel');
+    } finally {
+      setIsCloseLoading(false);
+    }
+  };
+
+  const getStateColor = (state: string) => {
+    switch (state) {
+      case 'active':
+        return 'bg-green-100 text-green-800';
+      case 'closing':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'closed':
+        return 'bg-gray-100 text-gray-800';
+      case 'dispute':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
+      <button
+        onClick={onBack}
+        className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 mb-6 transition-colors"
+      >
+        <svg className="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to channels
+      </button>
+
+      <div className="flex justify-between items-start mb-8">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">{channel.counterparty}</h1>
+          <p className="text-sm text-gray-500">ID: {channel.id}</p>
+        </div>
+        <span className={`px-4 py-2 rounded-full text-sm font-medium ${getStateColor(channel.state)}`}>
+          {channel.state}
+        </span>
+      </div>
+
+      <div className="mb-8 p-6 bg-gray-50 rounded-xl">
+        <p className="text-sm text-gray-500 mb-2">Current Balance</p>
+        <p className="text-4xl font-bold text-gray-900">${channel.balance}</p>
+      </div>
+
+      {channel.state === 'active' && (
+        <div className="mb-8 p-6 border border-gray-200 rounded-xl">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Top Up Channel</h2>
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <Label htmlFor="topup-amount">Amount ($)</Label>
+              <Input
+                id="topup-amount"
+                type="number"
+                step="0.01"
+                value={topUpAmount}
+                onChange={(e) => setTopUpAmount(e.target.value)}
+                placeholder="10.00"
+                disabled={isTopUpLoading}
+              />
+            </div>
+            <div className="flex items-end">
+              <Button onClick={handleTopUp} disabled={isTopUpLoading || !topUpAmount}>
+                {isTopUpLoading ? 'Top Up...' : 'Top Up'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {channel.history && channel.history.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">History</h2>
+          <div className="space-y-3">
+            {channel.history.map((item) => (
+              <div key={item.id} className="p-4 border border-gray-200 rounded-xl flex justify-between items-center">
+                <div>
+                  <p className="text-sm font-medium text-gray-900 capitalize">{item.type}</p>
+                  {item.description && <p className="text-xs text-gray-500">{item.description}</p>}
+                </div>
+                <div className="text-right">
+                  {item.amount && (
+                    <p className="text-sm font-semibold text-gray-900">${item.amount}</p>
+                  )}
+                  <p className="text-xs text-gray-500">{new Date(item.timestamp).toLocaleString()}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {channel.state === 'active' && (
+        <div className="p-6 border border-red-200 rounded-xl">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Close Channel</h2>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={isCloseLoading}
+            >
+              {isCloseLoading ? 'Closing...' : 'Cooperative Close'}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => handleClose(true)}
+              disabled={isCloseLoading}
+            >
+              {isCloseLoading ? 'Closing...' : 'Unilateral Close'}
+            </Button>
+          </div>
+          <p className="text-xs text-gray-500 mt-3">
+            Cooperative close is recommended. Unilateral close will start a dispute period.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/channels/OpenChannelModal.tsx
+++ b/client/components/channels/OpenChannelModal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { openChannel, PaymentChannel } from '@/lib/payment-channel';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface OpenChannelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onChannelOpened: (channel: PaymentChannel) => void;
+}
+
+export function OpenChannelModal({ isOpen, onClose, onChannelOpened }: OpenChannelModalProps) {
+  const [depositAmount, setDepositAmount] = useState('');
+  const [counterparty, setCounterparty] = useState('SYNCRO Executor');
+  const [isLoading, setIsLoading] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!depositAmount || parseFloat(depositAmount) <= 0) return;
+    setIsLoading(true);
+    try {
+      const channel = await openChannel(depositAmount, counterparty);
+      onChannelOpened(channel);
+      setDepositAmount('');
+      setCounterparty('SYNCRO Executor');
+      onClose();
+    } catch (err) {
+      console.error(err);
+      alert('Failed to open channel');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="open-channel-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6">
+        <h3 id="open-channel-title" className="text-lg font-semibold text-gray-900 mb-4">Open Payment Channel</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="counterparty">Counterparty</Label>
+            <Input
+              id="counterparty"
+              value={counterparty}
+              onChange={(e) => setCounterparty(e.target.value)}
+              placeholder="SYNCRO Executor"
+              disabled={isLoading}
+            />
+          </div>
+          <div>
+            <Label htmlFor="deposit-amount">Deposit Amount ($)</Label>
+            <Input
+              id="deposit-amount"
+              type="number"
+              step="0.01"
+              value={depositAmount}
+              onChange={(e) => setDepositAmount(e.target.value)}
+              placeholder="100.00"
+              disabled={isLoading}
+              required
+            />
+          </div>
+          <div className="flex justify-end gap-3 pt-4">
+            <Button type="button" variant="outline" onClick={onClose} disabled={isLoading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading || !depositAmount}>
+              {isLoading ? 'Opening...' : 'Open Channel'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/lib/payment-channel.ts
+++ b/client/lib/payment-channel.ts
@@ -1,0 +1,68 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface PaymentChannel {
+  id: string;
+  counterparty: string;
+  balance: string;
+  state: 'active' | 'closing' | 'closed' | 'dispute';
+  lastUpdated: string;
+  expiry?: string;
+  history?: ChannelHistoryItem[];
+}
+
+export interface ChannelHistoryItem {
+  id: string;
+  type: 'open' | 'topup' | 'payment' | 'close' | 'dispute';
+  amount?: string;
+  timestamp: string;
+  description?: string;
+}
+
+export async function getChannels(): Promise<PaymentChannel[]> {
+  const res = await fetch(`${API_BASE}/api/payment-channels`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch channels');
+  return res.json();
+}
+
+export async function openChannel(depositAmount: string, counterparty: string = 'SYNCRO Executor'): Promise<PaymentChannel> {
+  const res = await fetch(`${API_BASE}/api/payment-channels`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ depositAmount, counterparty }),
+  });
+  if (!res.ok) throw new Error('Failed to open channel');
+  return res.json();
+}
+
+export async function topUpChannel(channelId: string, amount: string): Promise<PaymentChannel> {
+  const res = await fetch(`${API_BASE}/api/payment-channels/${channelId}/topup`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ amount }),
+  });
+  if (!res.ok) throw new Error('Failed to top up channel');
+  return res.json();
+}
+
+export async function closeChannel(channelId: string, unilateral: boolean = false): Promise<PaymentChannel> {
+  const res = await fetch(`${API_BASE}/api/payment-channels/${channelId}/close`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ unilateral }),
+  });
+  if (!res.ok) throw new Error('Failed to close channel');
+  return res.json();
+}
+
+export async function getChannel(channelId: string): Promise<PaymentChannel> {
+  const res = await fetch(`${API_BASE}/api/payment-channels/${channelId}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to fetch channel');
+  return res.json();
+}

--- a/client/supabase/migrations/20260623000000_add_reminder_jitter.sql
+++ b/client/supabase/migrations/20260623000000_add_reminder_jitter.sql
@@ -1,0 +1,8 @@
+-- Add reminder_jitter_level to user_preferences
+ALTER TABLE user_preferences 
+ADD COLUMN IF NOT EXISTS reminder_jitter_level TEXT DEFAULT 'off' 
+CHECK (reminder_jitter_level IN ('off', 'low', 'medium', 'high'));
+
+-- Add jitter_offset_hours to reminder_schedules
+ALTER TABLE reminder_schedules 
+ADD COLUMN IF NOT EXISTS jitter_offset_hours NUMERIC;

--- a/client/supabase/migrations/20260623000001_create_commitment_blinding_factors.sql
+++ b/client/supabase/migrations/20260623000001_create_commitment_blinding_factors.sql
@@ -1,0 +1,35 @@
+-- Create commitment_blinding_factors table
+CREATE TABLE IF NOT EXISTS commitment_blinding_factors (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_id VARCHAR(255) NOT NULL,
+  commitment_hash VARCHAR(255) NOT NULL,
+  blinding_factor TEXT NOT NULL,
+  event_data_plaintext JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(user_id, event_id)
+);
+
+CREATE INDEX idx_commitment_blinding_factors_user_id ON commitment_blinding_factors(user_id);
+CREATE INDEX idx_commitment_blinding_factors_event_id ON commitment_blinding_factors(event_id);
+CREATE INDEX idx_commitment_blinding_factors_commitment_hash ON commitment_blinding_factors(commitment_hash);
+
+-- Enable RLS
+ALTER TABLE commitment_blinding_factors ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+CREATE POLICY "commitment_blinding_factors_select_own"
+  ON commitment_blinding_factors FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_insert_own"
+  ON commitment_blinding_factors FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_update_own"
+  ON commitment_blinding_factors FOR UPDATE
+  USING (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_delete_own"
+  ON commitment_blinding_factors FOR DELETE
+  USING (user_id = auth.uid());

--- a/supabase/migrations/20260623000000_add_reminder_jitter.sql
+++ b/supabase/migrations/20260623000000_add_reminder_jitter.sql
@@ -1,0 +1,8 @@
+-- Add reminder_jitter_level to user_preferences
+ALTER TABLE user_preferences 
+ADD COLUMN IF NOT EXISTS reminder_jitter_level TEXT DEFAULT 'off' 
+CHECK (reminder_jitter_level IN ('off', 'low', 'medium', 'high'));
+
+-- Add jitter_offset_hours to reminder_schedules
+ALTER TABLE reminder_schedules 
+ADD COLUMN IF NOT EXISTS jitter_offset_hours NUMERIC;

--- a/supabase/migrations/20260623000001_create_commitment_blinding_factors.sql
+++ b/supabase/migrations/20260623000001_create_commitment_blinding_factors.sql
@@ -1,0 +1,35 @@
+-- Create commitment_blinding_factors table
+CREATE TABLE IF NOT EXISTS commitment_blinding_factors (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_id VARCHAR(255) NOT NULL,
+  commitment_hash VARCHAR(255) NOT NULL,
+  blinding_factor TEXT NOT NULL,
+  event_data_plaintext JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(user_id, event_id)
+);
+
+CREATE INDEX idx_commitment_blinding_factors_user_id ON commitment_blinding_factors(user_id);
+CREATE INDEX idx_commitment_blinding_factors_event_id ON commitment_blinding_factors(event_id);
+CREATE INDEX idx_commitment_blinding_factors_commitment_hash ON commitment_blinding_factors(commitment_hash);
+
+-- Enable RLS
+ALTER TABLE commitment_blinding_factors ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+CREATE POLICY "commitment_blinding_factors_select_own"
+  ON commitment_blinding_factors FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_insert_own"
+  ON commitment_blinding_factors FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_update_own"
+  ON commitment_blinding_factors FOR UPDATE
+  USING (user_id = auth.uid());
+
+CREATE POLICY "commitment_blinding_factors_delete_own"
+  ON commitment_blinding_factors FOR DELETE
+  USING (user_id = auth.uid());


### PR DESCRIPTION
This commit adds:
1. Payment channel management UI and API
   - New page at /settings/privacy/channels
   - ChannelCard, ChannelDetail, OpenChannelModal components
   - payment-channel.ts API client
2. Reminder timing jitter
   - Add reminder_jitter_level to UserPreferences
   - Add random jitter to reminder scheduling in reminder-engine.ts
   - UI configuration in privacy page
3. Blinding factors data export
   - Create commitment_blinding_factors table with RLS
   - Add blindingFactors to UserExportData in compliance-service.ts
   - Include blinding_factors.json in data export
   - ON DELETE CASCADE for user account deletion


Closes #846 
closes #850 
closes #857 

