### PR TITLE
feat(invoices): manage PDF invoices via Supabase Storage (#298)

### DIFF
--- a/client/app/api/invoices/[id]/signed-url/route.ts
+++ b/client/app/api/invoices/[id]/signed-url/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest } from "next/server"
+import { z } from "zod"
+import { HttpStatus } from "@/lib/api/types"
+import { createClient } from "@/lib/supabase/server"
+import {
+  ApiErrors,
+  createAuthenticatedApiRoute,
+  createSuccessResponse,
+  RateLimiters,
+} from "@/lib/api/index"
+import { getSignedInvoiceUrl, InvoiceError } from "@/lib/invoices/invoice-service"
+
+const idParamSchema = z.object({
+  id: z.string().uuid("Invalid invoice ID"),
+})
+
+/**
+ * GET /api/invoices/[id]/signed-url
+ *
+ * Returns a short-lived signed URL for viewing the authenticated user's invoice
+ * PDF. Powers the "View Invoice PDF" action on payment-history entries.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  return createAuthenticatedApiRoute(
+    async (_req: NextRequest, context, user) => {
+      const parsed = idParamSchema.safeParse({ id })
+      if (!parsed.success) {
+        throw ApiErrors.validationError("Invalid invoice ID", "id")
+      }
+
+      const supabase = await createClient()
+
+      try {
+        const signed = await getSignedInvoiceUrl(supabase, user.id, parsed.data.id)
+        return createSuccessResponse(signed, HttpStatus.OK, context.requestId)
+      } catch (error) {
+        if (error instanceof InvoiceError) {
+          throw mapInvoiceError(error)
+        }
+        throw error
+      }
+    },
+    {
+      rateLimit: RateLimiters.standard,
+    },
+  )(request)
+}
+
+function mapInvoiceError(error: InvoiceError) {
+  switch (error.code) {
+    case "not_found":
+      return ApiErrors.notFound("Invoice")
+    case "forbidden":
+      return ApiErrors.forbidden(error.message)
+    case "invalid_file":
+      return ApiErrors.validationError(error.message)
+    default:
+      return ApiErrors.internalError(error.message)
+  }
+}

--- a/client/app/api/invoices/route.ts
+++ b/client/app/api/invoices/route.ts
@@ -1,0 +1,107 @@
+import { type NextRequest } from "next/server"
+import { HttpStatus } from "@/lib/api/types"
+import { createClient } from "@/lib/supabase/server"
+import {
+  ApiErrors,
+  createAuthenticatedApiRoute,
+  createSuccessResponse,
+  RateLimiters,
+  emitAuditEvent,
+} from "@/lib/api/index"
+import {
+  InvoiceError,
+  listInvoices,
+  uploadInvoice,
+  MAX_INVOICE_BYTES,
+  INVOICE_CONTENT_TYPE,
+} from "@/lib/invoices/invoice-service"
+
+/**
+ * GET /api/invoices?subscriptionId=...
+ *
+ * List the authenticated user's invoices, most recent first.
+ */
+export const GET = createAuthenticatedApiRoute(
+  async (request: NextRequest, context, user) => {
+    const supabase = await createClient()
+    const subscriptionId = new URL(request.url).searchParams.get("subscriptionId") ?? undefined
+
+    try {
+      const invoices = await listInvoices(supabase, user.id, { subscriptionId })
+      return createSuccessResponse({ invoices }, HttpStatus.OK, context.requestId)
+    } catch (error) {
+      if (error instanceof InvoiceError) throw mapInvoiceError(error)
+      throw error
+    }
+  },
+  { rateLimit: RateLimiters.standard },
+)
+
+/**
+ * POST /api/invoices
+ *
+ * Direct upload of a PDF invoice via multipart form data (`file`, optional
+ * `subscriptionId` / `paymentId`). Stores the object in the private bucket and
+ * records its metadata.
+ */
+export const POST = createAuthenticatedApiRoute(
+  async (request: NextRequest, context, user) => {
+    let form: FormData
+    try {
+      form = await request.formData()
+    } catch {
+      throw ApiErrors.validationError("Expected multipart form data with a 'file' field")
+    }
+
+    const file = form.get("file")
+    if (!(file instanceof File)) {
+      throw ApiErrors.validationError("Missing 'file' upload", "file")
+    }
+    if (file.type !== INVOICE_CONTENT_TYPE) {
+      throw ApiErrors.validationError("Only PDF invoices are supported", "file")
+    }
+    if (file.size > MAX_INVOICE_BYTES) {
+      throw ApiErrors.validationError("Invoice exceeds the 10 MB size limit", "file")
+    }
+
+    const supabase = await createClient()
+
+    try {
+      const invoice = await uploadInvoice(supabase, user.id, {
+        body: await file.arrayBuffer(),
+        fileName: file.name || "invoice.pdf",
+        contentType: file.type,
+        sizeBytes: file.size,
+        subscriptionId: (form.get("subscriptionId") as string) || null,
+        paymentId: (form.get("paymentId") as string) || null,
+        source: "upload",
+      })
+
+      emitAuditEvent({
+        userId: user.id,
+        action: "invoice.upload",
+        resourceType: "invoice",
+        resourceId: invoice.id,
+      })
+
+      return createSuccessResponse({ invoice }, HttpStatus.CREATED, context.requestId)
+    } catch (error) {
+      if (error instanceof InvoiceError) throw mapInvoiceError(error)
+      throw error
+    }
+  },
+  { rateLimit: RateLimiters.standard },
+)
+
+function mapInvoiceError(error: InvoiceError) {
+  switch (error.code) {
+    case "not_found":
+      return ApiErrors.notFound("Invoice")
+    case "forbidden":
+      return ApiErrors.forbidden(error.message)
+    case "invalid_file":
+      return ApiErrors.validationError(error.message)
+    default:
+      return ApiErrors.internalError(error.message)
+  }
+}

--- a/client/components/ui/payment-timeline.tsx
+++ b/client/components/ui/payment-timeline.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { renewalHistoryApi, type RenewalEvent, type RenewalHistoryResponse } from '@/lib/api/renewal-history';
+import { getInvoiceSignedUrl } from '@/lib/api/invoices';
 import { BlockchainBadge } from '@/components/ui/blockchain-badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatCurrency } from '@/lib/currency-utils';
@@ -55,6 +56,43 @@ function formatDate(iso: string): string {
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
+
+/**
+ * Fetches a short-lived signed URL on click and opens the invoice PDF in a new
+ * tab. The URL is never embedded in the page — it is minted on demand so it
+ * cannot leak or outlive its short TTL.
+ */
+function ViewInvoiceButton({ invoiceId }: { invoiceId: string }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClick = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { url } = await getInvoiceSignedUrl(invoiceId);
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not open invoice');
+    } finally {
+      setLoading(false);
+    }
+  }, [invoiceId]);
+
+  return (
+    <span className="mt-0.5 inline-flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        className="text-xs text-indigo-500 hover:underline inline-flex items-center gap-1 focus:outline-none focus:ring-1 focus:ring-indigo-400 rounded disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {loading ? 'Opening…' : 'View Invoice PDF'} ↗
+      </button>
+      {error && <span className="text-xs text-red-500">{error}</span>}
+    </span>
+  );
+}
 
 function TimelineEventRow({
   event,
@@ -118,16 +156,20 @@ function TimelineEventRow({
           </p>
         )}
 
-        {event.explorerUrl && (
-          <a
-            href={event.explorerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-indigo-500 hover:underline mt-0.5 inline-block focus:outline-none focus:ring-1 focus:ring-indigo-400 rounded"
-          >
-            View on Stellar Explorer ↗
-          </a>
-        )}
+        <div className="flex flex-wrap items-center gap-3">
+          {event.explorerUrl && (
+            <a
+              href={event.explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-indigo-500 hover:underline mt-0.5 inline-block focus:outline-none focus:ring-1 focus:ring-indigo-400 rounded"
+            >
+              View on Stellar Explorer ↗
+            </a>
+          )}
+
+          {event.invoiceId && <ViewInvoiceButton invoiceId={event.invoiceId} />}
+        </div>
       </div>
     </li>
   );

--- a/client/lib/api/audit.ts
+++ b/client/lib/api/audit.ts
@@ -24,6 +24,7 @@ export type AuditAction =
   | "mfa.disable"
   | "privacy.settings_update"
   | "account.delete_request"
+  | "invoice.upload"
 
 export interface AuditEvent {
   /** Opaque user UUID — never email or username */

--- a/client/lib/api/invoices.ts
+++ b/client/lib/api/invoices.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-side helpers for the invoice API.
+ */
+
+export interface SignedInvoiceUrl {
+  url: string
+  fileName: string
+  expiresIn: number
+}
+
+/**
+ * Fetch a short-lived signed URL for viewing an invoice PDF. Same-origin call,
+ * so the Supabase session cookie authenticates the request.
+ */
+export async function getInvoiceSignedUrl(invoiceId: string): Promise<SignedInvoiceUrl> {
+  const res = await fetch(`/api/invoices/${invoiceId}/signed-url`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  })
+
+  const body = await res.json().catch(() => null)
+  if (!res.ok || !body?.success) {
+    throw new Error(body?.error?.message || `Failed to load invoice (${res.status})`)
+  }
+  return body.data as SignedInvoiceUrl
+}

--- a/client/lib/api/renewal-history.ts
+++ b/client/lib/api/renewal-history.ts
@@ -28,6 +28,8 @@ export interface RenewalEvent {
   explorerUrl?: string;
   channel?: string;
   notes?: string;
+  /** Id of an invoice PDF stored in Supabase Storage, if one is available. */
+  invoiceId?: string;
 }
 
 export interface RenewalHistoryResponse {

--- a/client/lib/invoices/__tests__/invoice-service.test.ts
+++ b/client/lib/invoices/__tests__/invoice-service.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  getSignedInvoiceUrl,
+  uploadInvoice,
+  listInvoices,
+  assertValidInvoiceFile,
+  buildInvoicePath,
+  InvoiceError,
+  INVOICES_BUCKET,
+  SIGNED_URL_TTL_SECONDS,
+  MAX_INVOICE_BYTES,
+  type InvoiceSupabaseClient,
+} from "../invoice-service"
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeSupabase(overrides: {
+  invoiceRow?: any
+  invoiceError?: any
+  signedUrl?: string | null
+  signError?: any
+  uploadError?: any
+  insertRow?: any
+  insertError?: any
+  listRows?: any
+  listError?: any
+} = {}) {
+  const single = vi.fn().mockResolvedValue({
+    data: overrides.invoiceRow ?? null,
+    error: overrides.invoiceError ?? null,
+  })
+  const insertSingle = vi.fn().mockResolvedValue({
+    data: overrides.insertRow ?? null,
+    error: overrides.insertError ?? null,
+  })
+
+  // Terminal for list queries: `.order()` resolves to the rows.
+  const order = vi.fn().mockResolvedValue({
+    data: overrides.listRows ?? [],
+    error: overrides.listError ?? null,
+  })
+
+  const createSignedUrl = vi.fn().mockResolvedValue({
+    data: overrides.signedUrl === null ? null : { signedUrl: overrides.signedUrl ?? "https://signed.example/inv.pdf" },
+    error: overrides.signError ?? null,
+  })
+  const upload = vi.fn().mockResolvedValue({
+    data: overrides.uploadError ? null : { path: "path" },
+    error: overrides.uploadError ?? null,
+  })
+  const remove = vi.fn().mockResolvedValue({ data: {}, error: null })
+
+  const selectBuilder: any = {
+    eq: vi.fn(() => selectBuilder),
+    order,
+    single,
+  }
+  const insertBuilder: any = {
+    select: vi.fn(() => ({ single: insertSingle })),
+  }
+
+  const from = vi.fn(() => ({
+    select: vi.fn(() => selectBuilder),
+    insert: vi.fn(() => insertBuilder),
+  }))
+
+  const storageFrom = { createSignedUrl, upload, remove }
+
+  const client = {
+    from,
+    storage: { from: vi.fn(() => storageFrom) },
+  } as unknown as InvoiceSupabaseClient
+
+  return { client, single, createSignedUrl, upload, remove, insertSingle, order, storageFrom }
+}
+
+const OWNER = "user-owner-1"
+
+describe("invoice-service", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  // ─── getSignedInvoiceUrl ───────────────────────────────────────────────────
+
+  describe("getSignedInvoiceUrl", () => {
+    it("mints a signed URL for an invoice the user owns", async () => {
+      const { client, createSignedUrl } = makeSupabase({
+        invoiceRow: {
+          id: "inv-1",
+          user_id: OWNER,
+          storage_path: `${OWNER}/inv-1.pdf`,
+          file_name: "march.pdf",
+        },
+      })
+
+      const result = await getSignedInvoiceUrl(client, OWNER, "inv-1")
+
+      expect(result.url).toBe("https://signed.example/inv.pdf")
+      expect(result.fileName).toBe("march.pdf")
+      expect(result.expiresIn).toBe(SIGNED_URL_TTL_SECONDS)
+      expect(createSignedUrl).toHaveBeenCalledWith(`${OWNER}/inv-1.pdf`, SIGNED_URL_TTL_SECONDS)
+    })
+
+    it("rejects access to another user's invoice with a forbidden error", async () => {
+      const { client, createSignedUrl } = makeSupabase({
+        invoiceRow: {
+          id: "inv-1",
+          user_id: "someone-else",
+          storage_path: "someone-else/inv-1.pdf",
+          file_name: "secret.pdf",
+        },
+      })
+
+      await expect(getSignedInvoiceUrl(client, OWNER, "inv-1")).rejects.toMatchObject({
+        code: "forbidden",
+      })
+      // Critically, no URL is ever generated for a non-owner.
+      expect(createSignedUrl).not.toHaveBeenCalled()
+    })
+
+    it("throws not_found when the invoice does not exist", async () => {
+      const { client } = makeSupabase({ invoiceRow: null, invoiceError: { message: "no rows" } })
+      await expect(getSignedInvoiceUrl(client, OWNER, "missing")).rejects.toMatchObject({
+        code: "not_found",
+      })
+    })
+
+    it("throws storage_error when signing fails", async () => {
+      const { client } = makeSupabase({
+        invoiceRow: { id: "inv-1", user_id: OWNER, storage_path: `${OWNER}/inv-1.pdf`, file_name: "x.pdf" },
+        signedUrl: null,
+        signError: { message: "bucket offline" },
+      })
+      await expect(getSignedInvoiceUrl(client, OWNER, "inv-1")).rejects.toMatchObject({
+        code: "storage_error",
+      })
+    })
+  })
+
+  // ─── validation helpers ────────────────────────────────────────────────────
+
+  describe("assertValidInvoiceFile", () => {
+    it("accepts a reasonable PDF", () => {
+      expect(() => assertValidInvoiceFile("application/pdf", 1024)).not.toThrow()
+    })
+
+    it("rejects non-PDF content types", () => {
+      expect(() => assertValidInvoiceFile("image/png", 1024)).toThrow(InvoiceError)
+    })
+
+    it("rejects empty files", () => {
+      expect(() => assertValidInvoiceFile("application/pdf", 0)).toThrow(/empty/)
+    })
+
+    it("rejects files over the size limit", () => {
+      expect(() => assertValidInvoiceFile("application/pdf", MAX_INVOICE_BYTES + 1)).toThrow(/size limit/)
+    })
+  })
+
+  describe("buildInvoicePath", () => {
+    it("namespaces the object under the user's folder as a .pdf", () => {
+      const path = buildInvoicePath(OWNER)
+      expect(path.startsWith(`${OWNER}/`)).toBe(true)
+      expect(path.endsWith(".pdf")).toBe(true)
+    })
+  })
+
+  // ─── uploadInvoice ─────────────────────────────────────────────────────────
+
+  describe("uploadInvoice", () => {
+    it("uploads a PDF and records metadata under the user's folder", async () => {
+      const insertRow = { id: "inv-9", user_id: OWNER, storage_path: `${OWNER}/x.pdf` }
+      const { client, upload, storageFrom } = makeSupabase({ insertRow })
+
+      const record = await uploadInvoice(client, OWNER, {
+        body: new Uint8Array([1, 2, 3]),
+        fileName: "april.pdf",
+        contentType: "application/pdf",
+        sizeBytes: 3,
+      })
+
+      expect(record.id).toBe("inv-9")
+      expect(client.storage.from).toHaveBeenCalledWith(INVOICES_BUCKET)
+      const [pathArg, , opts] = upload.mock.calls[0]
+      expect(pathArg.startsWith(`${OWNER}/`)).toBe(true)
+      expect(opts).toMatchObject({ contentType: "application/pdf", upsert: false })
+      expect(storageFrom.remove).not.toHaveBeenCalled()
+    })
+
+    it("rejects a non-PDF before touching storage", async () => {
+      const { client, upload } = makeSupabase()
+      await expect(
+        uploadInvoice(client, OWNER, {
+          body: new Uint8Array([1]),
+          fileName: "x.png",
+          contentType: "image/png",
+          sizeBytes: 1,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_file" })
+      expect(upload).not.toHaveBeenCalled()
+    })
+
+    it("rolls back the uploaded object if metadata insert fails", async () => {
+      const { client, remove } = makeSupabase({ insertError: { message: "db down" } })
+      await expect(
+        uploadInvoice(client, OWNER, {
+          body: new Uint8Array([1]),
+          fileName: "x.pdf",
+          contentType: "application/pdf",
+          sizeBytes: 1,
+        }),
+      ).rejects.toMatchObject({ code: "storage_error" })
+      expect(remove).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ─── listInvoices ──────────────────────────────────────────────────────────
+
+  describe("listInvoices", () => {
+    it("returns the user's invoices", async () => {
+      const rows = [{ id: "a" }, { id: "b" }]
+      const { client } = makeSupabase({ listRows: rows })
+      const result = await listInvoices(client, OWNER)
+      expect(result).toEqual(rows)
+    })
+  })
+})

--- a/client/lib/invoices/invoice-service.ts
+++ b/client/lib/invoices/invoice-service.ts
@@ -1,0 +1,231 @@
+/**
+ * Invoice storage service
+ *
+ * Server-side helpers for managing PDF invoices in the private Supabase
+ * `invoices` storage bucket (see migration
+ * `20260724000000_create_invoices_storage.sql`).
+ *
+ * Invoices are viewed through short-lived **signed URLs** rather than public
+ * links, and every operation is scoped to the owning user both here (defence in
+ * depth) and by the bucket/row RLS policies.
+ */
+
+export const INVOICES_BUCKET = "invoices"
+
+/** Lifetime of a generated signed URL, in seconds. */
+export const SIGNED_URL_TTL_SECONDS = 300
+
+/** Maximum accepted invoice size (10 MB), mirrored by the bucket config. */
+export const MAX_INVOICE_BYTES = 10 * 1024 * 1024
+
+export const INVOICE_CONTENT_TYPE = "application/pdf"
+
+export type InvoiceSource = "upload" | "email"
+
+export type InvoiceErrorCode =
+  | "not_found"
+  | "forbidden"
+  | "invalid_file"
+  | "storage_error"
+
+/** Typed error so API routes can map failures onto the right HTTP status. */
+export class InvoiceError extends Error {
+  constructor(
+    public readonly code: InvoiceErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = "InvoiceError"
+  }
+}
+
+export interface InvoiceRecord {
+  id: string
+  user_id: string
+  subscription_id: string | null
+  payment_id: string | null
+  storage_path: string
+  file_name: string
+  content_type: string
+  size_bytes: number
+  source: InvoiceSource
+  created_at: string
+}
+
+export interface SignedInvoiceUrl {
+  url: string
+  fileName: string
+  expiresIn: number
+}
+
+export interface UploadInvoiceInput {
+  /** Raw PDF bytes. */
+  body: ArrayBuffer | Uint8Array | Blob
+  fileName: string
+  contentType: string
+  sizeBytes: number
+  subscriptionId?: string | null
+  paymentId?: string | null
+  source?: InvoiceSource
+}
+
+/**
+ * Minimal structural view of the Supabase client used by this service. The real
+ * server client satisfies this shape; tests can pass a light-weight mock.
+ */
+export interface InvoiceSupabaseClient {
+  from(table: string): any
+  storage: {
+    from(bucket: string): {
+      createSignedUrl(
+        path: string,
+        expiresIn: number,
+      ): Promise<{ data: { signedUrl: string } | null; error: { message: string } | null }>
+      upload(
+        path: string,
+        body: ArrayBuffer | Uint8Array | Blob,
+        options?: { contentType?: string; upsert?: boolean },
+      ): Promise<{ data: { path: string } | null; error: { message: string } | null }>
+      remove(paths: string[]): Promise<{ data: unknown; error: { message: string } | null }>
+    }
+  }
+}
+
+/**
+ * Generate a short-lived signed URL for viewing a user's invoice PDF.
+ *
+ * Ownership is verified against the `invoices` row before any URL is minted, so
+ * an authenticated user can never obtain a link to another user's invoice even
+ * if they guess an id.
+ */
+export async function getSignedInvoiceUrl(
+  supabase: InvoiceSupabaseClient,
+  userId: string,
+  invoiceId: string,
+): Promise<SignedInvoiceUrl> {
+  const { data: invoice, error } = await supabase
+    .from("invoices")
+    .select("id, user_id, storage_path, file_name")
+    .eq("id", invoiceId)
+    .single()
+
+  if (error || !invoice) {
+    throw new InvoiceError("not_found", "Invoice not found")
+  }
+  if (invoice.user_id !== userId) {
+    throw new InvoiceError("forbidden", "You do not have access to this invoice")
+  }
+
+  const { data, error: signError } = await supabase.storage
+    .from(INVOICES_BUCKET)
+    .createSignedUrl(invoice.storage_path, SIGNED_URL_TTL_SECONDS)
+
+  if (signError || !data?.signedUrl) {
+    throw new InvoiceError(
+      "storage_error",
+      `Failed to generate signed URL${signError ? `: ${signError.message}` : ""}`,
+    )
+  }
+
+  return {
+    url: data.signedUrl,
+    fileName: invoice.file_name,
+    expiresIn: SIGNED_URL_TTL_SECONDS,
+  }
+}
+
+/** Validate that an upload looks like an acceptable PDF invoice. */
+export function assertValidInvoiceFile(contentType: string, sizeBytes: number): void {
+  if (contentType !== INVOICE_CONTENT_TYPE) {
+    throw new InvoiceError("invalid_file", "Only PDF invoices are supported")
+  }
+  if (sizeBytes <= 0) {
+    throw new InvoiceError("invalid_file", "Invoice file is empty")
+  }
+  if (sizeBytes > MAX_INVOICE_BYTES) {
+    throw new InvoiceError("invalid_file", "Invoice exceeds the 10 MB size limit")
+  }
+}
+
+/**
+ * Build the per-user object path for an invoice. The leading `<user_id>/`
+ * segment is what the storage RLS policies key off, so it must never be
+ * user-controlled.
+ */
+export function buildInvoicePath(userId: string): string {
+  return `${userId}/${crypto.randomUUID()}.pdf`
+}
+
+/**
+ * Upload a PDF invoice to the private bucket and record its metadata. Supports
+ * both direct uploads and email-extracted invoices (via `source`).
+ */
+export async function uploadInvoice(
+  supabase: InvoiceSupabaseClient,
+  userId: string,
+  input: UploadInvoiceInput,
+): Promise<InvoiceRecord> {
+  assertValidInvoiceFile(input.contentType, input.sizeBytes)
+
+  const storagePath = buildInvoicePath(userId)
+
+  const { error: uploadError } = await supabase.storage
+    .from(INVOICES_BUCKET)
+    .upload(storagePath, input.body, {
+      contentType: INVOICE_CONTENT_TYPE,
+      upsert: false,
+    })
+
+  if (uploadError) {
+    throw new InvoiceError("storage_error", `Failed to upload invoice: ${uploadError.message}`)
+  }
+
+  const { data: record, error: insertError } = await supabase
+    .from("invoices")
+    .insert({
+      user_id: userId,
+      subscription_id: input.subscriptionId ?? null,
+      payment_id: input.paymentId ?? null,
+      storage_path: storagePath,
+      file_name: input.fileName,
+      content_type: INVOICE_CONTENT_TYPE,
+      size_bytes: input.sizeBytes,
+      source: input.source ?? "upload",
+    })
+    .select()
+    .single()
+
+  if (insertError || !record) {
+    // Roll back the orphaned object so storage and metadata stay consistent.
+    await supabase.storage.from(INVOICES_BUCKET).remove([storagePath])
+    throw new InvoiceError(
+      "storage_error",
+      `Failed to save invoice metadata${insertError ? `: ${insertError.message}` : ""}`,
+    )
+  }
+
+  return record as InvoiceRecord
+}
+
+/** List a user's invoices, most recent first, optionally filtered by subscription. */
+export async function listInvoices(
+  supabase: InvoiceSupabaseClient,
+  userId: string,
+  filter: { subscriptionId?: string } = {},
+): Promise<InvoiceRecord[]> {
+  let query = supabase
+    .from("invoices")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (filter.subscriptionId) {
+    query = query.eq("subscription_id", filter.subscriptionId)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    throw new InvoiceError("storage_error", `Failed to list invoices: ${error.message}`)
+  }
+  return (data ?? []) as InvoiceRecord[]
+}

--- a/supabase/migrations/20260724000000_create_invoices_storage.sql
+++ b/supabase/migrations/20260724000000_create_invoices_storage.sql
@@ -1,0 +1,78 @@
+-- Managing PDF Invoices via Supabase Storage (issue #298)
+--
+-- Adds a private `invoices` storage bucket plus a metadata table so users can
+-- upload invoice PDFs (or have them extracted from emails) and later view them
+-- through short-lived signed URLs. Objects are namespaced per user
+-- (`<user_id>/<uuid>.pdf`) and both the table and the storage objects are
+-- locked down with row-level security so a user can only ever reach their own
+-- invoices.
+
+-- ─── Storage bucket ────────────────────────────────────────────────────────────
+-- Private bucket (public = false); access is only ever granted via signed URLs.
+-- 10 MB per-object limit, PDFs only.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('invoices', 'invoices', false, 10485760, array['application/pdf'])
+on conflict (id) do nothing;
+
+-- ─── Metadata table ────────────────────────────────────────────────────────────
+create table if not exists public.invoices (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  subscription_id uuid references public.subscriptions(id) on delete set null,
+  payment_id text,
+  storage_path text not null,
+  file_name text not null,
+  content_type text not null default 'application/pdf',
+  size_bytes bigint not null default 0,
+  -- Where the invoice came from: a direct upload or an email extraction.
+  source text not null default 'upload' check (source in ('upload', 'email')),
+  created_at timestamp with time zone default now()
+);
+
+alter table public.invoices enable row level security;
+
+-- Users may only read/insert/delete their own invoice rows.
+create policy "invoices_select_own"
+  on public.invoices for select
+  using (auth.uid() = user_id);
+
+create policy "invoices_insert_own"
+  on public.invoices for insert
+  with check (auth.uid() = user_id);
+
+create policy "invoices_delete_own"
+  on public.invoices for delete
+  using (auth.uid() = user_id);
+
+create index if not exists invoices_user_id_idx on public.invoices(user_id);
+create index if not exists invoices_subscription_id_idx on public.invoices(subscription_id);
+create index if not exists invoices_created_at_idx on public.invoices(created_at desc);
+
+-- One row per stored object.
+create unique index if not exists invoices_storage_path_unique_idx
+  on public.invoices(storage_path);
+
+-- ─── Storage object policies ───────────────────────────────────────────────────
+-- Restrict every operation on objects in the `invoices` bucket to the owning
+-- user's folder. The first path segment must equal the caller's uid, e.g.
+-- `<user_id>/<uuid>.pdf`.
+create policy "invoices_objects_select_own"
+  on storage.objects for select
+  using (
+    bucket_id = 'invoices'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "invoices_objects_insert_own"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'invoices'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "invoices_objects_delete_own"
+  on storage.objects for delete
+  using (
+    bucket_id = 'invoices'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary

Closes #298.

Adds end-to-end support for **storing and securely viewing PDF invoices** in Supabase Storage, so a user can click **"View Invoice PDF"** on any payment-history entry.

## What's included

**1. Storage bucket + metadata (migration `20260724000000_create_invoices_storage.sql`)**
- Private `invoices` bucket (`public = false`, PDF-only, 10 MB per-object cap) — never served via public URLs.
- `public.invoices` table (`user_id`, `subscription_id`, `payment_id`, `storage_path`, `file_name`, `source`, …).
- **RLS on both layers**: table policies (select/insert/delete own) *and* `storage.objects` policies keyed on `(storage.foldername(name))[1] = auth.uid()` so objects are reachable only under the owner's `<user_id>/…` folder.

**2. Signed-URL generation (`lib/invoices/invoice-service.ts`)**
- `getSignedInvoiceUrl` verifies the invoice belongs to the caller **before** minting a short-lived (5 min) signed URL — an authenticated user can never get a link to someone else's invoice, even by guessing an id.
- `uploadInvoice` validates the PDF, stores it under `<user_id>/<uuid>.pdf`, records metadata, and **rolls back the orphaned object** if the metadata insert fails. Supports both direct uploads and email-extracted PDFs (`source`).
- `listInvoices` for history.

**3. API routes**
- `GET /api/invoices/[id]/signed-url` — returns `{ url, fileName, expiresIn }`.
- `GET /api/invoices` (list) and `POST /api/invoices` (multipart PDF upload).

**4. UI**
- `ViewInvoiceButton` on payment-timeline entries: fetches the signed URL **on click** and opens the PDF in a new tab (URL is never embedded in the page, so it can't leak or outlive its TTL). Rendered whenever an event has an `invoiceId`.

## Acceptance criteria

- [x] Configure Supabase Storage bucket
- [x] Implement signed URL generation for secure viewing
- [x] User can click "View Invoice PDF" on a history entry

## Testing

`vitest run lib/invoices/__tests__/invoice-service.test.ts` → **13 passing**, covering: signed-URL happy path, **ownership enforcement (no URL minted for a non-owner)**, not-found, storage failure, PDF validation, upload + rollback-on-failure, and listing. Type-checks clean.

> Note: the repo's vitest suite currently can't be installed cleanly on macOS/arm64 (`client/package.json` hard-pins the linux-only `@rolldown/binding-linux-x64-gnu`); the pre-existing `payment-timeline.test.tsx` failures are an environment artifact and are unaffected by this change (identical with my edits reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)