### PR TITLE
fix(#1036): eliminate billing-cycle date drift with date-fns

### DIFF
--- a/backend/src/services/simulation-service.ts
+++ b/backend/src/services/simulation-service.ts
@@ -7,7 +7,7 @@ import type {
   SimulationSummary,
   RiskAssessment,
 } from '../types/simulation';
-import { addMonths, addQuarters, addYears } from 'date-fns';
+import { addMonths, addQuarters, addWeeks, addYears } from 'date-fns';
 
 /**
  * Simulation service for projecting subscription renewals
@@ -19,14 +19,17 @@ export class SimulationService {
    */
   calculateNextRenewal(
     currentDate: Date,
-    billingCycle: 'monthly' | 'quarterly' | 'yearly'
+    billingCycle: 'monthly' | 'quarterly' | 'yearly' | 'weekly' | 'annual'
   ): Date {
     switch (billingCycle) {
+      case 'weekly':
+        return addWeeks(currentDate, 1);
       case 'monthly':
         return addMonths(currentDate, 1);
       case 'quarterly':
         return addQuarters(currentDate, 1);
       case 'yearly':
+      case 'annual':
         return addYears(currentDate, 1);
       default:
         return currentDate;

--- a/backend/src/types/subscription.ts
+++ b/backend/src/types/subscription.ts
@@ -7,7 +7,7 @@ export interface Subscription {
   provider: string;
   price: number;
   currency: string;
-  billing_cycle: "monthly" | "yearly" | "quarterly";
+  billing_cycle: "monthly" | "yearly" | "quarterly" | "weekly" | "annual";
   status: "active" | "cancelled" | "paused" | "trial" | "expired";
   next_billing_date: string | null;
   category: string | null;
@@ -42,7 +42,7 @@ export interface SubscriptionCreateInput {
   merchant_id?: string;
   price: number;
   currency?: string;
-  billing_cycle: "monthly" | "yearly" | "quarterly";
+  billing_cycle: "monthly" | "yearly" | "quarterly" | "weekly" | "annual";
   status?: "active" | "cancelled" | "paused" | "trial" | "expired";
   next_billing_date?: string;
   category?: string;
@@ -66,7 +66,7 @@ export interface SubscriptionUpdateInput {
   merchant_id?: string;
   price?: number;
   currency?: string;
-  billing_cycle?: "monthly" | "yearly" | "quarterly";
+  billing_cycle?: "monthly" | "yearly" | "quarterly" | "weekly" | "annual";
   status?: "active" | "cancelled" | "paused" | "trial" | "expired";
   next_billing_date?: string;
   category?: string;

--- a/backend/tests/simulation-service.test.ts
+++ b/backend/tests/simulation-service.test.ts
@@ -9,28 +9,73 @@ describe("SimulationService", () => {
   });
 
   describe("calculateNextRenewal", () => {
+    it("should add 1 week for weekly billing cycle", () => {
+      const currentDate = new Date("2024-01-01T00:00:00.000Z");
+      const nextDate = service.calculateNextRenewal(currentDate, "weekly");
+      expect(nextDate.toISOString()).toBe(new Date("2024-01-08T00:00:00.000Z").toISOString());
+    });
+
     it("should add 1 month for monthly billing cycle", () => {
       const currentDate = new Date("2024-01-01T00:00:00.000Z");
       const nextDate = service.calculateNextRenewal(currentDate, "monthly");
-
       expect(nextDate.toISOString()).toBe(new Date("2024-02-01T00:00:00.000Z").toISOString());
     });
 
     it("should add 1 quarter for quarterly billing cycle", () => {
       const currentDate = new Date("2024-01-01T00:00:00.000Z");
       const nextDate = service.calculateNextRenewal(currentDate, "quarterly");
-
       expect(nextDate.toISOString()).toBe(new Date("2024-04-01T00:00:00.000Z").toISOString());
     });
 
-
-    it("should add 365 days for yearly billing cycle", () => {
-      const currentDate = new Date("2024-01-01");
+    it("should add 1 year for yearly billing cycle", () => {
+      const currentDate = new Date("2024-01-01T00:00:00.000Z");
       const nextDate = service.calculateNextRenewal(currentDate, "yearly");
+      expect(nextDate.toISOString()).toBe(new Date("2025-01-01T00:00:00.000Z").toISOString());
+    });
 
-      expect(nextDate.toISOString()).toBe(
-        new Date("2025-01-01").toISOString()
+    it("should treat annual the same as yearly", () => {
+      const d = new Date("2024-06-15T00:00:00.000Z");
+      expect(service.calculateNextRenewal(d, "annual").toISOString()).toBe(
+        service.calculateNextRenewal(d, "yearly").toISOString()
       );
+    });
+
+    // Month-end edge cases — the whole point of using date-fns over manual arithmetic
+    it("should clamp Jan 31 + 1 month to Feb 29 on a leap year", () => {
+      const jan31 = new Date("2024-01-31T00:00:00.000Z"); // 2024 is a leap year
+      const next = service.calculateNextRenewal(jan31, "monthly");
+      expect(next.toISOString()).toBe(new Date("2024-02-29T00:00:00.000Z").toISOString());
+    });
+
+    it("should clamp Jan 31 + 1 month to Feb 28 on a non-leap year", () => {
+      const jan31 = new Date("2023-01-31T00:00:00.000Z");
+      const next = service.calculateNextRenewal(jan31, "monthly");
+      expect(next.toISOString()).toBe(new Date("2023-02-28T00:00:00.000Z").toISOString());
+    });
+
+    it("should clamp Mar 31 + 1 quarter to Jun 30", () => {
+      const mar31 = new Date("2024-03-31T00:00:00.000Z");
+      const next = service.calculateNextRenewal(mar31, "quarterly");
+      expect(next.toISOString()).toBe(new Date("2024-06-30T00:00:00.000Z").toISOString());
+    });
+
+    it("no drift: applying monthly 12 times from Jan 31 lands on Jan 31 the next year", () => {
+      let date = new Date("2024-01-31T00:00:00.000Z");
+      for (let i = 0; i < 12; i++) {
+        date = service.calculateNextRenewal(date, "monthly");
+      }
+      expect(date.getUTCDate()).toBe(31);
+      expect(date.getUTCMonth()).toBe(0); // January
+      expect(date.getUTCFullYear()).toBe(2025);
+    });
+
+    it("no drift: applying weekly 52 times from a given date returns the same weekday one year later", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z"); // Monday
+      let date = start;
+      for (let i = 0; i < 52; i++) {
+        date = service.calculateNextRenewal(date, "weekly");
+      }
+      expect(date.getUTCDay()).toBe(start.getUTCDay());
     });
   });
 


### PR DESCRIPTION
- Add weekly and annual cases to calculateNextRenewal using addWeeks/addYears
- Extend billing_cycle union type to include 'weekly' | 'annual' (was silently falling through to default, returning unchanged date on every renewal)
- Add property-style tests covering month-end clamping (Jan 31 -> Feb 28/29), quarterly end clamping (Mar 31 -> Jun 30), and no-drift assertions over 12 monthly and 52 weekly iterations
- Fix misleading test description 'add 365 days' -> calendar-aware addYears


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
#1036 