### PR TITLE
Harden offline sync, admin settings persistence, payment DB failures, and admin audit events

### DIFF
--- a/client/app/api/admin/settings/__tests__/route.test.ts
+++ b/client/app/api/admin/settings/__tests__/route.test.ts
@@ -1,12 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { PUT } from "../route"
+import { PUT, GET } from "../route"
 import { requireAuth, requireRole } from "@/lib/api/auth"
 import { NextRequest } from "next/server"
+import { ApiErrors } from "@/lib/api/errors"
+import {
+  getAdminSettings,
+  updateAdminSettings,
+} from "@/lib/admin-settings-store"
+import { emitAuditEvent } from "@/lib/api/audit"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
 
 vi.mock("@/lib/api/auth", () => ({
   requireAuth: vi.fn(),
   requireRole: vi.fn(),
   createRequestContext: vi.fn().mockReturnValue({ requestId: "test-admin-id" }),
+}))
+
+vi.mock("@/lib/admin-settings-store", () => ({
+  getAdminSettings: vi.fn(),
+  updateAdminSettings: vi.fn(),
+  resetAdminSettingsStore: vi.fn(),
+  getCachedAdminSettings: vi.fn(),
+}))
+
+vi.mock("@/lib/api/audit", () => ({
+  emitAuditEvent: vi.fn(),
 }))
 
 describe("Admin Settings API Route", () => {
@@ -16,14 +37,21 @@ describe("Admin Settings API Route", () => {
     vi.clearAllMocks()
     vi.mocked(requireAuth).mockResolvedValue(mockOwner as any)
     vi.mocked(requireRole).mockResolvedValue(true as any)
+    vi.mocked(getAdminSettings).mockResolvedValue({
+      maintenanceMode: false,
+      enableRegistration: true,
+      rateLimitThreshold: 100,
+    })
   })
 
-  it("should update settings successfully with valid parameters", async () => {
+  it("persists settings and returns the saved state", async () => {
     const validBody = {
       maintenanceMode: true,
       enableRegistration: false,
       rateLimitThreshold: 100,
     }
+    const saved = { ...validBody }
+    vi.mocked(updateAdminSettings).mockResolvedValue(saved)
 
     const request = new NextRequest("http://localhost/api/admin/settings", {
       method: "PUT",
@@ -36,13 +64,18 @@ describe("Admin Settings API Route", () => {
     expect(response.status).toBe(200)
     expect(body.success).toBe(true)
     expect(body.data.updated).toBe(true)
-    expect(body.data.settings).toEqual(validBody)
+    expect(body.data.settings).toEqual(saved)
+    expect(updateAdminSettings).toHaveBeenCalledWith(validBody)
   })
 
-  it("should support partial settings updates", async () => {
-    const partialBody = {
+  it("returns merged saved state for partial updates, not only the submitted body", async () => {
+    const partialBody = { maintenanceMode: false }
+    const saved = {
       maintenanceMode: false,
+      enableRegistration: true,
+      rateLimitThreshold: 100,
     }
+    vi.mocked(updateAdminSettings).mockResolvedValue(saved)
 
     const request = new NextRequest("http://localhost/api/admin/settings", {
       method: "PUT",
@@ -53,63 +86,129 @@ describe("Admin Settings API Route", () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body.success).toBe(true)
-    expect(body.data.settings).toEqual(partialBody)
+    expect(body.data.settings).toEqual(saved)
+    expect(body.data.settings).not.toEqual(partialBody)
   })
 
-  it("should reject setting a negative rateLimitThreshold", async () => {
-    const invalidBody = {
-      rateLimitThreshold: -10,
-    }
+  it("emits an audit event for privileged settings changes", async () => {
+    const validBody = { maintenanceMode: true }
+    vi.mocked(updateAdminSettings).mockResolvedValue({
+      maintenanceMode: true,
+      enableRegistration: true,
+      rateLimitThreshold: 100,
+    })
 
     const request = new NextRequest("http://localhost/api/admin/settings", {
       method: "PUT",
-      body: JSON.stringify(invalidBody),
+      body: JSON.stringify(validBody),
+    })
+
+    await PUT(request)
+
+    expect(emitAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: mockOwner.id,
+        action: "admin.settings_update",
+        resourceType: "admin_settings",
+        metadata: expect.objectContaining({
+          route: "/api/admin/settings",
+          requestId: "test-admin-id",
+          changedFields: "maintenanceMode",
+          maintenanceMode: true,
+        }),
+      })
+    )
+  })
+
+  it("rejects unauthenticated users", async () => {
+    vi.mocked(requireAuth).mockRejectedValue(ApiErrors.unauthorized())
+
+    const request = new NextRequest("http://localhost/api/admin/settings", {
+      method: "PUT",
+      body: JSON.stringify({ maintenanceMode: true }),
+    })
+
+    const response = await PUT(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error.code).toBe("UNAUTHORIZED")
+    expect(updateAdminSettings).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-owner users", async () => {
+    vi.mocked(requireRole).mockRejectedValue(
+      ApiErrors.forbidden("Requires one of: owner")
+    )
+
+    const request = new NextRequest("http://localhost/api/admin/settings", {
+      method: "PUT",
+      body: JSON.stringify({ maintenanceMode: true }),
+    })
+
+    const response = await PUT(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error.code).toBe("FORBIDDEN")
+    expect(updateAdminSettings).not.toHaveBeenCalled()
+  })
+
+  it("should reject setting a negative rateLimitThreshold", async () => {
+    const request = new NextRequest("http://localhost/api/admin/settings", {
+      method: "PUT",
+      body: JSON.stringify({ rateLimitThreshold: -10 }),
     })
 
     const response = await PUT(request)
     const body = await response.json()
 
     expect(response.status).toBe(400)
-    expect(body.success).toBe(false)
     expect(body.error.code).toBe("VALIDATION_ERROR")
     expect(body.error.field).toBe("rateLimitThreshold")
   })
 
   it("should reject setting rateLimitThreshold to 0", async () => {
-    const invalidBody = {
-      rateLimitThreshold: 0,
-    }
-
     const request = new NextRequest("http://localhost/api/admin/settings", {
       method: "PUT",
-      body: JSON.stringify(invalidBody),
+      body: JSON.stringify({ rateLimitThreshold: 0 }),
     })
 
     const response = await PUT(request)
     const body = await response.json()
 
     expect(response.status).toBe(400)
-    expect(body.success).toBe(false)
     expect(body.error.code).toBe("VALIDATION_ERROR")
   })
 
   it("should reject invalid data types", async () => {
-    const invalidBody = {
-      maintenanceMode: "yes", // should be boolean
-    }
-
     const request = new NextRequest("http://localhost/api/admin/settings", {
       method: "PUT",
-      body: JSON.stringify(invalidBody),
+      body: JSON.stringify({ maintenanceMode: "yes" }),
     })
 
     const response = await PUT(request)
     const body = await response.json()
 
     expect(response.status).toBe(400)
-    expect(body.success).toBe(false)
     expect(body.error.code).toBe("VALIDATION_ERROR")
     expect(body.error.field).toBe("maintenanceMode")
+  })
+
+  it("GET returns persisted settings for owners", async () => {
+    const settings = {
+      maintenanceMode: true,
+      enableRegistration: false,
+      rateLimitThreshold: 50,
+    }
+    vi.mocked(getAdminSettings).mockResolvedValue(settings)
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/settings")
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data.settings).toEqual(settings)
   })
 })

--- a/client/app/api/admin/settings/route.ts
+++ b/client/app/api/admin/settings/route.ts
@@ -1,6 +1,13 @@
-import { NextRequest } from 'next/server'
-import { createApiRoute, createSuccessResponse, validateRequestBody } from '@/lib/api'
-import { z } from 'zod'
+import { type NextRequest } from "next/server"
+import {
+  createApiRoute,
+  createSuccessResponse,
+  validateRequestBody,
+  emitAuditEvent,
+  ApiErrors,
+} from "@/lib/api/index"
+import { updateAdminSettings, getAdminSettings } from "@/lib/admin-settings-store"
+import { z } from "zod"
 
 const adminSettingsSchema = z.object({
   maintenanceMode: z.boolean().optional(),
@@ -8,13 +15,67 @@ const adminSettingsSchema = z.object({
   rateLimitThreshold: z.number().int().positive().optional(),
 })
 
-export const PUT = createApiRoute(
-  async (request: NextRequest) => {
-    const body = await validateRequestBody(request, adminSettingsSchema)
-    return createSuccessResponse({ updated: true, settings: body })
+export const GET = createApiRoute(
+  async (_request: NextRequest, context) => {
+    const settings = await getAdminSettings()
+    return createSuccessResponse({ settings }, undefined, context.requestId)
   },
   {
     requireAuth: true,
-    requireRole: ['owner'],
+    requireRole: ["owner"],
+  }
+)
+
+export const PUT = createApiRoute(
+  async (request: NextRequest, context, user) => {
+    if (!user) {
+      throw ApiErrors.unauthorized()
+    }
+
+    const body = await validateRequestBody(request, adminSettingsSchema)
+    const changedFields = Object.keys(body).filter(
+      (key) => body[key as keyof typeof body] !== undefined
+    )
+
+    if (changedFields.length === 0) {
+      throw ApiErrors.validationError("At least one settings field is required")
+    }
+
+    let settings
+    try {
+      settings = await updateAdminSettings(body)
+    } catch (error) {
+      throw ApiErrors.internalError(
+        error instanceof Error ? error.message : "Failed to persist admin settings"
+      )
+    }
+
+    emitAuditEvent({
+      userId: user.id,
+      action: "admin.settings_update",
+      resourceType: "admin_settings",
+      resourceId: "platform",
+      metadata: {
+        route: "/api/admin/settings",
+        requestId: context.requestId,
+        changedFields: changedFields.join(","),
+        ...Object.fromEntries(
+          changedFields.map((field) => [
+            field,
+            body[field as keyof typeof body] as string | number | boolean,
+          ])
+        ),
+      },
+    })
+
+    return createSuccessResponse(
+      { updated: true, settings },
+      undefined,
+      context.requestId
+    )
+  },
+  {
+    requireAuth: true,
+    requireRole: ["owner"],
   }
 )

--- a/client/app/api/admin/users/__tests__/route.test.ts
+++ b/client/app/api/admin/users/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { GET } from "../route"
+import { requireAuth, requireRole } from "@/lib/api/auth"
+import { NextRequest } from "next/server"
+import { ApiErrors } from "@/lib/api/errors"
+import { emitAuditEvent } from "@/lib/api/audit"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock("@/lib/api/auth", () => ({
+  requireAuth: vi.fn(),
+  requireRole: vi.fn(),
+  createRequestContext: vi.fn().mockReturnValue({ requestId: "admin-users-req" }),
+}))
+
+vi.mock("@/lib/api/audit", () => ({
+  emitAuditEvent: vi.fn(),
+}))
+
+describe("Admin Users API Route", () => {
+  const mockAdmin = { id: "admin_1", email: "admin@example.com" }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue(mockAdmin as any)
+    vi.mocked(requireRole).mockResolvedValue(true as any)
+  })
+
+  it("emits an audit event on successful privileged user-list access", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/users")
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(emitAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: mockAdmin.id,
+        action: "admin.users_list",
+        resourceType: "admin_users",
+        metadata: expect.objectContaining({
+          route: "/api/admin/users",
+          requestId: "admin-users-req",
+        }),
+      })
+    )
+  })
+
+  it("rejects unauthenticated users without emitting audit", async () => {
+    vi.mocked(requireAuth).mockRejectedValue(ApiErrors.unauthorized())
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/users")
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.error.code).toBe("UNAUTHORIZED")
+    expect(emitAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it("rejects forbidden users without emitting audit", async () => {
+    vi.mocked(requireRole).mockRejectedValue(
+      ApiErrors.forbidden("Requires one of: admin, owner")
+    )
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/users")
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error.code).toBe("FORBIDDEN")
+    expect(emitAuditEvent).not.toHaveBeenCalled()
+  })
+})

--- a/client/app/api/admin/users/route.ts
+++ b/client/app/api/admin/users/route.ts
@@ -1,12 +1,37 @@
-import { NextRequest } from 'next/server'
-import { createApiRoute, createSuccessResponse } from '@/lib/api'
+import { type NextRequest } from "next/server"
+import {
+  createApiRoute,
+  createSuccessResponse,
+  emitAuditEvent,
+  ApiErrors,
+} from "@/lib/api/index"
 
 export const GET = createApiRoute(
-  async (request: NextRequest) => {
-    return createSuccessResponse({ users: [] })
+  async (_request: NextRequest, context, user) => {
+    if (!user) {
+      throw ApiErrors.unauthorized()
+    }
+
+    // Privileged user listing — emit audit even when the payload is empty/stubbed
+    emitAuditEvent({
+      userId: user.id,
+      action: "admin.users_list",
+      resourceType: "admin_users",
+      metadata: {
+        route: "/api/admin/users",
+        requestId: context.requestId,
+        resultCount: 0,
+      },
+    })
+
+    return createSuccessResponse(
+      { users: [] },
+      undefined,
+      context.requestId
+    )
   },
   {
     requireAuth: true,
-    requireRole: ['admin', 'owner'],
+    requireRole: ["admin", "owner"],
   }
 )

--- a/client/app/api/payments/route.ts
+++ b/client/app/api/payments/route.ts
@@ -39,6 +39,7 @@ export const POST = createAuthenticatedApiRoute(
         planName: body.planName,
         userId: user.id,
         userEmail: user.email || "",
+        requestId: context.requestId,
       },
     );
 
@@ -53,7 +54,14 @@ export const POST = createAuthenticatedApiRoute(
       action: "payment.create",
       resourceType: "payment",
       resourceId: result.transactionId,
-      metadata: { provider: body.provider, currency: body.currency },
+      metadata: {
+        provider: body.provider,
+        currency: body.currency,
+        requestId: context.requestId,
+        ...(result.persistenceDegraded
+          ? { persistenceDegraded: true, needsReconciliation: true }
+          : {}),
+      },
     })
 
     return createSuccessResponse(
@@ -62,8 +70,19 @@ export const POST = createAuthenticatedApiRoute(
           id: result.transactionId,
           amount: body.amount,
           currency: body.currency,
-          status: "succeeded",
+          status: result.requiresAction
+            ? "pending"
+            : result.persistenceDegraded
+              ? "succeeded_unreconciled"
+              : "succeeded",
           createdAt: new Date(),
+          ...(result.persistenceDegraded
+            ? {
+                persistenceDegraded: true,
+                needsReconciliation: true,
+                message: result.error,
+              }
+            : {}),
         },
       },
       HttpStatus.CREATED,

--- a/client/app/api/sync/offline/__tests__/route.test.ts
+++ b/client/app/api/sync/offline/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { POST } from "../route"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/api/auth"
+import { NextRequest } from "next/server"
+import { mockSupabaseClient } from "@/lib/test-utils/mocks"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock("@/lib/api/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/auth")>()
+  return {
+    ...actual,
+    requireAuth: vi.fn(),
+    createRequestContext: vi.fn().mockReturnValue({ requestId: "sync-req-1" }),
+  }
+})
+
+vi.mock("@/lib/telemetry", () => ({
+  trackError: vi.fn(),
+}))
+
+describe("Offline Sync API Route", () => {
+  let supabase: ReturnType<typeof mockSupabaseClient>
+  const mockUser = { id: "auth-user-123", email: "user@example.com" }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    supabase = mockSupabaseClient()
+    vi.mocked(createClient).mockResolvedValue(supabase as any)
+    vi.mocked(requireAuth).mockResolvedValue(mockUser as any)
+  })
+
+  function makeRequest(body: unknown) {
+    return new NextRequest("http://localhost/api/sync/offline", {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  it("rejects unauthenticated requests with UNAUTHORIZED", async () => {
+    const { ApiErrors } = await import("@/lib/api/errors")
+    vi.mocked(requireAuth).mockRejectedValue(ApiErrors.unauthorized())
+
+    const response = await POST(
+      makeRequest({ type: "create", payload: { name: "Netflix" } })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body.success).toBe(false)
+    expect(body.error.code).toBe("UNAUTHORIZED")
+  })
+
+  it("creates a subscription with the authenticated user_id", async () => {
+    supabase.insert.mockReturnThis()
+    supabase.select.mockReturnThis()
+    supabase.single.mockResolvedValue({
+      data: { id: "sub_1", name: "Netflix", user_id: "auth-user-123" },
+      error: null,
+    })
+
+    const response = await POST(
+      makeRequest({
+        type: "create",
+        payload: { name: "Netflix", price: 15.99 },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(supabase.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Netflix",
+        user_id: "auth-user-123",
+      })
+    )
+  })
+
+  it("rejects create payloads that attempt to override user_id", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "create",
+        payload: {
+          name: "Hijack",
+          user_id: "attacker-user-999",
+        },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+    expect(body.error.message).toContain("user_id")
+    expect(supabase.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects create payloads containing created_at or updated_at", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "create",
+        payload: {
+          name: "Spotify",
+          created_at: "2020-01-01T00:00:00Z",
+          updated_at: "2020-01-01T00:00:00Z",
+        },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+    expect(supabase.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects create payloads that supply a client-owned id", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "create",
+        payload: { name: "Disney+", id: "forced-id" },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.message).toContain("id")
+    expect(supabase.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects update payloads that attempt to change user_id", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "update",
+        payload: {
+          id: "sub_1",
+          user_id: "other-user",
+          name: "Renamed",
+        },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+    expect(body.error.message).toContain("user_id")
+    expect(supabase.update).not.toHaveBeenCalled()
+  })
+})

--- a/client/app/api/sync/offline/route.ts
+++ b/client/app/api/sync/offline/route.ts
@@ -1,16 +1,62 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { type NextRequest } from "next/server"
+import {
+  createAuthenticatedApiRoute,
+  createSuccessResponse,
+  ApiErrors,
+  ApiException,
+} from "@/lib/api/index"
 import { createClient } from "@/lib/supabase/server"
 import { trackError } from "@/lib/telemetry"
+import { ErrorCode, HttpStatus } from "@/lib/api/types"
 
-// Conflict resolution: Last-write-wins strategy with version tracking
+/**
+ * Fields that are always server-owned. Clients must not supply these on create.
+ * On update, `id` is allowed only as a lookup key and is never written back.
+ */
+const ALWAYS_PROTECTED = ["user_id", "created_at", "updated_at"] as const
+const CREATE_PROTECTED = [...ALWAYS_PROTECTED, "id"] as const
+
+function findPresentFields(
+  payload: Record<string, unknown>,
+  fields: readonly string[]
+): string[] {
+  return fields.filter((field) =>
+    Object.prototype.hasOwnProperty.call(payload, field)
+  )
+}
+
+function assertNoProtectedFields(
+  payload: Record<string, unknown>,
+  fields: readonly string[]
+): void {
+  const present = findPresentFields(payload, fields)
+  if (present.length > 0) {
+    throw ApiErrors.validationError(
+      `Payload must not include protected fields: ${present.join(", ")}`,
+      present[0],
+      { protectedFields: present }
+    )
+  }
+}
+
+function omitFields(
+  payload: Record<string, unknown>,
+  fields: readonly string[]
+): Record<string, unknown> {
+  const sanitized = { ...payload }
+  for (const field of fields) {
+    delete sanitized[field]
+  }
+  return sanitized
+}
+
 async function resolveConflict(
-  existingSubscription: any,
+  existingSubscription: Record<string, unknown>,
   updates: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
-  const existingVersion = existingSubscription.version || 0
-  const updateVersion = updates.version || 0
+  const existingVersion = Number(existingSubscription.version) || 0
+  const updateVersion = Number(updates.version) || 0
 
-  // Last-write-wins: if server version is higher, reject client changes
   if (existingVersion > updateVersion) {
     return {
       ...updates,
@@ -19,7 +65,6 @@ async function resolveConflict(
     }
   }
 
-  // Merge changes with server data
   return {
     ...existingSubscription,
     ...updates,
@@ -27,105 +72,148 @@ async function resolveConflict(
   }
 }
 
-export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+export const POST = createAuthenticatedApiRoute(
+  async (request: NextRequest, context, user) => {
+    let mutation: { type?: string; payload?: Record<string, unknown> }
+    try {
+      mutation = await request.json()
+    } catch {
+      throw ApiErrors.validationError("Invalid JSON body")
+    }
 
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    const { type, payload } = mutation
+
+    if (!type || typeof type !== "string") {
+      throw ApiErrors.validationError("Mutation type is required", "type")
+    }
+
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw ApiErrors.validationError("Mutation payload is required", "payload")
+    }
+
+    const supabase = await createClient()
+
+    try {
+      if (type === "create") {
+        assertNoProtectedFields(payload, CREATE_PROTECTED)
+
+        const { data, error } = await supabase
+          .from("subscriptions")
+          .insert({
+            ...omitFields(payload, CREATE_PROTECTED),
+            // Server-owned — assigned after all client fields
+            user_id: user.id,
+          })
+          .select()
+          .single()
+
+        if (error) {
+          throw ApiErrors.validationError(error.message)
+        }
+
+        return createSuccessResponse(
+          { success: true, data },
+          HttpStatus.OK,
+          context.requestId
+        )
+      }
+
+      if (type === "update") {
+        assertNoProtectedFields(payload, ALWAYS_PROTECTED)
+
+        const id = payload.id
+        if (!id || typeof id !== "string") {
+          throw ApiErrors.validationError("Subscription id is required", "id")
+        }
+
+        // Never write id / ownership / timestamps from the client
+        const updatePayload = omitFields(payload, [
+          ...ALWAYS_PROTECTED,
+          "id",
+        ])
+
+        const { data: existing, error: fetchError } = await supabase
+          .from("subscriptions")
+          .select("*")
+          .eq("id", id)
+          .eq("user_id", user.id)
+          .single()
+
+        if (fetchError && fetchError.code === "PGRST116") {
+          throw ApiErrors.notFound("Subscription")
+        }
+
+        if (fetchError) {
+          throw ApiErrors.validationError(fetchError.message)
+        }
+
+        if (
+          payload.version != null &&
+          existing.version != null &&
+          Number(payload.version) < Number(existing.version)
+        ) {
+          const resolved = await resolveConflict(existing, updatePayload)
+          throw new ApiException(
+            ErrorCode.CONFLICT,
+            "Conflict detected",
+            HttpStatus.CONFLICT,
+            { conflict: true, resolvedData: resolved }
+          )
+        }
+
+        const { data, error } = await supabase
+          .from("subscriptions")
+          .update({
+            ...updatePayload,
+            version: (Number(existing.version) || 0) + 1,
+            user_id: user.id,
+          })
+          .eq("id", id)
+          .eq("user_id", user.id)
+          .select()
+          .single()
+
+        if (error) {
+          throw ApiErrors.validationError(error.message)
+        }
+
+        return createSuccessResponse(
+          { success: true, data },
+          HttpStatus.OK,
+          context.requestId
+        )
+      }
+
+      if (type === "delete") {
+        const id = payload.id
+        if (!id || typeof id !== "string") {
+          throw ApiErrors.validationError("Subscription id is required", "id")
+        }
+
+        const { error } = await supabase
+          .from("subscriptions")
+          .delete()
+          .eq("id", id)
+          .eq("user_id", user.id)
+
+        if (error) {
+          throw ApiErrors.validationError(error.message)
+        }
+
+        return createSuccessResponse(
+          { success: true },
+          HttpStatus.OK,
+          context.requestId
+        )
+      }
+
+      throw ApiErrors.validationError("Unknown mutation type", "type")
+    } catch (error) {
+      if (error instanceof ApiException) {
+        throw error
+      }
+      trackError(error, "sync", { type, userId: user.id })
+      throw ApiErrors.internalError("Internal server error")
+    }
   }
-
-  const mutation = await request.json()
-
-  const { type, payload } = mutation
-
-  try {
-    if (type === "create") {
-      const { data, error } = await supabase
-        .from("subscriptions")
-        .insert({
-          user_id: user.id,
-          ...payload,
-        })
-        .select()
-        .single()
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
-      }
-
-      return NextResponse.json({ success: true, data })
-    }
-
-    if (type === "update") {
-      const id = payload.id as string
-
-      // Check for conflicts
-      const { data: existing, error: fetchError } = await supabase
-        .from("subscriptions")
-        .select("*")
-        .eq("id", id)
-        .eq("user_id", user.id)
-        .single()
-
-      if (fetchError && fetchError.code === "PGRST116") {
-        // Subscription not found - may have been deleted
-        return NextResponse.json({ error: "Subscription not found" }, { status: 404 })
-      }
-
-      if (fetchError) {
-        return NextResponse.json({ error: fetchError.message }, { status: 400 })
-      }
-
-      // Check for conflict (optimistic locking)
-      if (payload.version && existing.version && payload.version < existing.version) {
-        const resolved = await resolveConflict(existing, payload)
-        return NextResponse.json({ 
-          error: "Conflict detected", 
-          conflict: true,
-          resolvedData: resolved,
-        }, { status: 409 })
-      }
-
-      const { data, error } = await supabase
-        .from("subscriptions")
-        .update({
-          ...payload,
-          version: (existing.version || 0) + 1,
-        })
-        .eq("id", id)
-        .eq("user_id", user.id)
-        .select()
-        .single()
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
-      }
-
-      return NextResponse.json({ success: true, data })
-    }
-
-    if (type === "delete") {
-      const id = payload.id as string
-
-      const { error } = await supabase
-        .from("subscriptions")
-        .delete()
-        .eq("id", id)
-        .eq("user_id", user.id)
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
-      }
-
-      return NextResponse.json({ success: true })
-    }
-
-    return NextResponse.json({ error: "Unknown mutation type" }, { status: 400 })
-  } catch (error) {
-    trackError(error, "sync", { type, userId: user.id })
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
-  }
-}
+)

--- a/client/lib/__tests__/payment-service.test.ts
+++ b/client/lib/__tests__/payment-service.test.ts
@@ -22,6 +22,19 @@ vi.mock("../paypal-service", () => ({
   getPayPalService: vi.fn(),
 }))
 
+vi.mock("../api/audit", () => ({
+  emitAuditEvent: vi.fn(),
+}))
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
 describe("PaymentService", () => {
   let supabase: any
   let stripe: any
@@ -400,21 +413,64 @@ describe("PaymentService", () => {
   // ─── DB error handling ─────────────────────────────────────────────────────
 
   describe("Database Error Handling", () => {
-    it("should catch and log DB errors but still return a successful payment result", async () => {
+    it("returns a degraded result when insert fails after provider success", async () => {
       const service = new PaymentService({ provider: "mock" })
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
 
-      supabase.insert.mockRejectedValue(new Error("DB Connection Error"))
+      supabase.single.mockResolvedValue({ data: null, error: { code: "PGRST116" } })
+      supabase.insert.mockResolvedValue({
+        data: null,
+        error: { message: "insert failed" },
+      })
 
-      const result = await service.processPayment(100, "usd", "pm_123")
+      const result = await service.processPayment(100, "usd", "pm_123", {
+        userId: "user_123",
+        requestId: "req_abc",
+      })
 
       expect(result.success).toBe(true)
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to save payment to database:",
-        expect.any(Error)
-      )
+      expect(result.persistenceDegraded).toBe(true)
+      expect(result.needsReconciliation).toBe(true)
+      expect(result.transactionId).toContain("mock_")
+      expect(result.error).toContain("insert failed")
+    })
 
-      consoleSpy.mockRestore()
+    it("returns a degraded result when update fails after provider success", async () => {
+      const service = new PaymentService({ provider: "mock" })
+
+      supabase.single.mockResolvedValue({ data: { id: "pay_existing" }, error: null })
+      supabase.update.mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: "update failed" },
+        }),
+      })
+
+      const result = await service.processPayment(100, "usd", "pm_123", {
+        userId: "user_123",
+        requestId: "req_upd",
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.persistenceDegraded).toBe(true)
+      expect(result.needsReconciliation).toBe(true)
+      expect(result.error).toContain("update failed")
+    })
+
+    it("surfaces thrown DB errors as degraded persistence instead of swallowing them", async () => {
+      const service = new PaymentService({ provider: "mock" })
+
+      supabase.single.mockResolvedValue({ data: null, error: null })
+      supabase.insert.mockRejectedValue(new Error("DB Connection Error"))
+
+      const result = await service.processPayment(100, "usd", "pm_123", {
+        userId: "user_123",
+        requestId: "req_throw",
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.persistenceDegraded).toBe(true)
+      expect(result.needsReconciliation).toBe(true)
+      expect(result.error).toContain("DB Connection Error")
     })
   })
 })

--- a/client/lib/admin-settings-store.ts
+++ b/client/lib/admin-settings-store.ts
@@ -1,0 +1,107 @@
+/**
+ * Canonical store for platform-level admin settings.
+ *
+ * Writes update an in-process cache and upsert a singleton row in
+ * `app_settings` so values survive process restarts.
+ */
+
+import { createClient } from "@/lib/supabase/server"
+
+export type AdminSettings = {
+  maintenanceMode: boolean
+  enableRegistration: boolean
+  rateLimitThreshold: number
+}
+
+export type AdminSettingsUpdate = Partial<AdminSettings>
+
+const DEFAULT_SETTINGS: AdminSettings = {
+  maintenanceMode: false,
+  enableRegistration: true,
+  rateLimitThreshold: 100,
+}
+
+const SETTINGS_ROW_ID = "platform"
+
+let cachedSettings: AdminSettings = { ...DEFAULT_SETTINGS }
+
+/** Reset cache to defaults — for tests only. */
+export function resetAdminSettingsStore(): void {
+  cachedSettings = { ...DEFAULT_SETTINGS }
+}
+
+export function getCachedAdminSettings(): AdminSettings {
+  return { ...cachedSettings }
+}
+
+function mergeSettings(updates: AdminSettingsUpdate): AdminSettings {
+  return {
+    ...cachedSettings,
+    ...(updates.maintenanceMode !== undefined
+      ? { maintenanceMode: updates.maintenanceMode }
+      : {}),
+    ...(updates.enableRegistration !== undefined
+      ? { enableRegistration: updates.enableRegistration }
+      : {}),
+    ...(updates.rateLimitThreshold !== undefined
+      ? { rateLimitThreshold: updates.rateLimitThreshold }
+      : {}),
+  }
+}
+
+/**
+ * Load settings from the database into the cache, falling back to defaults
+ * when the row is missing or the query fails.
+ */
+export async function getAdminSettings(): Promise<AdminSettings> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from("app_settings")
+      .select("maintenance_mode, enable_registration, rate_limit_threshold")
+      .eq("id", SETTINGS_ROW_ID)
+      .maybeSingle()
+
+    if (!error && data) {
+      cachedSettings = {
+        maintenanceMode: Boolean(data.maintenance_mode),
+        enableRegistration: Boolean(data.enable_registration),
+        rateLimitThreshold:
+          Number(data.rate_limit_threshold) || DEFAULT_SETTINGS.rateLimitThreshold,
+      }
+    }
+  } catch {
+    // Keep cached / default values when DB is unavailable
+  }
+
+  return getCachedAdminSettings()
+}
+
+/**
+ * Merge and persist supported settings. Returns the full saved state
+ * (not just the submitted partial body).
+ */
+export async function updateAdminSettings(
+  updates: AdminSettingsUpdate
+): Promise<AdminSettings> {
+  const next = mergeSettings(updates)
+
+  const supabase = await createClient()
+  const { error } = await supabase.from("app_settings").upsert(
+    {
+      id: SETTINGS_ROW_ID,
+      maintenance_mode: next.maintenanceMode,
+      enable_registration: next.enableRegistration,
+      rate_limit_threshold: next.rateLimitThreshold,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  )
+
+  if (error) {
+    throw new Error(`Failed to persist admin settings: ${error.message}`)
+  }
+
+  cachedSettings = next
+  return getCachedAdminSettings()
+}

--- a/client/lib/api/audit.ts
+++ b/client/lib/api/audit.ts
@@ -14,6 +14,7 @@
 export type AuditAction =
   | "payment.create"
   | "payment.refund"
+  | "payment.persistence_failed"
   | "subscription.import"
   | "subscription.delete"
   | "subscription.bulk_delete"
@@ -25,6 +26,8 @@ export type AuditAction =
   | "privacy.settings_update"
   | "account.delete_request"
   | "invoice.upload"
+  | "admin.settings_update"
+  | "admin.users_list"
 
 export interface AuditEvent {
   /** Opaque user UUID — never email or username */

--- a/client/lib/payment-service.ts
+++ b/client/lib/payment-service.ts
@@ -4,19 +4,45 @@ import { getStripeInstance } from "./stripe-config"
 import { getPayPalService } from "./paypal-service"
 import { getPaystackService } from "./paystack-service"
 import { isPaymentProviderEnabled } from "./feature-flags"
+import { emitAuditEvent } from "./api/audit"
+import { logger } from "./logger"
 
 export interface PaymentConfig {
   provider: "stripe" | "paypal" | "mock" | "paystack"
   apiKey?: string
 }
 
+/**
+ * Failure contract (provider success / database failure):
+ *
+ * When the payment provider reports success (or requiresAction) but the local
+ * `payments` row cannot be inserted/updated, we do **not** flip `success` to
+ * false — the charge already happened. Instead we return a degraded result:
+ *   - `success: true` (provider outcome)
+ *   - `persistenceDegraded: true`
+ *   - `needsReconciliation: true`
+ *   - `error` describing the persistence failure
+ *
+ * Callers must surface this to operators/clients and must not treat the
+ * response as fully reconciled. Structured logs + `payment.persistence_failed`
+ * audit events are emitted with `transactionId` and `requestId` so webhooks
+ * or a reconciliation job can repair state.
+ */
 export interface PaymentResult {
   success: boolean
   transactionId: string
   error?: string
   requiresAction?: boolean
   actionUrl?: string
+  /** Provider succeeded but local DB write failed */
+  persistenceDegraded?: boolean
+  /** Caller/ops should enqueue or await webhook reconciliation */
+  needsReconciliation?: boolean
 }
+
+export type PaymentPersistenceResult =
+  | { ok: true }
+  | { ok: false; error: string }
 
 export class PaymentService {
   private provider: string
@@ -63,34 +89,73 @@ export class PaymentService {
         }
       }
 
-      if (result.success && !result.requiresAction) {
-        await this.savePaymentToDatabase({
+      if (result.success || result.requiresAction) {
+        // requiresAction (PayPal/Paystack redirect or pending review) → pending
+        const dbStatus = result.requiresAction ? "pending" : "succeeded"
+
+        const persistence = await this.savePaymentToDatabase({
           amount,
           currency,
-          status: "succeeded",
+          status: dbStatus,
           provider: this.provider,
           transaction_id: result.transactionId,
           metadata,
           user_id: metadata.userId,
           plan_name: metadata.planName,
         })
-      } else if (result.requiresAction) {
-        // Save as pending — user still needs to complete the redirect flow
-        await this.savePaymentToDatabase({
-          amount,
-          currency,
-          status: "pending",
-          provider: this.provider,
-          transaction_id: result.transactionId,
-          metadata,
-          user_id: metadata.userId,
-          plan_name: metadata.planName,
-        })
+
+        if (!persistence.ok) {
+          const requestId =
+            typeof metadata.requestId === "string"
+              ? metadata.requestId
+              : undefined
+
+          logger.error("Payment persistence failed after provider success", {
+            provider: this.provider,
+            transactionId: result.transactionId,
+            requestId: requestId ?? null,
+            userId: metadata.userId ?? null,
+            persistenceError: persistence.error,
+            reconciliation: "enqueued",
+          })
+
+          emitAuditEvent({
+            userId: metadata.userId || "unknown",
+            action: "payment.persistence_failed",
+            resourceType: "payment",
+            resourceId: result.transactionId,
+            metadata: {
+              provider: this.provider,
+              requestId: requestId ?? null,
+              persistenceError: persistence.error,
+              needsReconciliation: true,
+            },
+          })
+
+          // Soft-enqueue: structured log is the reconciliation signal until a
+          // dedicated job worker exists. Webhooks remain the backup path.
+          this.enqueuePaymentReconciliation({
+            transactionId: result.transactionId,
+            provider: this.provider,
+            requestId,
+            userId: metadata.userId,
+            reason: persistence.error,
+          })
+
+          return {
+            ...result,
+            persistenceDegraded: true,
+            needsReconciliation: true,
+            error:
+              persistence.error ||
+              "Payment succeeded with provider but failed to save locally; reconciliation required",
+          }
+        }
       }
 
       return result
     } catch (error) {
-      console.error('[PaymentService] Payment processing error:', error)
+      logger.error("Payment processing error", { err: error })
       return {
         success: false,
         transactionId: "",
@@ -327,10 +392,12 @@ export class PaymentService {
     }
   }
 
-  private async savePaymentToDatabase(paymentData: any) {
+  private async savePaymentToDatabase(
+    paymentData: Record<string, unknown> & { transaction_id: string }
+  ): Promise<PaymentPersistenceResult> {
     try {
       const supabase = await createClient()
-      
+
       // Check if payment already exists (idempotency)
       const { data: existing } = await supabase
         .from("payments")
@@ -339,7 +406,9 @@ export class PaymentService {
         .single()
 
       if (existing) {
-        console.log('[PaymentService] Payment already exists, updating:', paymentData.transaction_id)
+        logger.info("Payment already exists, updating", {
+          transactionId: paymentData.transaction_id,
+        })
         const { error } = await supabase
           .from("payments")
           .update({
@@ -347,18 +416,52 @@ export class PaymentService {
             updated_at: new Date().toISOString(),
           })
           .eq("transaction_id", paymentData.transaction_id)
-        
-        if (error) throw error
+
+        if (error) {
+          return { ok: false, error: `Payment update failed: ${error.message}` }
+        }
       } else {
-        console.log('[PaymentService] Creating new payment record:', paymentData.transaction_id)
+        logger.info("Creating new payment record", {
+          transactionId: paymentData.transaction_id,
+        })
         const { error } = await supabase.from("payments").insert(paymentData)
-        if (error) throw error
+        if (error) {
+          return { ok: false, error: `Payment insert failed: ${error.message}` }
+        }
       }
+
+      return { ok: true }
     } catch (error) {
-      console.error("[PaymentService] Failed to save payment to database:", error)
-      // We don't want to fail the whole payment if only the logging fails.
-      // Webhooks are the reliable source of truth for payment status.
+      const message =
+        error instanceof Error ? error.message : "Unknown persistence error"
+      logger.error("Failed to save payment to database", {
+        err: error,
+        transactionId: paymentData.transaction_id,
+      })
+      return { ok: false, error: message }
     }
+  }
+
+  /**
+   * Soft-enqueue reconciliation work. Until a durable queue exists, this emits
+   * a structured log line that ops/alerting can pick up; webhooks remain the
+   * primary repair path.
+   */
+  private enqueuePaymentReconciliation(job: {
+    transactionId: string
+    provider: string
+    requestId?: string
+    userId?: string
+    reason: string
+  }): void {
+    logger.warn("payment.reconciliation_enqueued", {
+      queue: "payment_reconciliation",
+      transactionId: job.transactionId,
+      provider: job.provider,
+      requestId: job.requestId ?? null,
+      userId: job.userId ?? null,
+      reason: job.reason,
+    })
   }
 
   async refundPayment(transactionId: string): Promise<PaymentResult> {

--- a/supabase/migrations/20260725010000_create_app_settings.sql
+++ b/supabase/migrations/20260725010000_create_app_settings.sql
@@ -1,0 +1,35 @@
+-- Platform-wide admin settings (singleton row)
+CREATE TABLE IF NOT EXISTS public.app_settings (
+  id TEXT PRIMARY KEY DEFAULT 'platform',
+  maintenance_mode BOOLEAN NOT NULL DEFAULT false,
+  enable_registration BOOLEAN NOT NULL DEFAULT true,
+  rate_limit_threshold INTEGER NOT NULL DEFAULT 100 CHECK (rate_limit_threshold > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.app_settings (id)
+VALUES ('platform')
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE public.app_settings ENABLE ROW LEVEL SECURITY;
+
+-- Owners (profiles.role) may read/write platform settings.
+-- API layer still enforces requireRole(['owner']).
+DROP POLICY IF EXISTS "app_settings_owner_all" ON public.app_settings;
+CREATE POLICY "app_settings_owner_all"
+  ON public.app_settings
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role = 'owner'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.role = 'owner'
+    )
+  );


### PR DESCRIPTION
closes #1137 
closes #1138 
closes #1147 
closes #1153


## Summary
Closes four API integrity gaps: offline sync ownership override, non-persisting admin settings, swallowed payment DB failures after provider success, and missing admin audit events.

### Task 1 — Offline sync cannot override `user_id`
- Migrated `POST /api/sync/offline` to `createAuthenticatedApiRoute` + standard `ApiErrors` / success responses.
- Rejects payloads that include protected fields (`user_id`, `id` on create, `created_at`, `updated_at`).
- Assigns server-owned `user_id` **after** client fields on create/update so ownership cannot be smuggled in.
- Regression tests cover create override attempts and auth error conventions.

### Task 2 — Admin settings now persist
- Added canonical store `client/lib/admin-settings-store.ts` backed by `app_settings` (migration included).
- `PUT /api/admin/settings` writes via the store and returns the **saved** full settings object (not just the request body).
- Added `GET` for owners to read persisted settings.
- Owner-only auth tests for success, `401`, and `403`.

### Task 3 — Payment persistence failures are explicit
- Documented failure contract on `PaymentResult`: provider success stays `success: true`, but returns `persistenceDegraded` + `needsReconciliation` instead of silent swallow.
- Emits structured logs + `payment.persistence_failed` audit (transaction ID + request ID).
- Soft-enqueues reconciliation via structured `payment.reconciliation_enqueued` log.
- Payments API surfaces `succeeded_unreconciled` when degraded.
- Tests for insert failure, update failure, and thrown DB errors.

### Task 4 — Privileged admin routes emit audit events
- Settings updates emit `admin.settings_update` with actor ID, route, changed fields, and request ID.
- User-list access emits `admin.users_list` (including auth failure paths that must **not** emit).
- Extended `AuditAction` union accordingly.

## Test plan
- [x] `vitest` offline sync route tests (user_id override rejected)
- [x] `vitest` admin settings persist + owner/unauthorized/forbidden + audit
- [x] `vitest` admin users audit emission / auth failure handling
- [x] `vitest` payment insert/update/throw persistence degradation cases
- [ ] Apply migration `20260725010000_create_app_settings.sql` in a staging DB and verify owner PUT/GET round-trip
- [ ] Manually confirm offline create with forged `user_id` returns `VALIDATION_ERROR`
- [ ] Manually confirm provider-success + forced DB failure returns degraded payment payload