### PR TITLE
feat: add cheaper alternatives detection to suggestion service

### DIFF
--- a/backend/src/routes/suggestions.ts
+++ b/backend/src/routes/suggestions.ts
@@ -29,6 +29,7 @@ const dismissSchema = z.object({
     'unused_subscription',
     'duplicate_service',
     'plan_downgrade',
+    'suggest_cheaper_alternatives',
   ]),
 });
 

--- a/backend/src/services/analytics-service.ts
+++ b/backend/src/services/analytics-service.ts
@@ -41,6 +41,15 @@ export class AnalyticsService {
 
       if (budgetError) throw budgetError;
 
+      // Get suggestions to calculate potential savings
+      const { data: suggestions, error: suggestionError } = await supabase
+        .from('suggestions')
+        .select('savings_per_year')
+        .eq('user_id', userId)
+        .eq('dismissed_until', null);
+
+      if (suggestionError) throw suggestionError;
+
       const typedSubs = (subscriptions || []) as Subscription[];
       const typedBudgets = (budgets || []) as Budget[];
 
@@ -58,6 +67,9 @@ export class AnalyticsService {
       };
 
       const upcomingRenewalsCount = countUpcomingRenewals(typedSubs, 7);
+      const potentialSavingsMonthly = (suggestions || [])
+        .filter(s => s.savings_per_year)
+        .reduce((sum, s) => sum + (s.savings_per_year || 0) / 12, 0);
 
       const summary = {
         total_monthly_spend: totalMonthlySpend,
@@ -66,7 +78,8 @@ export class AnalyticsService {
         monthly_trend: monthlyTrend,
         category_breakdown: categoryBreakdown,
         top_subscriptions: topSubscriptions,
-        budget_status: budgetStatus
+        budget_status: budgetStatus,
+        potential_savings_monthly: parseFloat(potentialSavingsMonthly.toFixed(2))
       };
 
       await queryCacheService.set(

--- a/backend/src/services/suggestion-service.ts
+++ b/backend/src/services/suggestion-service.ts
@@ -5,7 +5,8 @@ export type SuggestionType =
   | 'switch_to_annual'
   | 'unused_subscription'
   | 'duplicate_service'
-  | 'plan_downgrade';
+  | 'plan_downgrade'
+  | 'suggest_cheaper_alternatives';
 
 export interface Suggestion {
   id: string;
@@ -54,8 +55,31 @@ const ANNUAL_TEMPLATES: AnnualTemplate[] = [
   { name: 'Microsoft 365',    annualPrice:  99.99 },
 ];
 
+/** Known cheaper alternatives for popular subscriptions */
+interface CheaperAlternative {
+  name: string;
+  currentPrice: number;
+  cheaperAlternativeName: string;
+  cheaperAlternativePrice: number;
+  savingsPerMonth: number;
+}
+
+const CHEAPER_ALTERNATIVES: CheaperAlternative[] = [
+  { name: 'Netflix', currentPrice: 15.99, cheaperAlternativeName: 'Ad-free Lite', cheaperAlternativePrice: 9.99, savingsPerMonth: 6.00 },
+  { name: 'Spotify', currentPrice: 9.99, cheaperAlternativeName: 'Spotify Family', cheaperAlternativePrice: 7.99, savingsPerMonth: 2.00 },
+  { name: 'Disney+', currentPrice: 7.99, cheaperAlternativeName: 'Disney+ (Quarterly)', cheaperAlternativePrice: 5.99, savingsPerMonth: 2.00 },
+  { name: 'Hulu', currentPrice: 5.99, cheaperAlternativeName: 'Hulu Basic', cheaperAlternativePrice: 4.99, savingsPerMonth: 1.00 },
+  { name: 'YouTube Premium', currentPrice: 11.99, cheaperAlternativeName: 'YouTube Premium Student', cheaperAlternativePrice: 4.99, savingsPerMonth: 7.00 },
+  { name: 'ChatGPT Plus', currentPrice: 20.00, cheaperAlternativeName: 'ChatGPT Team', cheaperAlternativePrice: 15.00, savingsPerMonth: 5.00 },
+  { name: 'Claude Pro', currentPrice: 20.00, cheaperAlternativeName: 'Claude Team', cheaperAlternativePrice: 15.00, savingsPerMonth: 5.00 },
+  { name: 'GitHub Copilot', currentPrice: 10.00, cheaperAlternativeName: 'GitHub Copilot Business', cheaperAlternativePrice: 8.00, savingsPerMonth: 2.00 },
+  { name: 'Adobe CC', currentPrice: 79.99, cheaperAlternativeName: 'Adobe Cloud Essential', cheaperAlternativePrice: 60.00, savingsPerMonth: 19.99 },
+  { name: 'Microsoft 365', currentPrice: 9.99, cheaperAlternativeName: 'Office Online Basic', cheaperAlternativePrice: 6.00, savingsPerMonth: 3.99 },
+];
+
 const UNUSED_DAYS_THRESHOLD = 60;
 const MIN_ANNUAL_SAVINGS = 20;
+const DISCOUNT_THRESHOLD = 5.00;
 const DISMISS_DAYS = 30;
 
 export class SuggestionService {
@@ -162,6 +186,23 @@ export class SuggestionService {
           message: `You may be paying twice for similar ${category.replace('_', ' ')} tools: ${sub.name} and ${others.join(', ')}. Compare plans →`,
         });
         break; // one suggestion per category group is enough
+      }
+    }
+
+    // 4. Cheaper alternatives detection
+    for (const sub of subs) {
+      const alt = CHEAPER_ALTERNATIVES.find(a => a.name.toLowerCase() === sub.name.toLowerCase());
+      if (!alt) continue;
+      if (isDismissed(sub.id, 'suggest_cheaper_alternatives')) continue;
+      if (alt.savingsPerMonth >= DISCOUNT_THRESHOLD) {
+        suggestions.push({
+          id: `${sub.id}:suggest_cheaper_alternatives`,
+          type: 'suggest_cheaper_alternatives',
+          subscriptionId: sub.id,
+          subscriptionName: sub.name,
+          message: `Try ${alt.cheaperAlternativeName} for $${alt.cheaperAlternativePrice}/mo instead of ${sub.name} ($${sub.price}/mo). Save $${alt.savingsPerMonth}/mo ($${alt.savingsPerMonth * 12}/yr).`,
+          savingsPerYear: alt.savingsPerMonth * 12,
+        });
       }
     }
 

--- a/backend/src/types/analytics.ts
+++ b/backend/src/types/analytics.ts
@@ -31,6 +31,7 @@ export interface AnalyticsSummary {
     current_spend: number;
     percentage: number;
   };
+  potential_savings_monthly: number;
 }
 
 export interface Budget {

--- a/client/app/page-data.ts
+++ b/client/app/page-data.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { buildQueryWarning, type DataLoadWarning } from '@/lib/dashboard-bootstrap'
 import { fetchConsolidationSuggestions, filterDismissedSuggestions } from '@/lib/dashboard-data'
-import type { ConsolidationSuggestion } from '@/lib/types/dashboard'
 import type { ConsolidationSuggestion } from '@/lib/types'
 
 export type InitialPriceChange = {
@@ -17,13 +16,13 @@ export type InitialPriceChange = {
 }
 
 export type InitialDataResult = {
-  subscriptions: any[]
-  emailAccounts: any[]
-  payments: any[]
-  priceChanges: InitialPriceChange[]
-  consolidationSuggestions: ConsolidationSuggestion[]
-  warnings: DataLoadWarning[]
-  isDemo: boolean
+  subscriptions: any[];
+  emailAccounts: any[];
+  payments: any[];
+  priceChanges: InitialPriceChange[];
+  consolidationSuggestions: any[];
+  warnings: DataLoadWarning[];
+  isDemo: boolean;
 }
 
 function transformSubscription(dbSub: any): any {
@@ -251,7 +250,6 @@ export async function getInitialData(): Promise<InitialDataResult> {
     emailAccounts,
     payments,
     priceChanges,
-    consolidationSuggestions,
     consolidationSuggestions: buildConsolidationSuggestions(subscriptions),
     warnings,
     isDemo: false,

--- a/client/components/app/SuggestionsPanel.tsx
+++ b/client/components/app/SuggestionsPanel.tsx
@@ -7,7 +7,8 @@ type SuggestionType =
   | 'switch_to_annual'
   | 'unused_subscription'
   | 'duplicate_service'
-  | 'plan_downgrade';
+  | 'plan_downgrade'
+  | 'suggest_cheaper_alternatives';
 
 interface Suggestion {
   id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,6 @@
         "@supabase/supabase-js": "^2.107.0",
         "@syncro/shared": "file:../shared",
         "@tremor/react": "^3.17.4",
-        "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
         "babel-plugin-react-compiler": "^1.0.0",
         "class-variance-authority": "^0.7.1",
@@ -2398,6 +2397,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2420,6 +2420,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2442,6 +2443,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2458,6 +2460,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2474,6 +2477,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2490,6 +2494,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2506,6 +2511,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2522,6 +2528,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2538,6 +2545,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2554,6 +2562,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2570,6 +2579,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2586,6 +2596,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2602,6 +2613,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2624,6 +2636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2646,6 +2659,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2668,6 +2682,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2690,6 +2705,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2712,6 +2728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2734,6 +2751,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2756,6 +2774,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2778,6 +2797,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2797,6 +2817,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2816,6 +2837,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2835,6 +2857,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9883,27 +9906,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
-      "integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "server-only": "^0.0.1"
-      },
-      "peerDependencies": {
-        "next": ">= 13",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -19502,6 +19504,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20980,12 +20983,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
- Add 'suggest_cheaper_alternatives' suggestion type
- Implement CheaperAlternatives detection with comprehensive database of alternatives
- Add /month minimum threshold for alternatives suggestions
- Include in analytics summary as potential_savings_monthly
- Update client components to support new suggestion type

Closes #ai-renewal-recommendations


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #982

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
