### PR TITLE
feat: add end-to-end privacy integration test suite

### DIFF
--- a/.github/workflows/privacy-tests.yml
+++ b/.github/workflows/privacy-tests.yml
@@ -1,0 +1,35 @@
+name: Privacy Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'contracts/**'
+      - 'shared/src/crypto/**'
+      - 'tests/privacy/**'
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/**'
+      - 'shared/src/crypto/**'
+      - 'tests/privacy/**'
+
+jobs:
+  privacy-tests:
+    name: Privacy Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run privacy integration tests
+        run: npx vitest run tests/privacy/ --reporter=verbose

--- a/tests/privacy/audit-log.test.ts
+++ b/tests/privacy/audit-log.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMerkleTree,
+  getMerkleRoot,
+  generateMerkleProof,
+  verifyMerkleProof,
+} from '../../shared/src/crypto/merkle';
+import { createPaymentCommitment } from '../../shared/src/crypto/payment-commitment';
+
+describe('Privacy Integration: Private Audit Log', () => {
+  it('should log events as commitments in a Merkle tree', () => {
+    const events = [
+      'subscription:created:netflix:2025-01-15',
+      'payment:processed:netflix:15.99:2025-02-15',
+      'payment:processed:netflix:15.99:2025-03-15',
+      'subscription:cancelled:netflix:2025-04-01',
+    ];
+
+    const commitments = events.map((event) => {
+      const commitment = createPaymentCommitment(BigInt(event.length), event);
+      return commitment.amountCommitment;
+    });
+
+    const root = getMerkleRoot(commitments);
+    expect(root).toBeDefined();
+    expect(typeof root).toBe('string');
+  });
+
+  it('should generate a Merkle proof for selective disclosure', () => {
+    const events = ['event_a', 'event_b', 'event_c', 'event_d'];
+    const commitments = events.map((e) =>
+      createPaymentCommitment(BigInt(e.length), e).amountCommitment
+    );
+
+    const proof = generateMerkleProof(commitments, 1);
+
+    expect(proof.leaf).toBe(commitments[1]);
+    expect(proof.path.length).toBeGreaterThan(0);
+    expect(proof.root).toBeDefined();
+  });
+
+  it('should verify a valid Merkle proof', () => {
+    const events = ['event_a', 'event_b', 'event_c', 'event_d'];
+    const commitments = events.map((e) =>
+      createPaymentCommitment(BigInt(e.length), e).amountCommitment
+    );
+
+    const proof = generateMerkleProof(commitments, 2);
+    const isValid = verifyMerkleProof(proof);
+    expect(isValid).toBe(true);
+  });
+
+  it('should reject a tampered Merkle proof', () => {
+    const events = ['event_a', 'event_b', 'event_c', 'event_d'];
+    const commitments = events.map((e) =>
+      createPaymentCommitment(BigInt(e.length), e).amountCommitment
+    );
+
+    const proof = generateMerkleProof(commitments, 0);
+    const tamperedProof = {
+      ...proof,
+      leaf: commitments[1],
+    };
+    const isValid = verifyMerkleProof(tamperedProof);
+    expect(isValid).toBe(false);
+  });
+
+  it('should support selective disclosure without revealing other events', () => {
+    const events = [
+      'payment:netflix:15.99',
+      'payment:spotify:9.99',
+      'payment:adobe:54.99',
+      'payment:github:4.00',
+    ];
+
+    const commitments = events.map((e) =>
+      createPaymentCommitment(BigInt(e.length), e).amountCommitment
+    );
+
+    const root = getMerkleRoot(commitments);
+
+    const disclosedIndex = 2;
+    const proof = generateMerkleProof(commitments, disclosedIndex);
+
+    expect(verifyMerkleProof(proof)).toBe(true);
+    expect(proof.root).toBe(root);
+
+    expect(proof.leaf).toBe(commitments[disclosedIndex]);
+    for (let i = 0; i < commitments.length; i++) {
+      if (i !== disclosedIndex) {
+        expect(proof.leaf).not.toBe(commitments[i]);
+      }
+    }
+  });
+
+  it('should maintain audit log integrity across multiple entries', () => {
+    const auditEntries: string[] = [];
+    for (let i = 0; i < 16; i++) {
+      auditEntries.push(`audit_entry_${i}_${Date.now()}`);
+    }
+
+    const commitments = auditEntries.map((e) =>
+      createPaymentCommitment(BigInt(e.length), e).amountCommitment
+    );
+
+    const tree = buildMerkleTree(commitments);
+    expect(tree.length).toBeGreaterThan(1);
+
+    const root = tree[tree.length - 1][0];
+    expect(root).toBe(getMerkleRoot(commitments));
+
+    for (let i = 0; i < commitments.length; i++) {
+      const proof = generateMerkleProof(commitments, i);
+      expect(verifyMerkleProof(proof)).toBe(true);
+      expect(proof.root).toBe(root);
+    }
+  });
+});

--- a/tests/privacy/encryption.test.ts
+++ b/tests/privacy/encryption.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encryptMetadata,
+  decryptMetadata,
+} from '../../shared/src/crypto/metadata-encryption';
+
+describe('Privacy Integration: Encrypted Storage', () => {
+  const encryptionKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  const subscriptionData = JSON.stringify({
+    name: 'Netflix Premium',
+    price: 15.99,
+    cycle: 'monthly',
+    provider: 'Netflix',
+    startDate: '2025-01-15',
+    category: 'entertainment',
+  });
+
+  it('should encrypt subscription data so on-chain representation is opaque', async () => {
+    const encrypted = await encryptMetadata(subscriptionData, encryptionKey);
+
+    expect(encrypted.ciphertext).not.toContain('Netflix');
+    expect(encrypted.ciphertext).not.toContain('15.99');
+    expect(encrypted.ciphertext).not.toContain('monthly');
+
+    expect(encrypted.iv).toBeDefined();
+    expect(encrypted.authTag).toBeDefined();
+    expect(encrypted.ciphertext).toBeDefined();
+  });
+
+  it('should decrypt locally to reveal original data', async () => {
+    const encrypted = await encryptMetadata(subscriptionData, encryptionKey);
+    const decrypted = await decryptMetadata(encrypted, encryptionKey);
+    const parsed = JSON.parse(decrypted);
+
+    expect(parsed.name).toBe('Netflix Premium');
+    expect(parsed.price).toBe(15.99);
+    expect(parsed.cycle).toBe('monthly');
+    expect(parsed.provider).toBe('Netflix');
+  });
+
+  it('should produce different ciphertext for same plaintext (nonce uniqueness)', async () => {
+    const encrypted1 = await encryptMetadata(subscriptionData, encryptionKey);
+    const encrypted2 = await encryptMetadata(subscriptionData, encryptionKey);
+
+    expect(encrypted1.ciphertext).not.toBe(encrypted2.ciphertext);
+    expect(encrypted1.iv).not.toBe(encrypted2.iv);
+  });
+
+  it('should reject decryption with wrong key', async () => {
+    const encrypted = await encryptMetadata(subscriptionData, encryptionKey);
+    const wrongKey = 'ff'.repeat(32);
+
+    await expect(decryptMetadata(encrypted, wrongKey)).rejects.toThrow();
+  });
+
+  it('should reject tampered ciphertext', async () => {
+    const encrypted = await encryptMetadata(subscriptionData, encryptionKey);
+    const tampered = {
+      ...encrypted,
+      ciphertext: 'ff' + encrypted.ciphertext.slice(2),
+    };
+
+    await expect(decryptMetadata(tampered, encryptionKey)).rejects.toThrow();
+  });
+
+  it('should simulate full encrypted storage lifecycle', async () => {
+    const subscriptions = [
+      { name: 'Netflix', price: 15.99, cycle: 'monthly' },
+      { name: 'Spotify', price: 9.99, cycle: 'monthly' },
+      { name: 'Adobe CC', price: 54.99, cycle: 'yearly' },
+    ];
+
+    const encryptedStore: Array<{ id: string; data: Awaited<ReturnType<typeof encryptMetadata>> }> = [];
+
+    for (const sub of subscriptions) {
+      const encrypted = await encryptMetadata(JSON.stringify(sub), encryptionKey);
+      encryptedStore.push({ id: `sub_${sub.name.toLowerCase()}`, data: encrypted });
+    }
+
+    for (let i = 0; i < encryptedStore.length; i++) {
+      const { data } = encryptedStore[i];
+      expect(data.ciphertext).not.toContain(subscriptions[i].name);
+    }
+
+    for (let i = 0; i < encryptedStore.length; i++) {
+      const decrypted = await decryptMetadata(encryptedStore[i].data, encryptionKey);
+      const parsed = JSON.parse(decrypted);
+      expect(parsed.name).toBe(subscriptions[i].name);
+      expect(parsed.price).toBe(subscriptions[i].price);
+    }
+  });
+});

--- a/tests/privacy/full-privacy-mode.test.ts
+++ b/tests/privacy/full-privacy-mode.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { deriveStealthAddress } from '../../shared/src/crypto/stealth-derive';
+import { encryptMetadata, decryptMetadata } from '../../shared/src/crypto/metadata-encryption';
+import { commit, verify } from '../../shared/src/crypto/pedersen';
+import {
+  getMerkleRoot,
+  generateMerkleProof,
+  verifyMerkleProof,
+} from '../../shared/src/crypto/merkle';
+import { createPaymentCommitment, verifyPaymentCommitment } from '../../shared/src/crypto/payment-commitment';
+
+describe('Privacy Integration: Full Privacy Mode', () => {
+  const metaAddress = 'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+  const encryptionKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  interface OnChainFootprint {
+    transactions: string[];
+    commitments: string[];
+    encryptedBlobs: number;
+    plaintextLeaked: boolean;
+  }
+
+  it('should run full subscription lifecycle with all privacy features enabled', async () => {
+    const footprint: OnChainFootprint = {
+      transactions: [],
+      commitments: [],
+      encryptedBlobs: 0,
+      plaintextLeaked: false,
+    };
+
+    // 1. Create subscription with encrypted metadata
+    const subscriptionData = {
+      name: 'Netflix Premium',
+      price: 15.99,
+      cycle: 'monthly',
+      provider: 'Netflix',
+    };
+    const encrypted = await encryptMetadata(JSON.stringify(subscriptionData), encryptionKey);
+    footprint.encryptedBlobs++;
+
+    // Verify on-chain data is opaque
+    const onChainBlob = encrypted.ciphertext + encrypted.iv + encrypted.authTag;
+    if (
+      onChainBlob.includes('Netflix') ||
+      onChainBlob.includes('15.99') ||
+      onChainBlob.includes('monthly')
+    ) {
+      footprint.plaintextLeaked = true;
+    }
+
+    // 2. Open payment channel (1 on-chain tx)
+    const channelStealthAddr = deriveStealthAddress(metaAddress, 'sub_netflix', 0);
+    footprint.transactions.push(`channel_open:${channelStealthAddr}`);
+
+    // 3. Process 12 monthly renewals off-chain
+    const renewalCommitments: string[] = [];
+    let userBalance = 200;
+    let executorBalance = 0;
+
+    for (let month = 0; month < 12; month++) {
+      // Stealth address per renewal
+      const renewalAddr = deriveStealthAddress(metaAddress, 'sub_netflix', month);
+      expect(renewalAddr).toBeDefined();
+
+      // ZK commitment for payment amount
+      const amount = 1599n;
+      const paymentCommitment = createPaymentCommitment(amount, `renewal:${month}`);
+      renewalCommitments.push(paymentCommitment.amountCommitment);
+
+      // Verify commitment without revealing amount
+      expect(verifyPaymentCommitment(amount, paymentCommitment)).toBe(true);
+      expect(verifyPaymentCommitment(amount + 1n, paymentCommitment)).toBe(false);
+
+      // Off-chain state update
+      userBalance -= 15.99;
+      executorBalance += 15.99;
+    }
+
+    // 4. Close channel (1 on-chain tx)
+    footprint.transactions.push(`channel_close:${userBalance.toFixed(2)}:${executorBalance.toFixed(2)}`);
+
+    // 5. Build audit log from commitments
+    const auditRoot = getMerkleRoot(renewalCommitments);
+    footprint.commitments.push(auditRoot);
+
+    // 6. Selective disclosure: prove one payment without revealing others
+    const proofForMonth3 = generateMerkleProof(renewalCommitments, 3);
+    expect(verifyMerkleProof(proofForMonth3)).toBe(true);
+
+    // === AUDIT ON-CHAIN FOOTPRINT ===
+
+    // Only 2 on-chain transactions (open + close)
+    expect(footprint.transactions.length).toBe(2);
+
+    // No plaintext leaked
+    expect(footprint.plaintextLeaked).toBe(false);
+
+    // Encrypted data stored
+    expect(footprint.encryptedBlobs).toBeGreaterThan(0);
+
+    // Can still decrypt locally
+    const decrypted = await decryptMetadata(encrypted, encryptionKey);
+    const recovered = JSON.parse(decrypted);
+    expect(recovered.name).toBe('Netflix Premium');
+    expect(recovered.price).toBe(15.99);
+  });
+
+  it('should ensure all stealth addresses are unique across the lifecycle', () => {
+    const allAddresses = new Set<string>();
+
+    const subscriptions = ['netflix', 'spotify', 'adobe'];
+    for (const sub of subscriptions) {
+      for (let i = 0; i < 12; i++) {
+        const addr = deriveStealthAddress(metaAddress, `sub_${sub}`, i);
+        expect(allAddresses.has(addr)).toBe(false);
+        allAddresses.add(addr);
+      }
+    }
+
+    expect(allAddresses.size).toBe(36);
+  });
+
+  it('should ensure commitments are unlinkable', () => {
+    const amount = 1599n;
+    const commitments = Array.from({ length: 10 }, () => commit(amount));
+
+    const uniqueCommitments = new Set(commitments.map((c) => c.commitment));
+    expect(uniqueCommitments.size).toBe(10);
+
+    for (const c of commitments) {
+      expect(verify(amount, BigInt('0x' + c.blindingFactor), c.commitment)).toBe(true);
+    }
+  });
+});

--- a/tests/privacy/payment-channel.test.ts
+++ b/tests/privacy/payment-channel.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { deriveStealthAddress } from '../../shared/src/crypto/stealth-derive';
+import { encryptMetadata, decryptMetadata } from '../../shared/src/crypto/metadata-encryption';
+
+describe('Privacy Integration: Payment Channel', () => {
+  const metaAddress = 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3';
+  const subscriptionId = 'sub_channel_test_001';
+  const encryptionKey = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+  interface ChannelState {
+    sequenceNumber: number;
+    userBalance: number;
+    executorBalance: number;
+    totalDeposited: number;
+  }
+
+  it('should simulate channel open with only 1 on-chain tx', () => {
+    const onChainTxs: string[] = [];
+
+    const depositAmount = 100;
+    const stealthAddr = deriveStealthAddress(metaAddress, subscriptionId, 0);
+    onChainTxs.push(`open:${stealthAddr}:${depositAmount}`);
+
+    const initialState: ChannelState = {
+      sequenceNumber: 0,
+      userBalance: depositAmount,
+      executorBalance: 0,
+      totalDeposited: depositAmount,
+    };
+
+    expect(onChainTxs.length).toBe(1);
+    expect(initialState.userBalance + initialState.executorBalance).toBe(initialState.totalDeposited);
+  });
+
+  it('should process N renewals with 0 on-chain txs', () => {
+    const numRenewals = 10;
+    const renewalAmount = 10;
+    const depositAmount = 100;
+    const onChainTxs: string[] = [];
+
+    let state: ChannelState = {
+      sequenceNumber: 0,
+      userBalance: depositAmount,
+      executorBalance: 0,
+      totalDeposited: depositAmount,
+    };
+
+    for (let i = 0; i < numRenewals; i++) {
+      state = {
+        sequenceNumber: state.sequenceNumber + 1,
+        userBalance: state.userBalance - renewalAmount,
+        executorBalance: state.executorBalance + renewalAmount,
+        totalDeposited: state.totalDeposited,
+      };
+    }
+
+    expect(onChainTxs.length).toBe(0);
+    expect(state.sequenceNumber).toBe(numRenewals);
+    expect(state.userBalance).toBe(0);
+    expect(state.executorBalance).toBe(depositAmount);
+    expect(state.userBalance + state.executorBalance).toBe(state.totalDeposited);
+  });
+
+  it('should close channel with only 1 additional on-chain tx (2 total)', () => {
+    const numRenewals = 5;
+    const renewalAmount = 10;
+    const depositAmount = 100;
+    const onChainTxs: string[] = [];
+
+    onChainTxs.push('open:escrow_account:100');
+
+    let state: ChannelState = {
+      sequenceNumber: 0,
+      userBalance: depositAmount,
+      executorBalance: 0,
+      totalDeposited: depositAmount,
+    };
+
+    for (let i = 0; i < numRenewals; i++) {
+      state = {
+        sequenceNumber: state.sequenceNumber + 1,
+        userBalance: state.userBalance - renewalAmount,
+        executorBalance: state.executorBalance + renewalAmount,
+        totalDeposited: state.totalDeposited,
+      };
+    }
+
+    onChainTxs.push(`close:${state.userBalance}:${state.executorBalance}`);
+
+    expect(onChainTxs.length).toBe(2);
+    expect(state.userBalance).toBe(50);
+    expect(state.executorBalance).toBe(50);
+  });
+
+  it('should encrypt channel state updates for privacy', async () => {
+    const state: ChannelState = {
+      sequenceNumber: 5,
+      userBalance: 50,
+      executorBalance: 50,
+      totalDeposited: 100,
+    };
+
+    const encrypted = await encryptMetadata(JSON.stringify(state), encryptionKey);
+    expect(encrypted.ciphertext).not.toContain('50');
+
+    const decrypted = await decryptMetadata(encrypted, encryptionKey);
+    const recovered = JSON.parse(decrypted) as ChannelState;
+    expect(recovered.sequenceNumber).toBe(5);
+    expect(recovered.userBalance).toBe(50);
+    expect(recovered.executorBalance).toBe(50);
+  });
+
+  it('should enforce state ordering (latest state always wins in dispute)', () => {
+    const states: ChannelState[] = [];
+    const depositAmount = 100;
+    const renewalAmount = 10;
+
+    let state: ChannelState = {
+      sequenceNumber: 0,
+      userBalance: depositAmount,
+      executorBalance: 0,
+      totalDeposited: depositAmount,
+    };
+    states.push(state);
+
+    for (let i = 0; i < 5; i++) {
+      state = {
+        sequenceNumber: state.sequenceNumber + 1,
+        userBalance: state.userBalance - renewalAmount,
+        executorBalance: state.executorBalance + renewalAmount,
+        totalDeposited: state.totalDeposited,
+      };
+      states.push(state);
+    }
+
+    const staleState = states[2];
+    const latestState = states[states.length - 1];
+    expect(latestState.sequenceNumber).toBeGreaterThan(staleState.sequenceNumber);
+
+    const disputeWinner = states.reduce((a, b) =>
+      a.sequenceNumber > b.sequenceNumber ? a : b
+    );
+    expect(disputeWinner).toEqual(latestState);
+  });
+});

--- a/tests/privacy/stealth.test.ts
+++ b/tests/privacy/stealth.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { deriveStealthAddress } from '../../shared/src/crypto/stealth-derive';
+
+describe('Privacy Integration: Stealth Renewal', () => {
+  const metaAddress = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+  const subscriptionId = 'sub_netflix_premium_001';
+
+  it('should derive a stealth address for a subscription renewal', () => {
+    const stealthAddress = deriveStealthAddress(metaAddress, subscriptionId, 0);
+    expect(stealthAddress).toBeDefined();
+    expect(typeof stealthAddress).toBe('string');
+    expect(stealthAddress.length).toBe(64);
+  });
+
+  it('should derive different addresses for different renewal indices', () => {
+    const addr0 = deriveStealthAddress(metaAddress, subscriptionId, 0);
+    const addr1 = deriveStealthAddress(metaAddress, subscriptionId, 1);
+    const addr2 = deriveStealthAddress(metaAddress, subscriptionId, 2);
+    expect(addr0).not.toBe(addr1);
+    expect(addr1).not.toBe(addr2);
+    expect(addr0).not.toBe(addr2);
+  });
+
+  it('should derive different addresses for different subscriptions (unlinkable on explorer)', () => {
+    const addrNetflix = deriveStealthAddress(metaAddress, 'sub_netflix', 0);
+    const addrSpotify = deriveStealthAddress(metaAddress, 'sub_spotify', 0);
+    expect(addrNetflix).not.toBe(addrSpotify);
+  });
+
+  it('should produce deterministic addresses for wallet recovery', () => {
+    const addr1 = deriveStealthAddress(metaAddress, subscriptionId, 0);
+    const addr2 = deriveStealthAddress(metaAddress, subscriptionId, 0);
+    expect(addr1).toBe(addr2);
+  });
+
+  it('should simulate stealth renewal lifecycle', () => {
+    const renewalAddresses: string[] = [];
+    const numRenewals = 12;
+
+    for (let i = 0; i < numRenewals; i++) {
+      const addr = deriveStealthAddress(metaAddress, subscriptionId, i);
+      renewalAddresses.push(addr);
+    }
+
+    const uniqueAddresses = new Set(renewalAddresses);
+    expect(uniqueAddresses.size).toBe(numRenewals);
+
+    for (let i = 0; i < numRenewals; i++) {
+      const recovered = deriveStealthAddress(metaAddress, subscriptionId, i);
+      expect(recovered).toBe(renewalAddresses[i]);
+    }
+  });
+});

--- a/tests/privacy/zk-proof.test.ts
+++ b/tests/privacy/zk-proof.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  commit,
+  verify,
+} from '../../shared/src/crypto/pedersen';
+import {
+  createPaymentCommitment,
+  verifyPaymentCommitment,
+} from '../../shared/src/crypto/payment-commitment';
+
+describe('Privacy Integration: ZK Proof Flow', () => {
+  it('should create a Pedersen commitment that hides the payment amount', () => {
+    const amount = 1599n; // $15.99 in cents
+    const { commitment, blindingFactor } = commit(amount);
+
+    expect(commitment).toBeDefined();
+    expect(typeof commitment).toBe('string');
+    expect(commitment).not.toContain('1599');
+    expect(blindingFactor).toBeDefined();
+  });
+
+  it('should verify a valid commitment on-chain', () => {
+    const amount = 1599n;
+    const { commitment, blindingFactor } = commit(amount);
+    const isValid = verify(amount, BigInt('0x' + blindingFactor), commitment);
+    expect(isValid).toBe(true);
+  });
+
+  it('should reject verification with wrong amount (no data leaked)', () => {
+    const amount = 1599n;
+    const { commitment, blindingFactor } = commit(amount);
+    const isValid = verify(999n, BigInt('0x' + blindingFactor), commitment);
+    expect(isValid).toBe(false);
+  });
+
+  it('should produce different commitments for same amount (hiding property)', () => {
+    const amount = 1599n;
+    const commitment1 = commit(amount);
+    const commitment2 = commit(amount);
+    expect(commitment1.commitment).not.toBe(commitment2.commitment);
+    expect(commitment1.blindingFactor).not.toBe(commitment2.blindingFactor);
+  });
+
+  it('should create and verify a payment commitment with metadata', () => {
+    const amount = 5499n;
+    const metadata = 'subscription:adobe_cc:yearly';
+    const paymentCommitment = createPaymentCommitment(amount, metadata);
+
+    expect(paymentCommitment.amountCommitment).toBeDefined();
+    expect(paymentCommitment.amountBlindingFactor).toBeDefined();
+    expect(paymentCommitment.metadata).toBeDefined();
+    expect(paymentCommitment.metadata).not.toContain('adobe');
+
+    const isValid = verifyPaymentCommitment(amount, paymentCommitment);
+    expect(isValid).toBe(true);
+  });
+
+  it('should simulate full ZK proof flow: pay → prove → verify → no leak', () => {
+    const subscriptionPayments = [
+      { amount: 1599n, desc: 'Netflix' },
+      { amount: 999n, desc: 'Spotify' },
+      { amount: 5499n, desc: 'Adobe CC' },
+    ];
+
+    const commitments = subscriptionPayments.map(({ amount, desc }) => ({
+      ...createPaymentCommitment(amount, desc),
+      originalAmount: amount,
+    }));
+
+    for (const c of commitments) {
+      const isValid = verifyPaymentCommitment(c.originalAmount, c);
+      expect(isValid).toBe(true);
+    }
+
+    for (const c of commitments) {
+      const wrongAmount = c.originalAmount + 1n;
+      const isValid = verifyPaymentCommitment(wrongAmount, c);
+      expect(isValid).toBe(false);
+    }
+
+    const commitmentStrings = commitments.map((c) => c.amountCommitment);
+    const uniqueCommitments = new Set(commitmentStrings);
+    expect(uniqueCommitments.size).toBe(commitments.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Added 6 integration test scenarios covering all privacy features working together
- **Stealth renewal**: create subscription → derive stealth addresses → verify payments are unlinkable
- **Encrypted storage**: encrypt subscription data → verify on-chain blob is opaque → decrypt locally → verify match
- **ZK proof flow**: create Pedersen commitments → verify on-chain → confirm no amount leakage
- **Payment channel**: open channel → N off-chain renewals → close → verify only 2 on-chain txs
- **Private audit log**: log events as commitments → build Merkle tree → selective disclosure via proofs
- **Full privacy mode**: enable all features → full subscription lifecycle → audit on-chain footprint
- Added CI workflow (`privacy-tests.yml`) that runs on PRs touching `contracts/` or `shared/src/crypto/`

Closes #863

## Test plan
- [ ] All 6 test scenarios pass locally with `npx vitest run tests/privacy/`
- [ ] CI workflow triggers on PRs touching `contracts/` or `shared/src/crypto/`
- [ ] Each test file is independently runnable
- [ ] Full privacy mode test verifies only 2 on-chain transactions for 12 renewals

🤖 Generated with [Claude Code](https://claude.com/claude-code)