### PR TITLE
feat(security): subscription-tier rate limiting with Redis sliding window

### DIFF
--- a/backend/src/config/rate-limit.ts
+++ b/backend/src/config/rate-limit.ts
@@ -8,6 +8,24 @@ export interface RateLimitConfig {
   legacyHeaders: boolean;
 }
 
+export type SubscriptionTier = 'free' | 'pro' | 'enterprise';
+
+export interface TierRateLimitConfig {
+  windowMs: number;
+  limits: Record<SubscriptionTier, number>;
+  sensitiveMultiplier: number;
+}
+
+export const TIER_RATE_LIMIT_CONFIG: TierRateLimitConfig = {
+  windowMs: 60 * 1000, // 1-minute sliding window
+  limits: {
+    free: 100,
+    pro: 500,
+    enterprise: 2000,
+  },
+  sensitiveMultiplier: 0.1, // 10% of normal limit for sensitive endpoints
+};
+
 export interface PrivacyRateLimitConfig {
   stealthAddress: RateLimitConfig & { windowHours: number };
   zkProof: RateLimitConfig & { windowMinutes: number };

--- a/backend/src/middleware/rate-limit-factory.ts
+++ b/backend/src/middleware/rate-limit-factory.ts
@@ -1,9 +1,10 @@
 import rateLimit, { RateLimitRequestHandler } from 'express-rate-limit';
-import { Request } from 'express';
+import { Request, RequestHandler } from 'express';
 import { rateLimitConfig } from '../config/rate-limit';
 import { createRedisStore } from '../lib/redis-store';
 import { AuthenticatedRequest } from './auth';
 import logger from '../config/logger';
+import { createSubscriptionTierLimiter, TierRateLimiterOptions } from './subscription-tier-rate-limiter';
 
 /**
  * Key generator for user-based rate limiting
@@ -302,6 +303,15 @@ export class RateLimiterFactory {
   }
 
   /**
+   * Create rate limiter based on the authenticated user's subscription tier.
+   * Free: 100 req/min, Pro: 500 req/min, Enterprise: 2000 req/min.
+   * Uses a Redis sliding window counter when Redis is available.
+   */
+  static createSubscriptionTierLimiter(opts: TierRateLimiterOptions = {}): RequestHandler {
+    return createSubscriptionTierLimiter(opts);
+  }
+
+  /**
    * Get Redis store status for health monitoring.
    * When `degraded` is true the app is running with the in-memory fallback
    * because Redis was configured but is currently unreachable.
@@ -325,3 +335,4 @@ export const createStealthAddressLimiter = () => RateLimiterFactory.createStealt
 export const createZkProofLimiter = () => RateLimiterFactory.createZkProofLimiter();
 export const createPaymentChannelStateUpdateLimiter = () => RateLimiterFactory.createPaymentChannelStateUpdateLimiter();
 export const createSelectiveDisclosureLimiter = () => RateLimiterFactory.createSelectiveDisclosureLimiter();
+export { createSubscriptionTierLimiter } from './subscription-tier-rate-limiter';

--- a/backend/src/middleware/subscription-tier-rate-limiter.ts
+++ b/backend/src/middleware/subscription-tier-rate-limiter.ts
@@ -1,0 +1,178 @@
+import { Request, Response, NextFunction } from 'express';
+import { createClient, RedisClientType } from 'redis';
+import { supabase } from '../config/database';
+import logger from '../config/logger';
+import { AuthenticatedRequest } from './auth';
+import { SubscriptionTier, TIER_RATE_LIMIT_CONFIG } from '../config/rate-limit';
+
+const REDIS_URL = process.env.REDIS_URL || process.env.RATE_LIMIT_REDIS_URL;
+const TIER_CACHE_TTL_S = 300; // cache tier lookups for 5 minutes
+
+let redisClient: RedisClientType | null = null;
+
+async function getRedisClient(): Promise<RedisClientType | null> {
+  if (redisClient) return redisClient;
+  if (!REDIS_URL) return null;
+  try {
+    const client = createClient({ url: REDIS_URL });
+    client.on('error', (err) => logger.error('Tier rate limiter Redis error:', err));
+    await client.connect();
+    redisClient = client;
+    return client;
+  } catch (err) {
+    logger.warn('Tier rate limiter: Redis unavailable, falling back to in-memory:', err);
+    return null;
+  }
+}
+
+// In-memory fallbacks
+const tierCache = new Map<string, { tier: SubscriptionTier; expiresAt: number }>();
+const inMemoryCounters = new Map<string, number[]>();
+
+function normalizeToTier(raw: string | null | undefined): SubscriptionTier {
+  if (!raw) return 'free';
+  const lower = raw.toLowerCase();
+  if (lower.includes('enterprise')) return 'enterprise';
+  if (lower.includes('pro') || lower.includes('premium') || lower.includes('plus')) return 'pro';
+  return 'free';
+}
+
+async function getUserTier(userId: string, redis: RedisClientType | null): Promise<SubscriptionTier> {
+  const cacheKey = `tier_cache:${userId}`;
+
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached) return cached as SubscriptionTier;
+    } catch {
+      // fall through to DB lookup
+    }
+  } else {
+    const mem = tierCache.get(userId);
+    if (mem && mem.expiresAt > Date.now()) return mem.tier;
+  }
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('subscription_tier')
+    .eq('id', userId)
+    .maybeSingle();
+
+  const tier = normalizeToTier(data?.subscription_tier);
+
+  if (redis) {
+    try {
+      await redis.set(cacheKey, tier, { EX: TIER_CACHE_TTL_S });
+    } catch { /* non-fatal */ }
+  } else {
+    tierCache.set(userId, { tier, expiresAt: Date.now() + TIER_CACHE_TTL_S * 1000 });
+  }
+
+  return tier;
+}
+
+async function slidingWindowCheck(
+  userId: string,
+  tier: SubscriptionTier,
+  limit: number,
+  windowMs: number,
+  redis: RedisClientType | null,
+): Promise<{ allowed: boolean; remaining: number; resetAt: number; total: number }> {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+  const resetAt = Math.ceil((now + windowMs) / 1000);
+
+  if (redis) {
+    const key = `tier_rl:${tier}:${userId}`;
+    try {
+      await redis.zRemRangeByScore(key, '-inf', String(windowStart));
+      const count = await redis.zCard(key);
+      if (count < limit) {
+        await redis.zAdd(key, { score: now, value: `${now}-${Math.random()}` });
+        await redis.pExpire(key, windowMs);
+        return { allowed: true, remaining: limit - count - 1, resetAt, total: limit };
+      }
+      return { allowed: false, remaining: 0, resetAt, total: limit };
+    } catch (err) {
+      logger.warn('Tier rate limiter: Redis sliding window failed, allowing request:', err);
+      return { allowed: true, remaining: limit, resetAt, total: limit };
+    }
+  }
+
+  // In-memory sliding window fallback
+  const key = `${tier}:${userId}`;
+  const timestamps = (inMemoryCounters.get(key) ?? []).filter((t) => t > windowStart);
+  if (timestamps.length < limit) {
+    timestamps.push(now);
+    inMemoryCounters.set(key, timestamps);
+    return { allowed: true, remaining: limit - timestamps.length, resetAt, total: limit };
+  }
+  return { allowed: false, remaining: 0, resetAt, total: limit };
+}
+
+export interface TierRateLimiterOptions {
+  sensitive?: boolean;
+}
+
+export function createSubscriptionTierLimiter(opts: TierRateLimiterOptions = {}) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const authReq = req as AuthenticatedRequest;
+    const userId = authReq.user?.id;
+
+    if (!userId) {
+      next();
+      return;
+    }
+
+    const redis = await getRedisClient();
+    let tier: SubscriptionTier = 'free';
+
+    try {
+      tier = await getUserTier(userId, redis);
+    } catch (err) {
+      logger.warn('Tier rate limiter: failed to get user tier, defaulting to free:', err);
+    }
+
+    const { windowMs, limits, sensitiveMultiplier } = TIER_RATE_LIMIT_CONFIG;
+    const baseLimit = limits[tier];
+    const limit = opts.sensitive ? Math.max(1, Math.floor(baseLimit * sensitiveMultiplier)) : baseLimit;
+
+    const { allowed, remaining, resetAt, total } = await slidingWindowCheck(
+      userId,
+      tier,
+      limit,
+      windowMs,
+      redis,
+    );
+
+    res.set({
+      'X-RateLimit-Limit': String(total),
+      'X-RateLimit-Remaining': String(Math.max(0, remaining)),
+      'X-RateLimit-Reset': String(resetAt),
+      'X-RateLimit-Policy': `${total};w=${Math.floor(windowMs / 1000)}`,
+    });
+
+    if (!allowed) {
+      const retryAfter = resetAt - Math.floor(Date.now() / 1000);
+      res.set('Retry-After', String(retryAfter));
+
+      logger.warn('Subscription tier rate limit exceeded', {
+        userId,
+        tier,
+        limit,
+        path: req.path,
+        method: req.method,
+        sensitive: opts.sensitive ?? false,
+      });
+
+      res.status(429).json({
+        error: 'Too many requests',
+        message: `Rate limit exceeded for ${tier} tier (${total} req/min). Retry after ${retryAfter}s.`,
+        retryAfter,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/tests/subscription-tier-rate-limiter.test.ts
+++ b/backend/tests/subscription-tier-rate-limiter.test.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+import express from 'express';
+import { createSubscriptionTierLimiter } from '../src/middleware/subscription-tier-rate-limiter';
+
+jest.mock('../src/config/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('../src/config/database', () => ({
+  supabase: {
+    from: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({ data: { subscription_tier: 'free' }, error: null }),
+        }),
+      }),
+    }),
+  },
+}));
+
+function makeApp(opts: Parameters<typeof createSubscriptionTierLimiter>[0] = {}) {
+  const app = express();
+  app.use((req, _res, next) => {
+    (req as any).user = { id: 'user-123', email: 'test@example.com', role: 'member' };
+    next();
+  });
+  app.use(createSubscriptionTierLimiter(opts));
+  app.get('/test', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('createSubscriptionTierLimiter', () => {
+  it('sets X-RateLimit headers on successful requests', async () => {
+    const res = await request(makeApp()).get('/test').expect(200);
+    expect(res.headers['x-ratelimit-limit']).toBeDefined();
+    expect(res.headers['x-ratelimit-remaining']).toBeDefined();
+    expect(res.headers['x-ratelimit-reset']).toBeDefined();
+  });
+
+  it('allows unauthenticated requests through without rate limiting', async () => {
+    const app = express();
+    app.use(createSubscriptionTierLimiter());
+    app.get('/test', (_req, res) => res.json({ ok: true }));
+    await request(app).get('/test').expect(200);
+  });
+
+  it('returns 429 with Retry-After when limit exceeded (free tier = 100)', async () => {
+    const app = makeApp();
+    const promises = Array.from({ length: 101 }, () => request(app).get('/test'));
+    const responses = await Promise.all(promises);
+    const limited = responses.filter((r) => r.status === 429);
+    expect(limited.length).toBeGreaterThan(0);
+    expect(limited[0].headers['retry-after']).toBeDefined();
+    expect(limited[0].body.error).toBe('Too many requests');
+  });
+
+  it('applies a lower limit for sensitive endpoints', async () => {
+    const app = makeApp({ sensitive: true });
+    // Sensitive free tier = 10 req/min (100 * 0.1)
+    const promises = Array.from({ length: 11 }, () => request(app).get('/test'));
+    const responses = await Promise.all(promises);
+    const limited = responses.filter((r) => r.status === 429);
+    expect(limited.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #945

## Changes
- Added `SubscriptionTier` type and `TIER_RATE_LIMIT_CONFIG` to `rate-limit.ts` (Free: 100 req/min, Pro: 500 req/min, Enterprise: 2000 req/min)
- Created `subscription-tier-rate-limiter.ts`: looks up `profiles.subscription_tier`, implements Redis ZSET sliding window counter with in-memory fallback
- All responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `X-RateLimit-Policy` headers
- 429 responses include `Retry-After` header
- Sensitive endpoints supported via `{ sensitive: true }` option (10% of normal limit)
- Exported from `rate-limit-factory.ts` for easy composition
- Added unit tests covering headers, unauthenticated pass-through, limit enforcement, and sensitive endpoint limits