### PR TITLE
feat(stealth): implement ECDH ephemeral address derivation

### DIFF
--- a/backend/src/services/renewal-executor.ts
+++ b/backend/src/services/renewal-executor.ts
@@ -3,6 +3,7 @@ import { supabase } from '../config/database';
 import { blockchainService } from './blockchain-service';
 import { webhookService } from './webhook-service';
 import { addMonths, addQuarters, addYears } from 'date-fns';
+import { deriveEphemeralStealthAddress } from '@syncro/shared/crypto';
 
 interface RenewalRequest {
   subscriptionId: string;
@@ -36,7 +37,25 @@ export class RenewalExecutor {
         return await this.logFailure(subscriptionId, userId, 'billing_window_invalid', billingWindow.reason);
       }
 
-      // Step 3: Trigger contract renewal
+      // Step 3: Derive ephemeral stealth address (if configured)
+      const stealthMetaViewKey = process.env.STEALTH_VIEW_PUBKEY;
+      const stealthMetaSpendKey = process.env.STEALTH_SPEND_PUBKEY;
+      if (stealthMetaViewKey && stealthMetaSpendKey) {
+        try {
+          const { ephemeralPubkey, stealthAddress } = deriveEphemeralStealthAddress(
+            { viewPublicKey: stealthMetaViewKey, spendPublicKey: stealthMetaSpendKey },
+            `${subscriptionId}:${approvalId}`,
+          );
+          logger.info('Stealth address derived for renewal', { subscriptionId, ephemeralPubkey, stealthAddress });
+        } catch (stealthErr) {
+          logger.warn('Stealth address derivation failed (non-fatal)', {
+            subscriptionId,
+            error: stealthErr instanceof Error ? stealthErr.message : String(stealthErr),
+          });
+        }
+      }
+
+      // Step 4: Trigger contract renewal
       const contractResult = await this.triggerContractRenewal(
         subscriptionId,
         approvalId,
@@ -47,10 +66,10 @@ export class RenewalExecutor {
         return await this.logFailure(subscriptionId, userId, 'contract_failure', contractResult.error);
       }
 
-      // Step 4: Update DB
+      // Step 5: Update DB
       await this.updateSubscription(subscriptionId, contractResult.transactionHash);
 
-      // Step 5: Log result
+      // Step 6: Log result
       await this.logSuccess(subscriptionId, userId, contractResult.transactionHash);
 
       return {

--- a/backend/tests/stealth-derive.test.ts
+++ b/backend/tests/stealth-derive.test.ts
@@ -1,4 +1,5 @@
-import { deriveStealthAddress } from '../../shared/src/crypto/stealth-derive';
+import { deriveStealthAddress, deriveEphemeralStealthAddress } from '@syncro/shared/crypto';
+import type { StealthMetaAddress } from '@syncro/shared/crypto';
 
 // ── deriveStealthAddress unit tests ──────────────────────────────────────────
 
@@ -37,6 +38,61 @@ describe('deriveStealthAddress', () => {
 
   it('throws RangeError for non-integer index', () => {
     expect(() => deriveStealthAddress(META, SUB_ID, 1.5)).toThrow(RangeError);
+  });
+});
+
+// ── deriveEphemeralStealthAddress unit tests ──────────────────────────────────
+
+describe('deriveEphemeralStealthAddress', () => {
+  // Deterministic secp256k1 keypairs for testing (private keys → compressed pubkeys)
+  // view private key: 0x01 * 32, spend private key: 0x02 * 32
+  const VIEW_PRIV = '0101010101010101010101010101010101010101010101010101010101010101';
+  const SPEND_PRIV = '0202020202020202020202020202020202020202020202020202020202020202';
+
+  // Pre-computed from secp256k1.getPublicKey(privKey, true)
+  // We derive these at runtime to avoid hardcoding and to stay library-agnostic
+  let META: StealthMetaAddress;
+
+  beforeAll(async () => {
+    // Dynamically derive test pubkeys so the test works regardless of platform
+    const { secp256k1 } = await import('@noble/curves/secp256k1');
+    const viewPub = secp256k1.getPublicKey(VIEW_PRIV, true);
+    const spendPub = secp256k1.getPublicKey(SPEND_PRIV, true);
+    const toHex = (b: Uint8Array) => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+    META = { viewPublicKey: toHex(viewPub), spendPublicKey: toHex(spendPub) };
+  });
+
+  it('returns hex strings for ephemeralPubkey and stealthAddress', () => {
+    const result = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    expect(result.ephemeralPubkey).toMatch(/^[0-9a-f]{66}$/); // 33-byte compressed secp256k1 point
+    expect(result.stealthAddress).toMatch(/^[0-9a-f]{66}$/);
+  });
+
+  it('is deterministic — same inputs produce same output', () => {
+    const r1 = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    const r2 = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    expect(r1.ephemeralPubkey).toBe(r2.ephemeralPubkey);
+    expect(r1.stealthAddress).toBe(r2.stealthAddress);
+  });
+
+  it('different entropy produces different (unlinkable) addresses', () => {
+    const r0 = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    const r1 = deriveEphemeralStealthAddress(META, 'sub-abc:1');
+    expect(r0.stealthAddress).not.toBe(r1.stealthAddress);
+    expect(r0.ephemeralPubkey).not.toBe(r1.ephemeralPubkey);
+  });
+
+  it('stealthAddress is a valid secp256k1 point', async () => {
+    const { secp256k1 } = await import('@noble/curves/secp256k1');
+    const { stealthAddress } = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    // fromHex throws if not a valid point
+    expect(() => secp256k1.ProjectivePoint.fromHex(stealthAddress)).not.toThrow();
+  });
+
+  it('ephemeralPubkey is a valid secp256k1 point', async () => {
+    const { secp256k1 } = await import('@noble/curves/secp256k1');
+    const { ephemeralPubkey } = deriveEphemeralStealthAddress(META, 'sub-abc:0');
+    expect(() => secp256k1.ProjectivePoint.fromHex(ephemeralPubkey)).not.toThrow();
   });
 });
 

--- a/shared/src/crypto/stealth-derive.ts
+++ b/shared/src/crypto/stealth-derive.ts
@@ -1,14 +1,80 @@
 import { createHmac } from "crypto";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+
+/**
+ * Stealth meta-address containing the recipient's view and spend public keys
+ * (secp256k1, compressed hex, 66 chars each).
+ */
+export interface StealthMetaAddress {
+  viewPublicKey: string;
+  spendPublicKey: string;
+}
+
+/**
+ * Result of ephemeral stealth address derivation.
+ * - ephemeralPubkey: R = r*G (publish in tx memo so recipient can detect the payment)
+ * - stealthAddress: P = spend_pubkey + hash(s)*G (one-time payment destination)
+ */
+export interface EphemeralStealthResult {
+  /** Compressed secp256k1 point R = r*G (hex). Publish in tx memo. */
+  ephemeralPubkey: string;
+  /** One-time stealth address P = spend_pubkey + hash(s)*G (hex). */
+  stealthAddress: string;
+}
+
+/**
+ * Derives a one-time ephemeral stealth address using ECDH (secp256k1).
+ *
+ * Protocol:
+ *   1. r  = sha256(entropy) mod n          — deterministic ephemeral scalar
+ *   2. R  = r * G                           — ephemeral pubkey (publish in memo)
+ *   3. s  = r * view_pubkey                 — ECDH shared secret point
+ *   4. h  = sha256(s.x || s.y)             — shared secret hash
+ *   5. P  = spend_pubkey + h*G             — one-time stealth address
+ *
+ * @param metaAddress - Recipient's stealth meta-address (view + spend pubkeys).
+ * @param entropy     - Per-payment entropy (e.g. `${subscriptionId}:${index}`).
+ * @returns { ephemeralPubkey, stealthAddress } — both as compressed-point hex strings.
+ */
+export function deriveEphemeralStealthAddress(
+  metaAddress: StealthMetaAddress,
+  entropy: string,
+): EphemeralStealthResult {
+  const n = secp256k1.CURVE.n;
+
+  // Step 1: deterministic ephemeral scalar r = sha256(entropy) mod n
+  const entropyBytes = new TextEncoder().encode(entropy);
+  const rBytes = sha256(entropyBytes);
+  const r = BigInt("0x" + bytesToHex(rBytes)) % n;
+  if (r === 0n) throw new Error("Invalid entropy: scalar is zero");
+
+  // Step 2: R = r * G
+  const R = secp256k1.ProjectivePoint.BASE.multiply(r);
+
+  // Step 3: s = r * view_pubkey (ECDH)
+  const viewPoint = secp256k1.ProjectivePoint.fromHex(metaAddress.viewPublicKey);
+  const S = viewPoint.multiply(r);
+
+  // Step 4: h = sha256(shared secret x-coordinate)
+  const sBytes = S.toRawBytes(true); // compressed
+  const h = BigInt("0x" + bytesToHex(sha256(sBytes))) % n;
+
+  // Step 5: P = spend_pubkey + h*G
+  const spendPoint = secp256k1.ProjectivePoint.fromHex(metaAddress.spendPublicKey);
+  const hG = secp256k1.ProjectivePoint.BASE.multiply(h);
+  const P = spendPoint.add(hG);
+
+  return {
+    ephemeralPubkey: bytesToHex(R.toRawBytes(true)),
+    stealthAddress: bytesToHex(P.toRawBytes(true)),
+  };
+}
 
 /**
  * Derives a deterministic stealth address for a subscription.
  *
  * Address = HMAC-SHA256(meta_address, `${subscriptionId}:${index}`)
- *
- * Properties:
- * - Same inputs always produce the same address (deterministic).
- * - Different indices produce different addresses (no collisions across subscriptions).
- * - On wallet recovery, iterate index 0..N to regenerate all addresses.
  *
  * @param metaAddress - The user's stealth meta-address (wallet-level secret).
  * @param subscriptionId - The subscription's unique identifier.
@@ -26,4 +92,8 @@ export function deriveStealthAddress(
   return createHmac("sha256", metaAddress)
     .update(`${subscriptionId}:${index}`)
     .digest("hex");
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }


### PR DESCRIPTION
## Summary

Implements ECDH-based ephemeral stealth address derivation as specified in #830.

## Changes

### `shared/src/crypto/stealth-derive.ts`
- Add `deriveEphemeralStealthAddress(metaAddress, entropy)` using secp256k1 ECDH:
  - `r = sha256(entropy) mod n` — deterministic ephemeral scalar
  - `R = r * G` — ephemeral pubkey (publish in tx memo for recipient detection)
  - `s = r * view_pubkey` — ECDH shared secret
  - `P = spend_pubkey + hash(s) * G` — one-time stealth address
- Add `StealthMetaAddress` and `EphemeralStealthResult` types
- Keep existing `deriveStealthAddress(meta, subId, index)` fully backward-compatible

### `backend/src/services/renewal-executor.ts`
- Add Step 3: derive ephemeral stealth address before contract renewal
- Non-fatal: skipped gracefully when `STEALTH_VIEW_PUBKEY`/`STEALTH_SPEND_PUBKEY` env vars not set
- Logs `ephemeralPubkey` and `stealthAddress` for tx memo publication

### `backend/tests/stealth-derive.test.ts`
- Add 5 new tests for `deriveEphemeralStealthAddress`: hex format, determinism, unlinkability, valid secp256k1 point checks

## Testing

All 16 tests pass (8 existing + 5 new ECDH + 3 existing subscription-service tests).

## Acceptance Criteria

- [x] Derived address is a valid secp256k1 point (verified by `secp256k1.ProjectivePoint.fromHex`)
- [x] Same inputs always produce the same stealth address (determinism test)
- [x] Different entropy values produce unlinkable addresses (unlinkability test)

Closes #830