### PR TITLE
ZK: Extract nullifier registry into its own module

### DIFF
--- a/contracts/contracts/zk-payment-verifier/src/commitment.rs
+++ b/contracts/contracts/zk-payment-verifier/src/commitment.rs
@@ -19,17 +19,3 @@ pub fn compute_commitment(
 
     env.crypto().sha256(&payload).into()
 }
-
-/// Compute nullifier: SHA-256("syncro:payment:v1" || blinding_factor || service_id)
-/// Deterministic per (blinding_factor, service_id) pair — prevents double-proving.
-pub fn compute_nullifier(
-    env: &Env,
-    blinding_factor: &BytesN<32>,
-    service_id: &Bytes,
-) -> BytesN<32> {
-    let mut payload = Bytes::from_slice(env, b"syncro:payment:v1");
-    payload.append(&Bytes::from_slice(env, &blinding_factor.to_array()));
-    payload.append(&service_id.clone());
-
-    env.crypto().sha256(&payload).into()
-}

--- a/contracts/contracts/zk-payment-verifier/src/lib.rs
+++ b/contracts/contracts/zk-payment-verifier/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Bytes, BytesN, Env, Map};
+use soroban_sdk::{contract, contractimpl, contracttype, Bytes, BytesN, Env};
 
 pub mod commitment;
+pub mod nullifier;
 
 #[contracttype]
 #[derive(Clone)]
@@ -39,35 +40,13 @@ impl ZkPaymentVerifier {
             return false;
         }
 
-        let nullifier = commitment::compute_nullifier(&env, &blinding_factor, &service_id);
-
-        let mut nullifiers: Map<BytesN<32>, bool> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Nullifiers)
-            .unwrap_or(Map::new(&env));
-
-        if nullifiers.contains_key(nullifier.clone()) {
-            return false;
-        }
-
-        nullifiers.set(nullifier, true);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Nullifiers, &nullifiers);
-
-        true
+        let computed_nullifier = nullifier::compute_nullifier(&env, &blinding_factor, &service_id);
+        nullifier::record(&env, computed_nullifier)
     }
 
     /// Check if a nullifier has already been used.
     pub fn is_nullifier_used(env: Env, nullifier: BytesN<32>) -> bool {
-        let nullifiers: Map<BytesN<32>, bool> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Nullifiers)
-            .unwrap_or(Map::new(&env));
-
-        nullifiers.contains_key(nullifier)
+        nullifier::is_used(&env, &nullifier)
     }
 }
 

--- a/contracts/contracts/zk-payment-verifier/src/nullifier.rs
+++ b/contracts/contracts/zk-payment-verifier/src/nullifier.rs
@@ -1,0 +1,60 @@
+//! On-chain nullifier registry, preventing the same ZK proof secret
+//! (a `blinding_factor` + `service_id` pair) from being used to prove the
+//! same payment twice.
+//!
+//! All submitted nullifiers live in a single persistent `Map`, so every
+//! lookup/insert reads and rewrites the whole set -- storage and per-call
+//! cost grow linearly with the number of nullifiers ever submitted. That's
+//! an accepted MVP tradeoff (see the issue this module was built for);
+//! revisit if proof volume grows large enough to make it a bottleneck.
+
+use soroban_sdk::{Bytes, BytesN, Env, Map};
+
+use crate::DataKey;
+
+/// Compute a nullifier: `SHA-256("syncro:payment:v1" || blinding_factor || service_id)`.
+///
+/// Deterministic per `(blinding_factor, service_id)` pair, so the same
+/// secret can never produce two different nullifiers. It reveals nothing
+/// about the underlying payment (amount, user, timestamp) -- it's a
+/// one-way hash of values only the prover knows, so an observer learns
+/// only "some proof already used this nullifier," never which payment.
+pub fn compute_nullifier(
+    env: &Env,
+    blinding_factor: &BytesN<32>,
+    service_id: &Bytes,
+) -> BytesN<32> {
+    let mut payload = Bytes::from_slice(env, b"syncro:payment:v1");
+    payload.append(&Bytes::from_slice(env, &blinding_factor.to_array()));
+    payload.append(&service_id.clone());
+
+    env.crypto().sha256(&payload).into()
+}
+
+fn load(env: &Env) -> Map<BytesN<32>, bool> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Nullifiers)
+        .unwrap_or(Map::new(env))
+}
+
+/// Whether `nullifier` has already been recorded.
+pub fn is_used(env: &Env, nullifier: &BytesN<32>) -> bool {
+    load(env).contains_key(nullifier.clone())
+}
+
+/// Record `nullifier` as used.
+///
+/// Returns `true` if it was freshly recorded, `false` if it was already
+/// present (a duplicate -- the existing entry is left untouched).
+pub fn record(env: &Env, nullifier: BytesN<32>) -> bool {
+    let mut nullifiers = load(env);
+    if nullifiers.contains_key(nullifier.clone()) {
+        return false;
+    }
+    nullifiers.set(nullifier, true);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Nullifiers, &nullifiers);
+    true
+}

--- a/contracts/contracts/zk-payment-verifier/src/test.rs
+++ b/contracts/contracts/zk-payment-verifier/src/test.rs
@@ -137,7 +137,7 @@ fn test_is_nullifier_used() {
     let service_id = Bytes::from_slice(&env, b"service_netflix");
     let blinding_factor = BytesN::from_array(&env, &[42u8; 32]);
 
-    let nullifier = commitment::compute_nullifier(&env, &blinding_factor, &service_id);
+    let nullifier = nullifier::compute_nullifier(&env, &blinding_factor, &service_id);
 
     assert!(!client.is_nullifier_used(&nullifier));
 


### PR DESCRIPTION
Closes #870
closes #187 
closes #887 

The double-proving prevention this issue asks for was already fully functional on `main`: `verify_and_record` already rejected duplicate nullifiers, the nullifier was already a one-way SHA-256 hash revealing nothing about the payment, and storage already grew as a single linearly-growing `Map` (acceptable for MVP per this issue's own acceptance criteria) -- all three acceptance criteria already had passing tests (`test_nullifier_prevents_double_proof`, `test_is_nullifier_used`, `test_different_services_independent_nullifiers`).

What was missing was the dedicated `nullifier.rs` module the issue's title and "Affected Code" section describe: the logic lived inline in `lib.rs` (storage manipulation) and `commitment.rs` (`compute_nullifier`). Extracted both into `nullifier.rs` as a self-contained registry API (`compute_nullifier`, `is_used`, `record`), with `lib.rs`'s contract functions now just delegating to it. Pure mechanical extraction -- behavior is unchanged, only the organization changed.

(`verifier.rs` in this same crate implements a different, more advanced ZK proof scheme but isn't declared as a module or referenced anywhere -- pre-existing and out of scope for this issue, left untouched.)

**Verification note:** no network access to fetch `soroban-sdk` in my sandbox. Verified via `rustc --emit=metadata` partial-resolution checks: identical pre-existing error profile before/after (just one more expected "unresolved import soroban_sdk" from the new file importing it), no new error categories. Please run the real test suite before merging.