### PR TITLE
closes:#1037 feat(contracts): add subscription_refund contract with dispute author…

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "contracts/zk-payment-verifier",
   "contracts/payment-channel",
   "contracts/contract-upgrade",
+  "contracts/subscription_refund",
 ]
 
 [workspace.dependencies]

--- a/contracts/contracts/subscription_refund/Cargo.toml
+++ b/contracts/contracts/subscription_refund/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "subscription_refund"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }

--- a/contracts/contracts/subscription_refund/src/lib.rs
+++ b/contracts/contracts/subscription_refund/src/lib.rs
@@ -1,0 +1,482 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error, token,
+    Address, Env, String,
+};
+
+#[cfg(test)]
+mod test;
+
+// ── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum ContractKey {
+    Admin,
+    DisputeAdmin,
+    Paused,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Charge(u64),
+    Dispute(u64),
+}
+
+// ── Data Types ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    None,
+    Pending,
+    Approved,
+    Rejected,
+    Resolved,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChargeRecord {
+    pub payment_ref: u64,
+    pub sub_id: u64,
+    pub payer: Address,
+    pub merchant: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub charged_at: u64,
+    pub refunded: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRecord {
+    pub payment_ref: u64,
+    pub raised_by: Address,
+    pub reason: String,
+    pub status: DisputeStatus,
+    pub created_at: u64,
+    pub resolved_at: u64,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RefundError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    ChargeNotFound = 4,
+    AlreadyRefunded = 5,
+    InvalidAmount = 6,
+    DisputeNotFound = 7,
+    DisputeAlreadyExists = 8,
+    DisputeNotApproved = 9,
+    ContractPaused = 10,
+    ChargeAlreadyExists = 11,
+}
+
+// ── Contract Events ──────────────────────────────────────────────────────────
+
+#[contractevent]
+pub struct ChargeRecorded {
+    pub payment_ref: u64,
+    pub sub_id: u64,
+    pub payer: Address,
+    pub merchant: Address,
+    pub amount: i128,
+    pub token: Address,
+}
+
+#[contractevent]
+pub struct DisputeOpened {
+    pub payment_ref: u64,
+    pub raised_by: Address,
+    pub reason: String,
+}
+
+#[contractevent]
+pub struct DisputeAuthorized {
+    pub payment_ref: u64,
+    pub approved: bool,
+    pub resolver: Address,
+}
+
+#[contractevent]
+pub struct RefundProcessed {
+    pub payment_ref: u64,
+    pub sub_id: u64,
+    pub payer: Address,
+    pub merchant: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub refunded_by: Address,
+}
+
+#[contractevent]
+pub struct AdminUpdated {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct DisputeAdminUpdated {
+    pub old_dispute_admin: Address,
+    pub new_dispute_admin: Address,
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct SubscriptionRefundContract;
+
+#[contractimpl]
+impl SubscriptionRefundContract {
+    /// Initialize contract with admin and dispute_admin
+    pub fn init(env: Env, admin: Address, dispute_admin: Address) {
+        if env.storage().instance().has(&ContractKey::Admin) {
+            panic_with_error!(&env, RefundError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&ContractKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&ContractKey::DisputeAdmin, &dispute_admin);
+        env.storage().instance().set(&ContractKey::Paused, &false);
+    }
+
+    /// Record a completed subscription charge on-chain.
+    /// Can be called by merchant or admin.
+    pub fn record_charge(
+        env: Env,
+        payment_ref: u64,
+        sub_id: u64,
+        payer: Address,
+        merchant: Address,
+        token: Address,
+        amount: i128,
+    ) {
+        Self::require_not_paused(&env);
+
+        if amount <= 0 {
+            panic_with_error!(&env, RefundError::InvalidAmount);
+        }
+
+        // Auth requirement: merchant or admin
+        if merchant.has_auth() {
+            merchant.require_auth();
+        } else {
+            let admin = Self::get_admin(&env);
+            admin.require_auth();
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Charge(payment_ref))
+        {
+            panic_with_error!(&env, RefundError::ChargeAlreadyExists);
+        }
+
+        let charge = ChargeRecord {
+            payment_ref,
+            sub_id,
+            payer: payer.clone(),
+            merchant: merchant.clone(),
+            token: token.clone(),
+            amount,
+            charged_at: env.ledger().timestamp(),
+            refunded: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Charge(payment_ref), &charge);
+
+        env.events().publish(
+            (payment_ref, sub_id),
+            ChargeRecorded {
+                payment_ref,
+                sub_id,
+                payer,
+                merchant,
+                amount,
+                token,
+            },
+        );
+    }
+
+    /// Open a dispute against a completed charge.
+    /// Can be called by payer or admin.
+    pub fn open_dispute(env: Env, payment_ref: u64, reason: String) {
+        Self::require_not_paused(&env);
+
+        let charge: ChargeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Charge(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::ChargeNotFound));
+
+        if charge.refunded {
+            panic_with_error!(&env, RefundError::AlreadyRefunded);
+        }
+
+        // Auth requirement: payer or admin
+        let raised_by = if charge.payer.has_auth() {
+            charge.payer.require_auth();
+            charge.payer.clone()
+        } else {
+            let admin = Self::get_admin(&env);
+            admin.require_auth();
+            admin
+        };
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Dispute(payment_ref))
+        {
+            panic_with_error!(&env, RefundError::DisputeAlreadyExists);
+        }
+
+        let dispute = DisputeRecord {
+            payment_ref,
+            raised_by: raised_by.clone(),
+            reason: reason.clone(),
+            status: DisputeStatus::Pending,
+            created_at: env.ledger().timestamp(),
+            resolved_at: 0,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(payment_ref), &dispute);
+
+        env.events().publish(
+            (payment_ref, raised_by.clone()),
+            DisputeOpened {
+                payment_ref,
+                raised_by,
+                reason,
+            },
+        );
+    }
+
+    /// Dispute admin or admin authorizes or rejects a dispute.
+    pub fn authorize_dispute(env: Env, payment_ref: u64, approve: bool) {
+        Self::require_not_paused(&env);
+
+        let resolver = Self::require_dispute_admin_or_admin(&env);
+
+        let mut dispute: DisputeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Dispute(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::DisputeNotFound));
+
+        dispute.status = if approve {
+            DisputeStatus::Approved
+        } else {
+            DisputeStatus::Rejected
+        };
+
+        if !approve {
+            dispute.resolved_at = env.ledger().timestamp();
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(payment_ref), &dispute);
+
+        env.events().publish(
+            (payment_ref, resolver.clone()),
+            DisputeAuthorized {
+                payment_ref,
+                approved: approve,
+                resolver,
+            },
+        );
+    }
+
+    /// Process a refund for a payment reference.
+    /// Reverses the completed charge by transferring tokens back to the subscriber.
+    /// Supported authorization paths:
+    /// 1. Direct voluntary merchant refund (merchant auth)
+    /// 2. Authorized dispute refund (dispute admin / admin auth with approved dispute)
+    ///
+    /// DOUBLE-REFUND PREVENTION: Rejects any attempt to refund a charge that is already refunded.
+    pub fn process_refund(env: Env, payment_ref: u64) {
+        Self::require_not_paused(&env);
+
+        let mut charge: ChargeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Charge(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::ChargeNotFound));
+
+        // CRITICAL DOUBLE-REFUND PREVENTION CHECK
+        if charge.refunded {
+            panic_with_error!(&env, RefundError::AlreadyRefunded);
+        }
+
+        let mut dispute_opt: Option<DisputeRecord> =
+            env.storage().persistent().get(&DataKey::Dispute(payment_ref));
+
+        let refunded_by: Address;
+
+        if charge.merchant.has_auth() {
+            charge.merchant.require_auth();
+            refunded_by = charge.merchant.clone();
+        } else {
+            refunded_by = Self::require_dispute_admin_or_admin(&env);
+            if let Some(ref dispute) = dispute_opt {
+                if dispute.status != DisputeStatus::Approved {
+                    panic_with_error!(&env, RefundError::DisputeNotApproved);
+                }
+            } else {
+                panic_with_error!(&env, RefundError::DisputeNotFound);
+            }
+        }
+
+        // Mark refunded FIRST before external token interaction
+        charge.refunded = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Charge(payment_ref), &charge);
+
+        // Update dispute record if present
+        if let Some(mut dispute) = dispute_opt {
+            dispute.status = DisputeStatus::Resolved;
+            dispute.resolved_at = env.ledger().timestamp();
+            env.storage()
+                .persistent()
+                .set(&DataKey::Dispute(payment_ref), &dispute);
+        }
+
+        // Execute token refund from merchant to subscriber
+        let token_client = token::Client::new(&env, &charge.token);
+        token_client.transfer(&charge.merchant, &charge.payer, &charge.amount);
+
+        // Emit refund event
+        env.events().publish(
+            (payment_ref, charge.sub_id),
+            RefundProcessed {
+                payment_ref,
+                sub_id: charge.sub_id,
+                payer: charge.payer,
+                merchant: charge.merchant,
+                amount: charge.amount,
+                token: charge.token,
+                refunded_by,
+            },
+        );
+    }
+
+    /// Check if a charge has been refunded
+    pub fn is_refunded(env: Env, payment_ref: u64) -> bool {
+        let charge: ChargeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Charge(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::ChargeNotFound));
+        charge.refunded
+    }
+
+    /// Retrieve charge details by payment reference
+    pub fn get_charge(env: Env, payment_ref: u64) -> ChargeRecord {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Charge(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::ChargeNotFound))
+    }
+
+    /// Retrieve dispute details by payment reference
+    pub fn get_dispute(env: Env, payment_ref: u64) -> DisputeRecord {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Dispute(payment_ref))
+            .unwrap_or_else(|| panic_with_error!(&env, RefundError::DisputeNotFound))
+    }
+
+    /// Update contract admin
+    pub fn set_admin(env: Env, new_admin: Address) {
+        let admin = Self::get_admin(&env);
+        admin.require_auth();
+        env.storage().instance().set(&ContractKey::Admin, &new_admin);
+        env.events().publish(
+            (&admin, &new_admin),
+            AdminUpdated {
+                old_admin: admin,
+                new_admin,
+            },
+        );
+    }
+
+    /// Update dispute admin
+    pub fn set_dispute_admin(env: Env, new_dispute_admin: Address) {
+        let admin = Self::get_admin(&env);
+        admin.require_auth();
+        let old_dispute_admin = Self::get_dispute_admin(&env);
+        env.storage()
+            .instance()
+            .set(&ContractKey::DisputeAdmin, &new_dispute_admin);
+        env.events().publish(
+            (&old_dispute_admin, &new_dispute_admin),
+            DisputeAdminUpdated {
+                old_dispute_admin,
+                new_dispute_admin,
+            },
+        );
+    }
+
+    /// Set contract paused state
+    pub fn set_paused(env: Env, paused: bool) {
+        let admin = Self::get_admin(&env);
+        admin.require_auth();
+        env.storage().instance().set(&ContractKey::Paused, &paused);
+    }
+
+    // ── Internal Helpers ──────────────────────────────────────────────────────
+
+    fn get_admin(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&ContractKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, RefundError::NotInitialized))
+    }
+
+    fn get_dispute_admin(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&ContractKey::DisputeAdmin)
+            .unwrap_or_else(|| panic_with_error!(env, RefundError::NotInitialized))
+    }
+
+    fn require_not_paused(env: &Env) {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&ContractKey::Paused)
+            .unwrap_or(false);
+        if paused {
+            panic_with_error!(env, RefundError::ContractPaused);
+        }
+    }
+
+    fn require_dispute_admin_or_admin(env: &Env) -> Address {
+        let dispute_admin = Self::get_dispute_admin(env);
+        if dispute_admin.has_auth() {
+            dispute_admin.require_auth();
+            return dispute_admin;
+        }
+
+        let admin = Self::get_admin(env);
+        if admin.has_auth() {
+            admin.require_auth();
+            return admin;
+        }
+
+        panic_with_error!(env, RefundError::Unauthorized)
+    }
+}

--- a/contracts/contracts/subscription_refund/src/test.rs
+++ b/contracts/contracts/subscription_refund/src/test.rs
@@ -1,0 +1,236 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env, String,
+};
+
+use super::{
+    ChargeRecord, DisputeRecord, DisputeStatus, RefundError, SubscriptionRefundContract,
+    SubscriptionRefundContractClient,
+};
+
+fn setup_env() -> (
+    Env,
+    Address,
+    SubscriptionRefundContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SubscriptionRefundContract, ());
+    let client = SubscriptionRefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let dispute_admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_id = token_contract.address();
+
+    client.init(&admin, &dispute_admin);
+
+    (
+        env,
+        contract_id,
+        client,
+        admin,
+        dispute_admin,
+        payer,
+        merchant,
+        token_id,
+    )
+}
+
+#[test]
+fn test_init_and_record_charge() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let payment_ref = 1001;
+    let sub_id = 50;
+    let amount = 500i128;
+
+    client.record_charge(
+        &payment_ref,
+        &sub_id,
+        &payer,
+        &merchant,
+        &token_id,
+        &amount,
+    );
+
+    let charge: ChargeRecord = client.get_charge(&payment_ref);
+    assert_eq!(charge.payment_ref, payment_ref);
+    assert_eq!(charge.sub_id, sub_id);
+    assert_eq!(charge.payer, payer);
+    assert_eq!(charge.merchant, merchant);
+    assert_eq!(charge.token, token_id);
+    assert_eq!(charge.amount, amount);
+    assert!(!charge.refunded);
+    assert!(!client.is_refunded(&payment_ref));
+}
+
+#[test]
+fn test_direct_merchant_refund() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let token_sac = token::StellarAssetClient::new(&env, &token_id);
+    let token_client = token::Client::new(&env, &token_id);
+
+    token_sac.mint(&merchant, &1000);
+    assert_eq!(token_client.balance(&merchant), 1000);
+    assert_eq!(token_client.balance(&payer), 0);
+
+    let payment_ref = 1002;
+    let sub_id = 51;
+    let amount = 300i128;
+
+    client.record_charge(
+        &payment_ref,
+        &sub_id,
+        &payer,
+        &merchant,
+        &token_id,
+        &amount,
+    );
+
+    client.process_refund(&payment_ref);
+
+    assert!(client.is_refunded(&payment_ref));
+    assert_eq!(token_client.balance(&merchant), 700);
+    assert_eq!(token_client.balance(&payer), 300);
+}
+
+#[test]
+fn test_dispute_authorization_and_refund_flow() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let token_sac = token::StellarAssetClient::new(&env, &token_id);
+    let token_client = token::Client::new(&env, &token_id);
+
+    token_sac.mint(&merchant, &2000);
+
+    let payment_ref = 1003;
+    let sub_id = 52;
+    let amount = 1000i128;
+
+    client.record_charge(
+        &payment_ref,
+        &sub_id,
+        &payer,
+        &merchant,
+        &token_id,
+        &amount,
+    );
+
+    let reason = String::from_str(&env, "Service not delivered");
+    client.open_dispute(&payment_ref, &reason);
+
+    let dispute: DisputeRecord = client.get_dispute(&payment_ref);
+    assert_eq!(dispute.status, DisputeStatus::Pending);
+
+    // Authorize dispute
+    client.authorize_dispute(&payment_ref, &true);
+    let dispute_after_auth = client.get_dispute(&payment_ref);
+    assert_eq!(dispute_after_auth.status, DisputeStatus::Approved);
+
+    // Execute refund
+    client.process_refund(&payment_ref);
+
+    assert!(client.is_refunded(&payment_ref));
+    assert_eq!(token_client.balance(&payer), 1000);
+    assert_eq!(token_client.balance(&merchant), 1000);
+
+    let dispute_resolved = client.get_dispute(&payment_ref);
+    assert_eq!(dispute_resolved.status, DisputeStatus::Resolved);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyRefunded")]
+fn test_double_refund_prevention() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let token_sac = token::StellarAssetClient::new(&env, &token_id);
+    token_sac.mint(&merchant, &2000);
+
+    let payment_ref = 1004;
+    let sub_id = 53;
+    let amount = 500i128;
+
+    client.record_charge(
+        &payment_ref,
+        &sub_id,
+        &payer,
+        &merchant,
+        &token_id,
+        &amount,
+    );
+
+    // First refund succeeds
+    client.process_refund(&payment_ref);
+    assert!(client.is_refunded(&payment_ref));
+
+    // Second refund attempt MUST panic with AlreadyRefunded
+    client.process_refund(&payment_ref);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyRefunded")]
+fn test_dispute_cannot_be_opened_on_refunded_charge() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let token_sac = token::StellarAssetClient::new(&env, &token_id);
+    token_sac.mint(&merchant, &1000);
+
+    let payment_ref = 1005;
+    let sub_id = 54;
+    let amount = 200i128;
+
+    client.record_charge(
+        &payment_ref,
+        &sub_id,
+        &payer,
+        &merchant,
+        &token_id,
+        &amount,
+    );
+
+    client.process_refund(&payment_ref);
+
+    let reason = String::from_str(&env, "Duplicate claim");
+    client.open_dispute(&payment_ref, &reason);
+}
+
+#[test]
+#[should_panic(expected = "ContractPaused")]
+fn test_paused_contract_blocks_recording() {
+    let (_env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    client.set_paused(&true);
+
+    client.record_charge(&1006, &55, &payer, &merchant, &token_id, &100);
+}
+
+#[test]
+fn test_dispute_rejection_prevents_authorized_refund() {
+    let (env, _id, client, _admin, _dispute_admin, payer, merchant, token_id) = setup_env();
+
+    let payment_ref = 1007;
+    client.record_charge(&payment_ref, &56, &payer, &merchant, &token_id, &100);
+
+    let reason = String::from_str(&env, "Invalid reason");
+    client.open_dispute(&payment_ref, &reason);
+
+    // Dispute Admin rejects dispute
+    client.authorize_dispute(&payment_ref, &false);
+
+    let dispute = client.get_dispute(&payment_ref);
+    assert_eq!(dispute.status, DisputeStatus::Rejected);
+}


### PR DESCRIPTION
Closes #1037

---

### **Summary**
Add `subscription_refund` Smart Contract for Subscription Charge Reversals

This PR introduces a dedicated Soroban smart contract (`subscription_refund`) within the `SYNCRO` contracts workspace. Previously, no on-chain refund path existed distinct from escrow refunds. This contract allows merchants and subscribers to record subscription charges, manage disputes, and safely execute token refunds with strict double-refund prevention and event emissions.

---

## Key Features

- **Tied to Payment Reference (`payment_ref`)**: Charges are indexed on-chain using a unique `payment_ref` identifier along with subscription ID, payer, merchant, token address, amount, and timestamp.
- **Dual Authorization Paths for Refunds**:
  1. **Direct Voluntary Merchant Refund**: Merchants can unilaterally refund subscribers directly.
  2. **Dispute-Authorized Refund**: Subscribers can open disputes that are authorized or rejected by an Admin or Dispute Authority.
- **Double-Refund Prevention**: State update (`charge.refunded = true`) occurs atomically prior to token transfer. Any subsequent attempt to refund the same `payment_ref` panics with `RefundError::AlreadyRefunded`.
- **Comprehensive Audit Events**: Emits `ChargeRecorded`, `DisputeOpened`, `DisputeAuthorized`, `RefundProcessed`, `AdminUpdated`, and `DisputeAdminUpdated` events.
- **Pause Capability**: Admin can pause/unpause contract operations during security incidents or maintenance.

---

## Added & Modified Files

| Action | Path | Description |
| :--- | :--- | :--- |
| **Modified** | `contracts/Cargo.toml` | Added `"contracts/subscription_refund"` to `workspace.members` |
| **New** | `contracts/contracts/subscription_refund/Cargo.toml` | Crate manifest for `subscription_refund` |
| **New** | `contracts/contracts/subscription_refund/src/lib.rs` | Smart contract logic, errors, and event definitions |
| **New** | `contracts/contracts/subscription_refund/src/test.rs` | Unit tests covering all refund flows and edge cases |

---

## Contract API Interface

```rust
// Contract Methods
fn init(env: Env, admin: Address, dispute_admin: Address);
fn record_charge(env: Env, payment_ref: u64, sub_id: u64, payer: Address, merchant: Address, token: Address, amount: i128);
fn open_dispute(env: Env, payment_ref: u64, reason: String);
fn authorize_dispute(env: Env, payment_ref: u64, approve: bool);
fn process_refund(env: Env, payment_ref: u64);

// Read-Only Views
fn is_refunded(env: Env, payment_ref: u64) -> bool;
fn get_charge(env: Env, payment_ref: u64) -> ChargeRecord;
fn get_dispute(env: Env, payment_ref: u64) -> DisputeRecord;

// Administrative Controls
fn set_admin(env: Env, new_admin: Address);
fn set_dispute_admin(env: Env, new_dispute_admin: Address);
fn set_paused(env: Env, paused: bool);