### PR TITLE
Tor: Add Bitrefill and Coincards as privacy-friendly gift card providers

### DIFF
--- a/backend/src/schemas/user-preferences.ts
+++ b/backend/src/schemas/user-preferences.ts
@@ -31,6 +31,9 @@ export const userPreferencesUpdateSchema = z.object({
   currency: z.string().min(3).max(5).optional(),
   timezone: z.string().optional(),
   locale: z.string().optional(),
+  preferred_gift_card_provider: z
+    .enum(['atomic_wallet', 'bitrefill', 'coincards'])
+    .optional(),
 });
 
 // ─── Quiet Hours Schema ─────────────────────────────────────────────────────

--- a/backend/src/services/user-preference-service.ts
+++ b/backend/src/services/user-preference-service.ts
@@ -26,6 +26,7 @@ export class UserPreferenceService {
         locale: 'en-US',
         calendar_sync_enabled: false,
         calendar_export_reminders: true,
+        preferred_gift_card_provider: 'atomic_wallet',
     };
 
     /**

--- a/backend/src/types/reminder.ts
+++ b/backend/src/types/reminder.ts
@@ -128,6 +128,8 @@ export interface UserPreferences {
   locale: string;
   calendar_sync_enabled: boolean;
   calendar_export_reminders: boolean;
+  /** id of the preferred gift-card purchasing provider (see client/lib/gift-card-providers/). */
+  preferred_gift_card_provider: string;
   /** ISO-8601 UTC string. */
   updated_at: string;
 }

--- a/client/app/settings/privacy/page.tsx
+++ b/client/app/settings/privacy/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { fetchUserPreferences, updateUserPreferences } from '@/lib/api/user-preferences';
+import { GIFT_CARD_PROVIDERS, DEFAULT_GIFT_CARD_PROVIDER_ID } from '@/lib/gift-card-providers';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -17,6 +19,48 @@ export default function DataPrivacyPage() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleteScheduled, setDeleteScheduled] = useState(false);
+
+  // Gift card provider state
+  const [giftCardProviderId, setGiftCardProviderId] = useState(DEFAULT_GIFT_CARD_PROVIDER_ID);
+  const [giftCardProviderLoading, setGiftCardProviderLoading] = useState(true);
+  const [giftCardProviderSaving, setGiftCardProviderSaving] = useState(false);
+  const [giftCardProviderError, setGiftCardProviderError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchUserPreferences()
+      .then((prefs) => {
+        if (!cancelled && prefs.preferred_gift_card_provider) {
+          setGiftCardProviderId(prefs.preferred_gift_card_provider);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setGiftCardProviderError(err instanceof Error ? err.message : 'Failed to load preferences');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setGiftCardProviderLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleGiftCardProviderChange = async (providerId: string) => {
+    const previous = giftCardProviderId;
+    setGiftCardProviderId(providerId);
+    setGiftCardProviderSaving(true);
+    setGiftCardProviderError(null);
+    try {
+      await updateUserPreferences({ preferred_gift_card_provider: providerId });
+    } catch (err) {
+      setGiftCardProviderId(previous);
+      setGiftCardProviderError(err instanceof Error ? err.message : 'Failed to save provider');
+    } finally {
+      setGiftCardProviderSaving(false);
+    }
+  };
 
   const handleExport = async () => {
     setExporting(true);
@@ -120,6 +164,56 @@ export default function DataPrivacyPage() {
             >
               Manage Email Preferences
             </Link>
+          </section>
+
+          {/* Section: Gift Card Provider */}
+          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
+            <h2 className="text-base font-semibold text-gray-900 mb-1">Gift Card Purchase Provider</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Choose which provider Syncro uses when you buy a crypto-funded gift card to pay for a subscription.
+              Providers vary in Tor support, KYC requirements, and accepted cryptocurrencies.
+            </p>
+
+            {giftCardProviderError && (
+              <p className="text-sm text-red-600 mb-3">{giftCardProviderError}</p>
+            )}
+
+            {giftCardProviderLoading ? (
+              <p className="text-sm text-gray-400">Loading...</p>
+            ) : (
+              <div className="space-y-2">
+                {GIFT_CARD_PROVIDERS.map((provider) => (
+                  <label
+                    key={provider.id}
+                    className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      giftCardProviderId === provider.id
+                        ? 'border-indigo-500 bg-indigo-50'
+                        : 'border-gray-200 hover:bg-gray-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="gift-card-provider"
+                      className="mt-1 w-4 h-4 text-indigo-600 focus:ring-indigo-500"
+                      checked={giftCardProviderId === provider.id}
+                      disabled={giftCardProviderSaving}
+                      onChange={() => handleGiftCardProviderChange(provider.id)}
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-gray-900">
+                        {provider.name}
+                        {provider.torSupport && (
+                          <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
+                            Tor-friendly
+                          </span>
+                        )}
+                      </span>
+                      <span className="block text-xs text-gray-500 mt-0.5">{provider.description}</span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
           </section>
 
           {/* Section 3: Delete Account */}

--- a/client/components/modals/manage-subscription-modal.tsx
+++ b/client/components/modals/manage-subscription-modal.tsx
@@ -20,10 +20,9 @@ import { NotesEditor } from "@/components/ui/notes-editor"
 import { TagInput } from "@/components/ui/tag-input"
 import { useTags } from "@/hooks/use-tags"
 import { apiPost } from "@/lib/api"
-import {
-  getGiftCardProviderFromSubscription,
-  openAtomicWalletGiftCard,
-} from "@/lib/atomic-wallet"
+import { getGiftCardProviderFromSubscription } from "@/lib/atomic-wallet"
+import { fetchUserPreferences } from "@/lib/api/user-preferences"
+import { getGiftCardProvider } from "@/lib/gift-card-providers"
 
 const CANCEL_LINKS: Record<string, string> = {
   "ChatGPT Plus": "https://platform.openai.com/account/billing/overview",
@@ -86,6 +85,22 @@ export default function ManageSubscriptionModal({
   const giftCardProvider = getGiftCardProviderFromSubscription(subscription)
   const giftCardAmount = Number(subscription.price || 0)
   const canBuyGiftCard = Boolean(giftCardProvider && giftCardAmount > 0)
+
+  const handleBuyGiftCard = async () => {
+    if (!giftCardProvider) return
+    let preferredProviderId: string | undefined
+    try {
+      const prefs = await fetchUserPreferences()
+      preferredProviderId = prefs.preferred_gift_card_provider
+    } catch {
+      // Fall back to the default (Atomic Wallet) if preferences can't be loaded.
+    }
+    const purchaseProvider = getGiftCardProvider(preferredProviderId)
+    const url = purchaseProvider.generatePurchaseUrl(giftCardAmount, giftCardProvider)
+    if (typeof window !== "undefined") {
+      window.location.href = url
+    }
+  }
 
   const handleDelete = () => {
     onDelete()
@@ -323,7 +338,7 @@ export default function ManageSubscriptionModal({
 
               {canBuyGiftCard && (
                 <button
-                  onClick={() => openAtomicWalletGiftCard(giftCardAmount, giftCardProvider!)}
+                  onClick={handleBuyGiftCard}
                   className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-[#007A5C] text-white rounded-lg font-semibold hover:bg-[#007A5C]/90 transition-colors"
                 >
                   <Gift className="w-4 h-4" />

--- a/client/lib/api/user-preferences.ts
+++ b/client/lib/api/user-preferences.ts
@@ -22,6 +22,7 @@ export interface UserPreferences {
   currency: string
   timezone: string
   locale: string
+  preferred_gift_card_provider: string
   updated_at: string
 }
 
@@ -46,6 +47,7 @@ export interface UserPreferencesUpdateInput {
   currency?: string
   timezone?: string
   locale?: string
+  preferred_gift_card_provider?: string
 }
 
 export interface QuietHoursUpdateInput {

--- a/client/lib/gift-card-providers/atomic-wallet-provider.ts
+++ b/client/lib/gift-card-providers/atomic-wallet-provider.ts
@@ -1,0 +1,21 @@
+import { getAtomicWalletGiftCardLink } from "../atomic-wallet"
+import type { GiftCardProvider } from "./types"
+
+/**
+ * Wraps the pre-existing Atomic Wallet integration (`lib/atomic-wallet.ts`)
+ * as a `GiftCardProvider`, so it participates in the same provider registry
+ * as the new Tor-friendly providers without changing its existing exports
+ * (still used directly by `manage-subscription-modal.tsx`'s tests).
+ */
+export const atomicWalletProvider: GiftCardProvider = {
+  id: "atomic_wallet",
+  name: "Atomic Wallet",
+  description: "Non-custodial wallet with built-in gift card purchases. No Tor support; standard KYC may apply.",
+  torSupport: false,
+  kycLevel: "low",
+  supportedRegions: "global",
+  acceptedCrypto: ["BTC", "ETH", "XLM", "USDC", "60+ other assets"],
+  generatePurchaseUrl(amount: number, cardBrand: string): string {
+    return getAtomicWalletGiftCardLink(amount, cardBrand)
+  },
+}

--- a/client/lib/gift-card-providers/bitrefill-provider.ts
+++ b/client/lib/gift-card-providers/bitrefill-provider.ts
@@ -1,0 +1,51 @@
+import type { GiftCardProvider } from "./types"
+
+const BITREFILL_WEB_URL = "https://www.bitrefill.com"
+// Published Bitrefill Tor mirror (see bitrefill.com footer / onion-location
+// header). Verify against https://bitrefill.com before relying on this in
+// production -- onion addresses occasionally rotate.
+const BITREFILL_ONION_URL =
+  "http://bitrefillxa3kr2zljvkc2wbsiy5y6vmgs3zr2lkbcq6ohwlbtwsfo7id.onion"
+
+function bitrefillSlug(cardBrand: string): string {
+  return cardBrand
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+/**
+ * Builds a Bitrefill purchase URL for `cardBrand`. Bitrefill's product
+ * pages follow the pattern `/buy/{slug}`; `amount` is passed as a query
+ * hint (Bitrefill product pages expose fixed denominations and will
+ * highlight/select the closest one client-side).
+ */
+function buildPurchaseUrl(base: string, amount: number, cardBrand: string): string {
+  const slug = bitrefillSlug(cardBrand)
+  const params = new URLSearchParams({
+    utm_source: "syncro",
+    amount: amount.toString(),
+  })
+  return `${base}/buy/${encodeURIComponent(slug)}-gift-card?${params.toString()}`
+}
+
+export const bitrefillProvider: GiftCardProvider = {
+  id: "bitrefill",
+  name: "Bitrefill",
+  description:
+    "Accessible via a Tor .onion mirror, accepts Lightning Network payments, and supports 150+ countries.",
+  torSupport: true,
+  onionUrl: BITREFILL_ONION_URL,
+  kycLevel: "none",
+  supportedRegions: "global",
+  acceptedCrypto: ["BTC", "BTC (Lightning)", "ETH", "LTC", "DOGE", "USDT"],
+  generatePurchaseUrl(amount: number, cardBrand: string): string {
+    return buildPurchaseUrl(BITREFILL_WEB_URL, amount, cardBrand)
+  },
+}
+
+/** Returns the .onion purchase URL instead of the clearnet one, for users on Tor Browser. */
+export function getBitrefillOnionPurchaseUrl(amount: number, cardBrand: string): string {
+  return buildPurchaseUrl(BITREFILL_ONION_URL, amount, cardBrand)
+}

--- a/client/lib/gift-card-providers/coincards-provider.ts
+++ b/client/lib/gift-card-providers/coincards-provider.ts
@@ -1,0 +1,31 @@
+import type { GiftCardProvider } from "./types"
+
+const COINCARDS_WEB_URL = "https://www.coincards.com"
+
+function coincardsSlug(cardBrand: string): string {
+  return cardBrand
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+export const coincardsProvider: GiftCardProvider = {
+  id: "coincards",
+  name: "Coincards",
+  description: "Canadian-based, Tor-friendly storefront. No account required to purchase.",
+  torSupport: true,
+  kycLevel: "none",
+  // Canadian-based but sells internationally; not Bitrefill-style "150+
+  // countries" so left global rather than narrowed to CA without a source.
+  supportedRegions: "global",
+  acceptedCrypto: ["BTC", "ETH", "LTC", "BCH", "USDC"],
+  generatePurchaseUrl(amount: number, cardBrand: string): string {
+    const slug = coincardsSlug(cardBrand)
+    const params = new URLSearchParams({
+      utm_source: "syncro",
+      amount: amount.toString(),
+    })
+    return `${COINCARDS_WEB_URL}/product/${encodeURIComponent(slug)}-gift-card?${params.toString()}`
+  },
+}

--- a/client/lib/gift-card-providers/gift-card-providers.test.ts
+++ b/client/lib/gift-card-providers/gift-card-providers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import {
+  GIFT_CARD_PROVIDERS,
+  DEFAULT_GIFT_CARD_PROVIDER_ID,
+  getGiftCardProvider,
+  isValidGiftCardProviderId,
+  atomicWalletProvider,
+  bitrefillProvider,
+  coincardsProvider,
+  getBitrefillOnionPurchaseUrl,
+} from "./index"
+
+describe("gift card provider registry", () => {
+  it("includes Atomic Wallet, Bitrefill, and Coincards", () => {
+    const ids = GIFT_CARD_PROVIDERS.map((p) => p.id)
+    expect(ids).toEqual(expect.arrayContaining(["atomic_wallet", "bitrefill", "coincards"]))
+  })
+
+  it("defaults to the existing Atomic Wallet provider", () => {
+    expect(DEFAULT_GIFT_CARD_PROVIDER_ID).toBe("atomic_wallet")
+  })
+
+  it("getGiftCardProvider falls back to the default for an unknown id", () => {
+    expect(getGiftCardProvider("not-a-real-provider").id).toBe("atomic_wallet")
+    expect(getGiftCardProvider(undefined).id).toBe("atomic_wallet")
+  })
+
+  it("getGiftCardProvider resolves a known id", () => {
+    expect(getGiftCardProvider("bitrefill").id).toBe("bitrefill")
+    expect(getGiftCardProvider("coincards").id).toBe("coincards")
+  })
+
+  it("isValidGiftCardProviderId distinguishes known from unknown ids", () => {
+    expect(isValidGiftCardProviderId("bitrefill")).toBe(true)
+    expect(isValidGiftCardProviderId("coincards")).toBe(true)
+    expect(isValidGiftCardProviderId("atomic_wallet")).toBe(true)
+    expect(isValidGiftCardProviderId("paypal")).toBe(false)
+  })
+})
+
+describe("Bitrefill provider", () => {
+  it("supports Tor and exposes an onion URL", () => {
+    expect(bitrefillProvider.torSupport).toBe(true)
+    expect(bitrefillProvider.onionUrl).toMatch(/\.onion$/)
+  })
+
+  it("generates a clearnet purchase URL with brand slug and amount", () => {
+    const url = bitrefillProvider.generatePurchaseUrl(25, "Amazon")
+    expect(url).toContain("bitrefill.com/buy/amazon-gift-card")
+    expect(url).toContain("amount=25")
+  })
+
+  it("normalizes multi-word brand names into a hyphenated slug", () => {
+    const url = bitrefillProvider.generatePurchaseUrl(50, "Google Play")
+    expect(url).toContain("/buy/google-play-gift-card")
+  })
+
+  it("getBitrefillOnionPurchaseUrl returns an onion-hosted URL", () => {
+    const url = getBitrefillOnionPurchaseUrl(10, "Steam")
+    expect(url).toContain(".onion/buy/steam-gift-card")
+  })
+})
+
+describe("Coincards provider", () => {
+  it("supports Tor and requires no account / KYC", () => {
+    expect(coincardsProvider.torSupport).toBe(true)
+    expect(coincardsProvider.kycLevel).toBe("none")
+  })
+
+  it("generates a purchase URL with brand slug and amount", () => {
+    const url = coincardsProvider.generatePurchaseUrl(40, "Visa")
+    expect(url).toContain("coincards.com/product/visa-gift-card")
+    expect(url).toContain("amount=40")
+  })
+})
+
+describe("Atomic Wallet provider (wrapped)", () => {
+  it("does not support Tor", () => {
+    expect(atomicWalletProvider.torSupport).toBe(false)
+  })
+
+  it("delegates to the existing atomic-wallet.ts URL builder", () => {
+    const url = atomicWalletProvider.generatePurchaseUrl(15, "Amazon")
+    expect(url).toContain("provider=amazon")
+    expect(url).toContain("amount=15")
+  })
+})

--- a/client/lib/gift-card-providers/index.ts
+++ b/client/lib/gift-card-providers/index.ts
@@ -1,0 +1,27 @@
+import { atomicWalletProvider } from "./atomic-wallet-provider"
+import { bitrefillProvider } from "./bitrefill-provider"
+import { coincardsProvider } from "./coincards-provider"
+import type { GiftCardProvider } from "./types"
+
+export * from "./types"
+export { atomicWalletProvider } from "./atomic-wallet-provider"
+export { bitrefillProvider, getBitrefillOnionPurchaseUrl } from "./bitrefill-provider"
+export { coincardsProvider } from "./coincards-provider"
+
+/** Every gift-card purchasing provider available to users. */
+export const GIFT_CARD_PROVIDERS: GiftCardProvider[] = [
+  atomicWalletProvider,
+  bitrefillProvider,
+  coincardsProvider,
+]
+
+export const DEFAULT_GIFT_CARD_PROVIDER_ID: string = atomicWalletProvider.id
+
+export function getGiftCardProvider(id: string | null | undefined): GiftCardProvider {
+  const found = GIFT_CARD_PROVIDERS.find((provider) => provider.id === id)
+  return found ?? atomicWalletProvider
+}
+
+export function isValidGiftCardProviderId(id: string): boolean {
+  return GIFT_CARD_PROVIDERS.some((provider) => provider.id === id)
+}

--- a/client/lib/gift-card-providers/types.ts
+++ b/client/lib/gift-card-providers/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Provider abstraction for purchasing gift cards with crypto.
+ *
+ * "Provider" here means the *purchasing service* (Atomic Wallet, Bitrefill,
+ * Coincards, ...) that fulfils a crypto-to-gift-card purchase -- not the
+ * gift card brand/merchant itself (Amazon, Steam, ...), which is passed in
+ * as `cardBrand` to `generatePurchaseUrl`. See `client/lib/atomic-wallet.ts`
+ * for the existing brand-name resolution helpers (`resolveGiftCardProvider`
+ * etc.), which predate this abstraction and use "provider" to mean brand.
+ */
+
+export type KycLevel = "none" | "low" | "medium" | "high"
+
+export interface GiftCardProviderMetadata {
+  /** Stable identifier, persisted as the user's preferred provider. */
+  id: string
+  /** Display name shown in Settings -> Privacy. */
+  name: string
+  /** Short description of the privacy trade-offs, shown in the UI. */
+  description: string
+  /** Whether the provider is reachable over Tor (has a published .onion address). */
+  torSupport: boolean
+  /** The provider's .onion address, when `torSupport` is true. */
+  onionUrl?: string
+  /** Approximate KYC burden for a typical purchase. */
+  kycLevel: KycLevel
+  /** ISO 3166-1 alpha-2 country codes, or "global" if unrestricted. */
+  supportedRegions: string[] | "global"
+  /** Cryptocurrencies/networks accepted at checkout. */
+  acceptedCrypto: string[]
+}
+
+export interface GiftCardProvider extends GiftCardProviderMetadata {
+  /**
+   * Build the URL (web or deep-link) that starts a purchase of `amount`
+   * worth of a `cardBrand` (e.g. "amazon", "steam") gift card through this
+   * provider.
+   */
+  generatePurchaseUrl(amount: number, cardBrand: string): string
+}

--- a/supabase/migrations/20260625000000_add_preferred_gift_card_provider.sql
+++ b/supabase/migrations/20260625000000_add_preferred_gift_card_provider.sql
@@ -1,0 +1,7 @@
+-- Preferred gift-card purchasing provider (Atomic Wallet, Bitrefill, Coincards, ...)
+-- See client/lib/gift-card-providers/ for the provider registry this references.
+ALTER TABLE public.user_preferences
+ADD COLUMN IF NOT EXISTS preferred_gift_card_provider TEXT NOT NULL DEFAULT 'atomic_wallet';
+
+COMMENT ON COLUMN public.user_preferences.preferred_gift_card_provider IS
+  'id of the user''s preferred gift-card purchasing provider, e.g. atomic_wallet, bitrefill, coincards';


### PR DESCRIPTION
Closes #849 

closes #485 

closes #877 

Adds `client/lib/gift-card-providers/` with a `GiftCardProvider` interface (`generatePurchaseUrl`, plus Tor/KYC/region/crypto metadata) and three implementations: the existing Atomic Wallet integration wrapped to implement the interface (without touching `lib/atomic-wallet.ts` itself, so its existing callers/tests keep working), plus new **Bitrefill** and **Coincards** providers (both Tor-friendly, no-KYC).

Adds a "Gift Card Purchase Provider" section to Settings -> Privacy with a provider picker, persisted via a new `preferred_gift_card_provider` column on `user_preferences`. `manage-subscription-modal.tsx`'s "Buy Gift Card" button now looks up the user's preferred provider and routes the purchase through it, instead of always hard-coding Atomic Wallet.

**Caveat:** Bitrefill/Coincards purchase URL patterns (and Bitrefill's `.onion` address) are best-effort based on their publicly documented URL structure -- I couldn't browse either site to verify live. Please double-check these against the real sites before this ships.