### PR TITLE
fix(#1025): implement AES-256-GCM decryption for blinding factors

### DIFF
--- a/client/lib/__tests__/audit-disclosure.test.ts
+++ b/client/lib/__tests__/audit-disclosure.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for AES-256-GCM decryption in AuditDisclosureClient.decryptBlindingFactor
+ *
+ * The method is private, so we access it via `(client as any)` to keep the
+ * production interface unchanged while still achieving full coverage.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AuditDisclosureClient } from '../audit-disclosure';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** 64-character hex key (32 bytes) used in every test. */
+const TEST_KEY_HEX = 'a'.repeat(64); // 32 bytes of 0xAA
+
+/**
+ * Encrypt `plaintext` with AES-256-GCM using the given key and optional IV.
+ * Returns a Buffer in the wire format expected by decryptBlindingFactor:
+ *   [ iv: 12 bytes ][ ciphertext+tag: N+16 bytes ]
+ */
+async function encryptForTest(
+  plaintext: Uint8Array,
+  keyHex: string = TEST_KEY_HEX,
+  iv?: Uint8Array
+): Promise<Buffer> {
+  const keyBytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    keyBytes[i] = parseInt(keyHex.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt']
+  );
+
+  const randomIv = new Uint8Array(new ArrayBuffer(12));
+  crypto.getRandomValues(randomIv);
+  // Ensure the IV is backed by a plain ArrayBuffer (not SharedArrayBuffer) so
+  // WebCrypto's BufferSource constraint is satisfied.
+  const srcIv = iv ?? randomIv;
+  const usedIv = new Uint8Array(new ArrayBuffer(12));
+  usedIv.set(srcIv);
+
+  // Ensure plaintext is backed by a plain ArrayBuffer for WebCrypto compatibility.
+  const plaintextBuf = new Uint8Array(new ArrayBuffer(plaintext.byteLength));
+  plaintextBuf.set(plaintext);
+
+  const ciphertextWithTag = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: usedIv, tagLength: 128 },
+    cryptoKey,
+    plaintextBuf
+  );
+
+  // Wire format: iv || ciphertext+tag
+  const result = new Uint8Array(12 + ciphertextWithTag.byteLength);
+  result.set(usedIv, 0);
+  result.set(new Uint8Array(ciphertextWithTag), 12);
+  return Buffer.from(result);
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+describe('AuditDisclosureClient — decryptBlindingFactor', () => {
+  let client: AuditDisclosureClient;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.BLINDING_FACTOR_KEY;
+    process.env.BLINDING_FACTOR_KEY = TEST_KEY_HEX;
+    client = new AuditDisclosureClient();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BLINDING_FACTOR_KEY;
+    } else {
+      process.env.BLINDING_FACTOR_KEY = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('decrypts a valid AES-256-GCM ciphertext and returns the original plaintext', async () => {
+    const plaintext = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe]);
+    const encrypted = await encryptForTest(plaintext);
+
+    const result = await (client as any).decryptBlindingFactor(encrypted);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(plaintext);
+  });
+
+  it('correctly decrypts a 32-byte blinding factor (typical use case)', async () => {
+    // 32 random bytes representing a realistic blinding factor
+    const blindingFactor = crypto.getRandomValues(new Uint8Array(32));
+    const encrypted = await encryptForTest(blindingFactor);
+
+    const result = await (client as any).decryptBlindingFactor(encrypted);
+
+    expect(result).toEqual(blindingFactor);
+  });
+
+  it('produces a Uint8Array (not a Buffer or plain Array)', async () => {
+    const plaintext = new Uint8Array(16);
+    const encrypted = await encryptForTest(plaintext);
+
+    const result = await (client as any).decryptBlindingFactor(encrypted);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth-tag / tampered-ciphertext negative tests
+  // -------------------------------------------------------------------------
+
+  it('throws when the auth tag is tampered (last byte flipped)', async () => {
+    const plaintext = new Uint8Array([1, 2, 3, 4]);
+    const encrypted = await encryptForTest(plaintext);
+
+    // Flip the very last byte (auth tag)
+    const tampered = Buffer.from(encrypted);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    await expect(
+      (client as any).decryptBlindingFactor(tampered)
+    ).rejects.toThrow(/decryption failed|tampered/i);
+  });
+
+  it('throws when a ciphertext byte is flipped (body corruption)', async () => {
+    const plaintext = new Uint8Array(32).fill(0xab);
+    const encrypted = await encryptForTest(plaintext);
+
+    // Flip a byte in the ciphertext body (byte 12 = first byte after the IV)
+    const tampered = Buffer.from(encrypted);
+    tampered[12] ^= 0x01;
+
+    await expect(
+      (client as any).decryptBlindingFactor(tampered)
+    ).rejects.toThrow(/decryption failed|tampered/i);
+  });
+
+  it('throws when decrypting with the wrong key', async () => {
+    const plaintext = new Uint8Array([0x01, 0x02, 0x03]);
+    const encrypted = await encryptForTest(plaintext, TEST_KEY_HEX);
+
+    // Switch to a different key before decrypting
+    process.env.BLINDING_FACTOR_KEY = 'b'.repeat(64);
+
+    await expect(
+      (client as any).decryptBlindingFactor(encrypted)
+    ).rejects.toThrow(/decryption failed|tampered/i);
+  });
+
+  it('throws when the IV is replaced but ciphertext+tag remain (IV mismatch)', async () => {
+    const plaintext = new Uint8Array([0xca, 0xfe]);
+    const originalIv = new Uint8Array(12).fill(0x01);
+    const encrypted = await encryptForTest(plaintext, TEST_KEY_HEX, originalIv);
+
+    // Replace IV with all-zeros
+    const tampered = Buffer.from(encrypted);
+    tampered.fill(0x00, 0, 12);
+
+    await expect(
+      (client as any).decryptBlindingFactor(tampered)
+    ).rejects.toThrow(/decryption failed|tampered/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Input-validation negative tests
+  // -------------------------------------------------------------------------
+
+  it('throws when the buffer is shorter than the minimum 28 bytes', async () => {
+    const tooShort = Buffer.alloc(27);
+
+    await expect(
+      (client as any).decryptBlindingFactor(tooShort)
+    ).rejects.toThrow(/too short/i);
+  });
+
+  it('throws when BLINDING_FACTOR_KEY is not set', async () => {
+    delete process.env.BLINDING_FACTOR_KEY;
+    delete process.env.NEXT_PUBLIC_BLINDING_FACTOR_KEY;
+
+    const plaintext = new Uint8Array([0x01]);
+    const encrypted = await encryptForTest(plaintext);
+
+    await expect(
+      (client as any).decryptBlindingFactor(encrypted)
+    ).rejects.toThrow(/BLINDING_FACTOR_KEY.*not set/i);
+  });
+
+  it('throws when BLINDING_FACTOR_KEY is the wrong length', async () => {
+    process.env.BLINDING_FACTOR_KEY = 'abc'; // only 3 hex chars
+
+    const plaintext = new Uint8Array([0x01]);
+    const encrypted = await encryptForTest(plaintext);
+
+    await expect(
+      (client as any).decryptBlindingFactor(encrypted)
+    ).rejects.toThrow(/64 hex/i);
+  });
+});

--- a/client/lib/audit-disclosure.ts
+++ b/client/lib/audit-disclosure.ts
@@ -153,7 +153,7 @@ class CommitmentEncoder {
 /**
  * Compute SHA-256 hash
  */
-async function sha256(data: Uint8Array): Promise<Uint8Array> {
+async function sha256(data: BufferSource): Promise<Uint8Array> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   return new Uint8Array(hashBuffer);
 }
@@ -296,7 +296,7 @@ export class AuditDisclosureClient {
       throw new Error(`Failed to fetch commitments: ${error?.message || 'Not found'}`);
     }
     
-    const indices = records.map(r => r.commitment_index);
+    const indices = records.map((r: { commitment_index: number }) => r.commitment_index);
     return this.generateMultipleDisclosures(userId, indices);
   }
   
@@ -457,16 +457,80 @@ export class AuditDisclosureClient {
   }
   
   /**
-   * Decrypt blinding factor
-   * 
-   * Note: In production, blinding factors are encrypted at rest.
-   * This function would decrypt using keys from a secure key store.
-   * For MVP, blinding factors may be stored unencrypted.
+   * Decrypt a blinding factor that was encrypted with AES-256-GCM.
+   *
+   * Expected wire format (all concatenated, no separators):
+   *   [ iv: 12 bytes ][ ciphertext: N bytes ][ auth tag: 16 bytes ]
+   *
+   * The AES key is read from the environment variable BLINDING_FACTOR_KEY,
+   * which must be a 64-character hex string (32 bytes / 256 bits).
+   *
+   * Throws if the auth tag does not verify (tampered ciphertext) or if the
+   * key is missing / malformed.
    */
   private async decryptBlindingFactor(encrypted: Buffer): Promise<Uint8Array> {
-    // TODO: Implement actual decryption with AES-256-GCM
-    // For MVP, assume blinding factors are stored unencrypted
-    return new Uint8Array(encrypted);
+    // Minimum: 12-byte IV + 0-byte ciphertext + 16-byte tag = 28 bytes
+    if (encrypted.length < 28) {
+      throw new Error('Encrypted blinding factor is too short to be valid AES-256-GCM ciphertext');
+    }
+
+    // Resolve the raw key material from the environment
+    const keyHex =
+      process.env.BLINDING_FACTOR_KEY ??
+      process.env.NEXT_PUBLIC_BLINDING_FACTOR_KEY;
+
+    if (!keyHex) {
+      throw new Error(
+        'BLINDING_FACTOR_KEY environment variable is not set — cannot decrypt blinding factor'
+      );
+    }
+
+    if (keyHex.length !== 64) {
+      throw new Error(
+        'BLINDING_FACTOR_KEY must be exactly 64 hex characters (32 bytes / AES-256)'
+      );
+    }
+
+    // Decode hex key → raw bytes
+    const keyBytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      keyBytes[i] = parseInt(keyHex.slice(i * 2, i * 2 + 2), 16);
+    }
+
+    // Import the raw key for AES-GCM decryption (non-extractable)
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      keyBytes,
+      { name: 'AES-GCM', length: 256 },
+      false,     // non-extractable
+      ['decrypt']
+    );
+
+    // Copy into plain Uint8Arrays backed by a concrete ArrayBuffer so that
+    // WebCrypto's BufferSource constraint (ArrayBuffer, not ArrayBufferLike) is satisfied.
+    const iv = new Uint8Array(encrypted.slice(0, 12));
+    const ciphertextWithTag = new Uint8Array(encrypted.slice(12));
+
+    let plaintext: ArrayBuffer;
+    try {
+      plaintext = await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv,
+          tagLength: 128, // 16-byte auth tag (WebCrypto default, explicit for clarity)
+        },
+        cryptoKey,
+        ciphertextWithTag
+      );
+    } catch {
+      // WebCrypto throws a generic DOMException on auth-tag failure; surface a
+      // meaningful error so callers can distinguish tampering from other issues.
+      throw new Error(
+        'AES-256-GCM decryption failed — ciphertext may have been tampered with or the key is incorrect'
+      );
+    }
+
+    return new Uint8Array(plaintext);
   }
   
   /**


### PR DESCRIPTION
closes #1025

Replace placeholder decryptBlindingFactor with real crypto.subtle implementation.

Wire format: [ IV: 12 bytes ][ ciphertext ][ auth tag: 16 bytes ]
Key source: BLINDING_FACTOR_KEY env var (64-char hex / 32 bytes)

- Auth-tag verification via WebCrypto (tampered bytes throw a clear error)
- Input validation: min 28-byte buffer, key presence, key length
- Key imported as non-extractable

Add test suite (audit-disclosure.test.ts, 8 cases):
- Happy path: decrypts correctly, returns Uint8Array
- Negative: tampered tag, flipped body byte, wrong key, replaced IV
- Validation: too-short buffer, missing key, wrong-length key


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
