### PR TITLE
feat(crypto): implement HKDF key derivation from Stellar signing key

### DIFF
--- a/client/lib/stellar-wallet.ts
+++ b/client/lib/stellar-wallet.ts
@@ -1,4 +1,5 @@
 import { getBlockchainFlags } from '../../shared/blockchain-flags';
+import { deriveSubscriptionEncryptionKey } from '../../shared/src/crypto/key-derivation';
 
 type WalletInfo = {
   publicKey: string;
@@ -13,6 +14,8 @@ class StellarWalletService {
   private wallet: WalletInfo | null = null;
   private listeners: Map<WalletEventType, Set<WalletEventHandler>> = new Map();
   private readonly STORAGE_KEY = 'stellar_wallet_session';
+  /** In-memory session cache for derived encryption key — never persisted. */
+  private _encryptionKey: string | null = null;
 
   constructor() {
     this.loadSession();
@@ -47,6 +50,7 @@ class StellarWalletService {
   disconnect(): void {
     const wasConnected = this.wallet !== null;
     this.wallet = null;
+    this._encryptionKey = null;
     this.clearSession();
     if (wasConnected) this.emit('walletDisconnected');
   }
@@ -73,6 +77,26 @@ class StellarWalletService {
     });
 
     return signedXdr;
+  }
+
+  /**
+   * Derives and caches the AES-256 encryption key for this session using
+   * HKDF-SHA256 from the Stellar Ed25519 seed.
+   *
+   * The derived key is held in memory only — never written to disk or DB.
+   * Call this once per session after the user provides their secret key seed.
+   *
+   * @param stellarSecretKeySeed - Raw 32-byte Ed25519 seed.
+   */
+  deriveAndCacheEncryptionKey(stellarSecretKeySeed: Uint8Array): void {
+    this._encryptionKey = deriveSubscriptionEncryptionKey(stellarSecretKeySeed);
+  }
+
+  /**
+   * Returns the in-memory encryption key for this session, or null if not yet derived.
+   */
+  getEncryptionKey(): string | null {
+    return this._encryptionKey;
   }
 
   on(event: WalletEventType, handler: WalletEventHandler): () => void {

--- a/shared/src/__tests__/crypto.test.ts
+++ b/shared/src/__tests__/crypto.test.ts
@@ -1,6 +1,7 @@
 import {
   deriveKey,
   deriveKeyHex,
+  deriveSubscriptionEncryptionKey,
   encryptMetadata,
   decryptMetadata,
   encryptSubscriptionMetadata,
@@ -8,7 +9,6 @@ import {
   ed25519ToCurve25519PubKey,
   ed25519ToCurve25519SecKey,
   deriveStealthAddress,
-  deriveStealthSecretKey,
   commit,
   verify,
   buildMerkleTree,
@@ -33,6 +33,33 @@ describe('Crypto Utilities', () => {
       const derived1 = deriveKeyHex(ikm);
       const derived2 = deriveKeyHex(ikm);
       expect(derived1).toBe(derived2);
+    });
+  });
+
+  describe('deriveSubscriptionEncryptionKey', () => {
+    const seed = new Uint8Array(32).fill(0xab);
+
+    it('returns a 64-char hex string (256-bit key)', () => {
+      const key = deriveSubscriptionEncryptionKey(seed);
+      expect(key).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('is deterministic — same seed always yields the same key', () => {
+      const key1 = deriveSubscriptionEncryptionKey(seed);
+      const key2 = deriveSubscriptionEncryptionKey(seed);
+      expect(key1).toBe(key2);
+    });
+
+    it('different seeds yield different keys', () => {
+      const seed2 = new Uint8Array(32).fill(0xcd);
+      expect(deriveSubscriptionEncryptionKey(seed)).not.toBe(
+        deriveSubscriptionEncryptionKey(seed2),
+      );
+    });
+
+    it('rejects seeds that are not exactly 32 bytes', () => {
+      expect(() => deriveSubscriptionEncryptionKey(new Uint8Array(16))).toThrow();
+      expect(() => deriveSubscriptionEncryptionKey(new Uint8Array(33))).toThrow();
     });
   });
 

--- a/shared/src/crypto/key-derivation.ts
+++ b/shared/src/crypto/key-derivation.ts
@@ -7,6 +7,9 @@ export interface HKDFOptions {
   length?: number;
 }
 
+const SUBSCRIPTION_KEY_SALT = new TextEncoder().encode('syncro:subscription:v1');
+const SUBSCRIPTION_KEY_INFO = new TextEncoder().encode('encryption-key');
+
 /**
  * Derives a key using HKDF from Stellar keys or other secret material.
  * @param ikm Input key material (secret).
@@ -30,6 +33,27 @@ export function deriveKey(ikm: Uint8Array, options: HKDFOptions = {}): Uint8Arra
 export function deriveKeyHex(ikmHex: string, options: HKDFOptions = {}): string {
   const ikm = hexToBytes(ikmHex);
   const derived = deriveKey(ikm, options);
+  return bytesToHex(derived);
+}
+
+/**
+ * Derives a 256-bit AES encryption key from a Stellar Ed25519 signing key seed.
+ *
+ * Uses HKDF-SHA256 with:
+ *   salt = "syncro:subscription:v1"
+ *   info = "encryption-key"
+ *
+ * Deterministic: same Stellar key always produces the same encryption key.
+ * Works in both browser (SubtleCrypto) and Node.js environments.
+ *
+ * @param stellarSecretKeySeed - Raw 32-byte Ed25519 seed (from StrKey.decodeEd25519SecretSeed).
+ * @returns 32-byte AES key as a lowercase hex string.
+ */
+export function deriveSubscriptionEncryptionKey(stellarSecretKeySeed: Uint8Array): string {
+  if (stellarSecretKeySeed.length !== 32) {
+    throw new Error('Stellar secret key seed must be exactly 32 bytes');
+  }
+  const derived = hkdf(sha256, stellarSecretKeySeed, SUBSCRIPTION_KEY_SALT, SUBSCRIPTION_KEY_INFO, 32);
   return bytesToHex(derived);
 }
 

--- a/shared/src/crypto/metadata-encryption.ts
+++ b/shared/src/crypto/metadata-encryption.ts
@@ -62,7 +62,7 @@ export async function encryptMetadata(plaintext: string, keyHex: string): Promis
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const key = await crypto.subtle.importKey(
     'raw',
-    keyBytes,
+    keyBytes.buffer as ArrayBuffer,
     { name: 'AES-GCM' },
     false,
     ['encrypt']
@@ -94,7 +94,7 @@ export async function decryptMetadata(encrypted: EncryptedData, keyHex: string):
   ciphertextWithTag.set(authTag, ciphertext.length);
   const key = await crypto.subtle.importKey(
     'raw',
-    keyBytes,
+    keyBytes.buffer as ArrayBuffer,
     { name: 'AES-GCM' },
     false,
     ['decrypt']
@@ -102,9 +102,9 @@ export async function decryptMetadata(encrypted: EncryptedData, keyHex: string):
 
   try {
     const plaintextBuffer = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv },
+      { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer },
       key,
-      ciphertextWithTag
+      ciphertextWithTag.buffer as ArrayBuffer
     );
     return new TextDecoder().decode(plaintextBuffer);
   } catch {


### PR DESCRIPTION
## Summary

Closes #838

Derives a symmetric AES-256 encryption key from a user's Stellar Ed25519 signing key seed using HKDF-SHA256, with the domain-specific parameters specified in the issue.

## Changes

### `shared/src/crypto/key-derivation.ts`
- Add `deriveSubscriptionEncryptionKey(stellarSecretKeySeed: Uint8Array): string`
  - HKDF-SHA256 with salt `syncro:subscription:v1` and info `encryption-key`
  - Input: 32-byte Ed25519 seed; Output: 256-bit AES key as lowercase hex
  - Deterministic, pure — works in browser and Node.js
  - Throws if seed is not exactly 32 bytes

### `client/lib/stellar-wallet.ts`
- Add `deriveAndCacheEncryptionKey(stellarSecretKeySeed: Uint8Array): void`
  - Derives and stores the encryption key in-memory for the current session
- Add `getEncryptionKey(): string | null`
  - Returns the cached key, or `null` if not yet derived
- `disconnect()` now clears the cached key (never survives session end)

### `shared/src/__tests__/crypto.test.ts`
- 4 new tests for `deriveSubscriptionEncryptionKey`:
  - Returns 64-char hex (256-bit)
  - Deterministic for same seed
  - Different seeds yield different keys
  - Rejects seeds that are not 32 bytes
- Fix pre-existing import of non-existent `deriveStealthSecretKey`

### `shared/src/crypto/metadata-encryption.ts`
- Fix pre-existing `Uint8Array<ArrayBufferLike>` TS5.9 type errors in SubtleCrypto calls

## Testing

```
PASS shared/src/__tests__/crypto.test.ts
  Crypto Utilities
    deriveSubscriptionEncryptionKey
      ✓ returns a 64-char hex string (256-bit key)
      ✓ is deterministic — same seed always yields the same key
      ✓ different seeds yield different keys
      ✓ rejects seeds that are not exactly 32 bytes
  ... (all 19 tests pass)
```

## Acceptance Criteria

- [x] Same Stellar key always derives the same encryption key (deterministic)
- [x] Different Stellar keys produce independent encryption keys
- [x] Works in browser and Node.js environments (uses `@noble/hashes/hkdf` — isomorphic)
- [x] Key cached in-memory per session, never persisted