### PR TITLE
fix: strip referrer and tracking headers from gift card links

### DIFF
--- a/client/lib/atomic-wallet.test.ts
+++ b/client/lib/atomic-wallet.test.ts
@@ -5,6 +5,7 @@ import {
   getAtomicWalletGiftCardLink,
   normalizeGiftCardProvider,
   getGiftCardProviderFromSubscription,
+  stripTrackingParams,
 } from "./atomic-wallet"
 
 describe("Atomic Wallet gift card deep links", () => {
@@ -42,5 +43,41 @@ describe("Atomic Wallet gift card deep links", () => {
     expect(getAtomicWalletGiftCardLink(10, "Visa")).toBe(
       "https://atomicwallet.io/buy-gift-cards?amount=10&provider=visa",
     )
+  })
+})
+
+describe("stripTrackingParams", () => {
+  it("strips UTM parameters from URLs", () => {
+    const url = "https://example.com/page?amount=25&utm_source=app&utm_medium=referral&utm_campaign=test"
+    const stripped = stripTrackingParams(url)
+    expect(stripped).toBe("https://example.com/page?amount=25")
+  })
+
+  it("strips fbclid and gclid parameters", () => {
+    const url = "https://example.com/?item=1&fbclid=abc123&gclid=def456"
+    const stripped = stripTrackingParams(url)
+    expect(stripped).toBe("https://example.com/?item=1")
+  })
+
+  it("strips ref and source parameters", () => {
+    const url = "https://example.com/?amount=10&ref=syncro&source=app"
+    const stripped = stripTrackingParams(url)
+    expect(stripped).toBe("https://example.com/?amount=10")
+  })
+
+  it("preserves non-tracking parameters", () => {
+    const url = "https://example.com/buy?amount=25&provider=amazon"
+    const stripped = stripTrackingParams(url)
+    expect(stripped).toBe("https://example.com/buy?amount=25&provider=amazon")
+  })
+
+  it("returns original string for non-URL inputs", () => {
+    const url = "not-a-url"
+    expect(stripTrackingParams(url)).toBe("not-a-url")
+  })
+
+  it("handles URLs with no query params", () => {
+    const url = "https://example.com/page"
+    expect(stripTrackingParams(url)).toBe("https://example.com/page")
   })
 })

--- a/client/lib/atomic-wallet.ts
+++ b/client/lib/atomic-wallet.ts
@@ -1,6 +1,8 @@
 export const ATOMIC_WALLET_MOBILE_SCHEME = "atomicwallet://buy-gift-card"
 export const ATOMIC_WALLET_WEB_URL = "https://atomicwallet.io/buy-gift-cards"
 
+const TRACKING_PARAM_PREFIXES = ["utm_", "fbclid", "gclid", "ref", "source", "campaign", "medium", "content", "term"]
+
 const GIFT_CARD_PROVIDER_ALIASES: Array<[RegExp, string]> = [
   [/amazon/i, "amazon"],
   [/google\s*play|youtube|google play/i, "google_play"],
@@ -13,6 +15,25 @@ const GIFT_CARD_PROVIDER_ALIASES: Array<[RegExp, string]> = [
 const SUPPORTED_GIFT_CARD_PROVIDERS = new Set(
   GIFT_CARD_PROVIDER_ALIASES.map(([, provider]) => provider),
 )
+
+export function stripTrackingParams(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const keysToRemove: string[] = []
+    parsed.searchParams.forEach((_, key) => {
+      const lower = key.toLowerCase()
+      if (TRACKING_PARAM_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+        keysToRemove.push(key)
+      }
+    })
+    for (const key of keysToRemove) {
+      parsed.searchParams.delete(key)
+    }
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
 
 export function normalizeGiftCardProvider(provider: string): string {
   return provider.trim().replace(/\s+/g, "_").toLowerCase()
@@ -33,14 +54,18 @@ export function getAtomicWalletGiftCardDeepLink(amount: number, provider: string
   const normalizedProvider = normalizeGiftCardProvider(provider)
   const encodedProvider = encodeURIComponent(normalizedProvider)
   const encodedAmount = encodeURIComponent(amount.toString())
-  return `${ATOMIC_WALLET_MOBILE_SCHEME}?amount=${encodedAmount}&provider=${encodedProvider}`
+  return stripTrackingParams(
+    `${ATOMIC_WALLET_MOBILE_SCHEME}?amount=${encodedAmount}&provider=${encodedProvider}`
+  )
 }
 
 export function getAtomicWalletGiftCardWebLink(amount: number, provider: string): string {
   const normalizedProvider = normalizeGiftCardProvider(provider)
   const encodedProvider = encodeURIComponent(normalizedProvider)
   const encodedAmount = encodeURIComponent(amount.toString())
-  return `${ATOMIC_WALLET_WEB_URL}?amount=${encodedAmount}&provider=${encodedProvider}`
+  return stripTrackingParams(
+    `${ATOMIC_WALLET_WEB_URL}?amount=${encodedAmount}&provider=${encodedProvider}`
+  )
 }
 
 export function getAtomicWalletGiftCardLink(amount: number, provider: string): string {
@@ -59,7 +84,7 @@ export function openAtomicWalletGiftCard(amount: number, provider: string): stri
   const url = getAtomicWalletGiftCardLink(amount, provider)
 
   if (typeof window !== "undefined") {
-    window.location.href = url
+    window.open(url, "_blank", "noreferrer,noopener")
   }
 
   return url

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -21,6 +21,15 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Referrer-Policy',
+            value: 'no-referrer',
+          },
+        ],
+      },
+      {
         source: '/sw.js',
         headers: [
           {


### PR DESCRIPTION
## Summary
- Added `stripTrackingParams()` utility to remove UTM, fbclid, gclid, ref, source, and campaign query params from all generated gift card URLs
- Set `Referrer-Policy: no-referrer` header on all pages via `next.config.mjs` headers config
- Changed `openAtomicWalletGiftCard` to use `window.open(url, "_blank", "noreferrer,noopener")` instead of `window.location.href` to prevent Referer header leakage
- All outbound links to gift card providers (Atomic Wallet, etc.) now strip tracking params automatically
- Added tests verifying tracking param removal for UTM, fbclid, gclid, ref, and source params

Closes #848

## Test plan
- [ ] Verify no `Referer` header is sent to gift card providers (check via browser DevTools Network tab)
- [ ] Verify no UTM or tracking parameters appear in outbound URLs
- [ ] Run `npx vitest run client/lib/atomic-wallet.test.ts` to verify new strip tests pass
- [ ] Verify gift card purchase flow still works (button opens correct URL in new tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)