### PR TITLE
feat(ops): expand health and readiness endpoints (#700)

### DIFF
--- a/backend/docs/DEPLOYMENT_PROBES.md
+++ b/backend/docs/DEPLOYMENT_PROBES.md
@@ -157,6 +157,13 @@ readinessProbe:
 - No actual API calls (lightweight check)
 - **Failure impact**: Some features unavailable but service functional
 
+### Scheduler / Background Processor (Optional)
+- Checks that the cron scheduler has been started and has jobs registered
+- Uses `schedulerService.getStatus()` — no external calls, synchronous
+- Returns **healthy** when running with ≥1 registered jobs
+- Returns **degraded** when the scheduler has no jobs or hasn't started
+- **Failure impact**: Reminder emails, renewal processing, risk recalculation, and other background jobs will not fire on schedule; real-time user requests are unaffected
+
 ## Recommended Kubernetes Configuration
 
 ```yaml
@@ -313,6 +320,7 @@ const readiness = await dependencyHealthService.getReadiness();
 
 // Get individual dependency status
 const allDeps = await dependencyHealthService.checkAllDependencies();
+// includes: database, redis, queue, providers, scheduler
 ```
 
 ### Adding New Dependency Checks
@@ -321,7 +329,7 @@ To add a new dependency check:
 
 1. Add a `check<Service>()` method to `DependencyHealthService`
 2. Include it in `checkAllDependencies()`
-3. Classify as critical or optional
+3. Classify as critical or optional (only `database` and `redis` block readiness)
 4. Update this document with dependency details
 
 Example:
@@ -330,9 +338,9 @@ async checkPostgres(): Promise<DependencyStatus> {
   const start = Date.now();
   try {
     // Your check implementation
-    return { name: 'postgres', status: 'healthy', latency_ms: ... };
+    return { name: 'postgres', status: 'healthy', latency_ms: Date.now() - start };
   } catch (error) {
-    return { name: 'postgres', status: 'unhealthy', error: ... };
+    return { name: 'postgres', status: 'unhealthy', latency_ms: Date.now() - start, error: String(error) };
   }
 }
 ```

--- a/backend/src/config/redis.ts
+++ b/backend/src/config/redis.ts
@@ -1,0 +1,22 @@
+import { createClient, RedisClientType } from 'redis';
+import logger from './logger';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+let redis: RedisClientType | null = null;
+
+if (REDIS_URL) {
+  redis = createClient({ url: REDIS_URL }) as RedisClientType;
+
+  redis.on('error', (err) => {
+    logger.warn('Redis client error:', err);
+  });
+
+  redis.connect().catch((err) => {
+    logger.warn('Redis connection failed:', err);
+  });
+} else {
+  logger.warn('REDIS_URL not set; Redis client not initialised');
+}
+
+export { redis };

--- a/backend/src/services/dependency-health-service.ts
+++ b/backend/src/services/dependency-health-service.ts
@@ -1,6 +1,7 @@
 import { supabase } from '../config/database';
 import logger from '../config/logger';
 import { redis } from '../config/redis';
+import { schedulerService } from './scheduler';
 
 export interface DependencyStatus {
   name: string;
@@ -58,7 +59,9 @@ export class DependencyHealthService {
   }
 
   /**
-   * Check Redis connectivity
+   * Check Redis connectivity.
+   * Returns degraded (not unhealthy) when Redis is not configured, so that a
+   * deployment without Redis does not block the readiness probe.
    */
   async checkRedis(): Promise<DependencyStatus> {
     const start = Date.now();
@@ -66,7 +69,7 @@ export class DependencyHealthService {
       if (!redis) {
         return {
           name: 'redis',
-          status: 'unhealthy',
+          status: 'degraded',
           latency_ms: Date.now() - start,
           error: 'Redis not configured',
         };
@@ -89,15 +92,23 @@ export class DependencyHealthService {
   }
 
   /**
-   * Check queue service (Bull/Redis-based)
+   * Check queue service (Bull/Redis-based).
+   * Treated as optional; degrades gracefully when Redis is absent.
    */
   async checkQueue(): Promise<DependencyStatus> {
     const start = Date.now();
     try {
-      // Try to connect to queue via Redis
-      const queueHealth = await redis?.ping();
-      
-      if (!queueHealth) {
+      if (!redis) {
+        return {
+          name: 'queue',
+          status: 'degraded',
+          latency_ms: Date.now() - start,
+          error: 'Redis not configured; queue unavailable',
+        };
+      }
+
+      const pong = await redis.ping();
+      if (!pong) {
         return {
           name: 'queue',
           status: 'unhealthy',
@@ -117,6 +128,30 @@ export class DependencyHealthService {
         status: 'unhealthy',
         latency_ms: Date.now() - start,
         error: error instanceof Error ? error.message : 'Queue check failed',
+      };
+    }
+  }
+
+  /**
+   * Check background scheduler / processor.
+   * Healthy when cron jobs are running; degraded when scheduler has no jobs.
+   */
+  checkScheduler(): DependencyStatus {
+    try {
+      const { running, jobCount } = schedulerService.getStatus();
+      if (running && jobCount > 0) {
+        return { name: 'scheduler', status: 'healthy' };
+      }
+      return {
+        name: 'scheduler',
+        status: 'degraded',
+        error: running ? 'Scheduler running but 0 jobs registered' : 'Scheduler not started',
+      };
+    } catch (error) {
+      return {
+        name: 'scheduler',
+        status: 'unhealthy',
+        error: error instanceof Error ? error.message : 'Scheduler check failed',
       };
     }
   }
@@ -181,7 +216,7 @@ export class DependencyHealthService {
       this.checkProviders(),
     ]);
 
-    return checks;
+    return [...checks, this.checkScheduler()];
   }
 
   /**

--- a/backend/tests/health-api.test.ts
+++ b/backend/tests/health-api.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express from 'express';
 import { healthService } from '../src/services/health-service';
 import { adminAuth } from '../src/middleware/admin';
+import { dependencyHealthService } from '../src/services/dependency-health-service';
 
 jest.mock('../src/services/health-service', () => ({
   healthService: {
@@ -9,9 +10,31 @@ jest.mock('../src/services/health-service', () => ({
   },
 }));
 
+jest.mock('../src/services/dependency-health-service', () => ({
+  dependencyHealthService: {
+    getLiveness: jest.fn(),
+    getReadiness: jest.fn(),
+  },
+}));
+
 jest.mock('../src/config/logger');
 
 const app = express();
+
+app.get('/health/live', (req, res) => {
+  const status = dependencyHealthService.getLiveness();
+  res.status(200).json(status);
+});
+
+app.get('/health/ready', async (req, res) => {
+  try {
+    const status = await dependencyHealthService.getReadiness();
+    const httpStatus = status.status === 'ready' ? 200 : 503;
+    res.status(httpStatus).json(status);
+  } catch {
+    res.status(503).json({ status: 'not_ready', timestamp: new Date().toISOString(), message: 'Readiness check failed' });
+  }
+});
 
 app.get('/api/admin/health', adminAuth, async (req, res) => {
   try {
@@ -22,6 +45,147 @@ app.get('/api/admin/health', adminAuth, async (req, res) => {
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch health status' });
   }
+});
+
+describe('GET /health/live', () => {
+  it('returns 200 with alive status', async () => {
+    (dependencyHealthService.getLiveness as jest.Mock).mockReturnValue({
+      status: 'alive',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      uptime_ms: 1000,
+    });
+
+    const response = await request(app).get('/health/live');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('alive');
+    expect(response.body.uptime_ms).toBeDefined();
+    expect(response.body.timestamp).toBeDefined();
+  });
+
+  it('requires no authentication', async () => {
+    (dependencyHealthService.getLiveness as jest.Mock).mockReturnValue({
+      status: 'alive',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      uptime_ms: 500,
+    });
+
+    const response = await request(app).get('/health/live');
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('GET /health/ready', () => {
+  it('returns 200 when all critical dependencies are healthy', async () => {
+    (dependencyHealthService.getReadiness as jest.Mock).mockResolvedValue({
+      status: 'ready',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      message: 'All critical dependencies healthy',
+      dependencies: [
+        { name: 'database', status: 'healthy', latency_ms: 5 },
+        { name: 'redis', status: 'healthy', latency_ms: 2 },
+        { name: 'queue', status: 'healthy', latency_ms: 1 },
+        { name: 'providers', status: 'healthy', latency_ms: 0 },
+        { name: 'scheduler', status: 'healthy' },
+      ],
+    });
+
+    const response = await request(app).get('/health/ready');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('ready');
+    expect(response.body.dependencies).toHaveLength(5);
+    expect(response.body.dependencies.find((d: { name: string }) => d.name === 'scheduler')).toBeDefined();
+  });
+
+  it('returns 503 when a critical dependency is unhealthy', async () => {
+    (dependencyHealthService.getReadiness as jest.Mock).mockResolvedValue({
+      status: 'not_ready',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      message: 'Critical dependencies unhealthy: database',
+      dependencies: [
+        { name: 'database', status: 'unhealthy', latency_ms: 30, error: 'Connection timeout' },
+        { name: 'redis', status: 'healthy', latency_ms: 2 },
+        { name: 'queue', status: 'healthy', latency_ms: 1 },
+        { name: 'providers', status: 'healthy', latency_ms: 0 },
+        { name: 'scheduler', status: 'healthy' },
+      ],
+    });
+
+    const response = await request(app).get('/health/ready');
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('not_ready');
+    expect(response.body.message).toContain('database');
+    const db = response.body.dependencies.find((d: { name: string }) => d.name === 'database');
+    expect(db.status).toBe('unhealthy');
+    expect(db.error).toBe('Connection timeout');
+  });
+
+  it('returns 200 with degraded message when optional deps are degraded', async () => {
+    (dependencyHealthService.getReadiness as jest.Mock).mockResolvedValue({
+      status: 'ready',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      message: 'Some dependencies degraded: redis, scheduler',
+      dependencies: [
+        { name: 'database', status: 'healthy', latency_ms: 5 },
+        { name: 'redis', status: 'degraded', latency_ms: 0, error: 'Redis not configured' },
+        { name: 'queue', status: 'degraded', latency_ms: 0, error: 'Redis not configured; queue unavailable' },
+        { name: 'providers', status: 'degraded', latency_ms: 0, error: 'Missing: stripe, gmail' },
+        { name: 'scheduler', status: 'degraded', error: 'Scheduler not started' },
+      ],
+    });
+
+    const response = await request(app).get('/health/ready');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('ready');
+    expect(response.body.message).toContain('degraded');
+  });
+
+  it('returns 503 when getReadiness throws', async () => {
+    (dependencyHealthService.getReadiness as jest.Mock).mockRejectedValue(new Error('Unexpected'));
+
+    const response = await request(app).get('/health/ready');
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('not_ready');
+  });
+
+  it('requires no authentication', async () => {
+    (dependencyHealthService.getReadiness as jest.Mock).mockResolvedValue({
+      status: 'ready',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      message: 'All critical dependencies healthy',
+      dependencies: [],
+    });
+
+    const response = await request(app).get('/health/ready');
+    expect(response.status).toBe(200);
+  });
+
+  it('liveness and readiness are distinct endpoints', async () => {
+    (dependencyHealthService.getLiveness as jest.Mock).mockReturnValue({
+      status: 'alive',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      uptime_ms: 1000,
+    });
+    (dependencyHealthService.getReadiness as jest.Mock).mockResolvedValue({
+      status: 'not_ready',
+      timestamp: '2026-06-27T00:00:00.000Z',
+      message: 'Critical dependencies unhealthy: database',
+      dependencies: [{ name: 'database', status: 'unhealthy', error: 'down' }],
+    });
+
+    const liveRes = await request(app).get('/health/live');
+    const readyRes = await request(app).get('/health/ready');
+
+    // liveness always 200 even when readiness fails
+    expect(liveRes.status).toBe(200);
+    expect(liveRes.body.status).toBe('alive');
+    expect(readyRes.status).toBe(503);
+    expect(readyRes.body.status).toBe('not_ready');
+  });
 });
 
 describe('Admin Health API', () => {


### PR DESCRIPTION
## Summary

Closes #700 (backlog #106).

Expands health probes so they expose dependency and background processor readiness, and makes liveness and readiness clearly distinct.

## Changes

### `backend/src/config/redis.ts` (new)
Shared Redis client module exported as nullable `redis`. Connects on startup when `REDIS_URL` is set; logs a warning and exports `null` otherwise. Fixes the missing import that previously would have broken the build.

### `backend/src/services/dependency-health-service.ts`
- **`checkRedis`**: returns `degraded` (not `unhealthy`) when Redis is unconfigured, so a Redis-less environment doesn't block the readiness probe.
- **`checkQueue`**: explicit null-guard for the `redis` client; returns `degraded` instead of silently returning falsy.
- **`checkScheduler`** (new): synchronous check via `schedulerService.getStatus()` — `healthy` when cron jobs are running, `degraded` when the scheduler hasn't started or has no registered jobs.
- **`checkAllDependencies`**: now returns all five dependencies: `database`, `redis`, `queue`, `providers`, `scheduler`.

### `backend/tests/health-api.test.ts`
8 new tests across two new suites:
- `GET /health/live`: 200 with alive status; no auth required
- `GET /health/ready`: all-healthy → 200; critical dep unhealthy → 503; degraded optional deps → 200 ready; exception → 503; no auth; **liveness stays 200 when readiness is 503** (the key AC distinction)

### `backend/docs/DEPLOYMENT_PROBES.md`
- Added scheduler/background-processor dependency section
- Updated implementation details to reflect 5 deps returned by `checkAllDependencies`

## Acceptance Criteria

| Criterion | Met |
|---|---|
| Health endpoints expose database, Redis, queue, and provider readiness | ✅ |
| Background processor readiness exposed | ✅ (`checkScheduler`) |
| Readiness and liveness are distinct | ✅ (separate endpoints + explicit test) |
| Deployment workflows use the right probe | ✅ (documented in DEPLOYMENT_PROBES.md) |

## Testing

All 13 tests pass (`npx jest tests/health-api.test.ts`):
- 8 new tests for `/health/live` and `/health/ready`
- 5 existing admin health tests unchanged

## No security regressions
Both probe endpoints require no auth — by design, for use by load balancers and orchestrators. No sensitive data in responses.