### PR TITLE
fix: refund provider selection, scoped tags, docs links, colon labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,16 +2,16 @@
 name: Bug Report
 about: Report a bug or unexpected behavior in SYNCRO.
 title: "[BUG] "
-labels: ["status/triage", "type/bug"]
+labels: ["status:triage", "type:bug"]
 assignees: ""
 ---
 
 ## Bug Report
 
 ### Taxonomy (For Triagers)
-- **Area:** [e.g., area/client, area/backend, area/contracts, area/supabase, area/sdk, area/shared, area/docs, area/scripts, area/governance, area/ops]
-- **Risk:** [risk/low | risk/medium | risk/high]
-- **Priority:** [priority/P0 | priority/P1 | priority/P2 | priority/P3]
+- **Area:** [e.g., area:frontend, area:backend, area:blockchain, area:data, area:docs, area:ops]
+- **Risk:** [risk:low | risk:medium | risk:high]
+- **Priority:** [priority:p0 | priority:p1 | priority:p2]
 
 ---
 
@@ -38,12 +38,11 @@ What actually happens?
 ---
 
 ### Environment
-- Workspace / Area: [e.g., client, backend, sdk, etc.]
 - OS:
-- Node version:
-- Browser:
+- Browser / Node version:
+- SYNCRO version / commit:
 
 ---
 
 ### Additional Context
-Logs, screenshots, or extra details.
+Logs, screenshots, or related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,16 +2,16 @@
 name: Feature Request
 about: Propose a new feature or enhancement for SYNCRO.
 title: "[FEAT] "
-labels: ["status/triage", "type/feature"]
+labels: ["status:triage", "type:feature"]
 assignees: ""
 ---
 
 ## Feature Request
 
 ### Taxonomy (For Triagers)
-- **Area:** [e.g., area/client, area/backend, area/contracts, area/supabase, area/sdk, area/shared, area/docs, area/scripts, area/governance, area/ops]
-- **Risk:** [risk/low | risk/medium | risk/high]
-- **Priority:** [priority/P0 | priority/P1 | priority/P2 | priority/P3]
+- **Area:** [e.g., area:frontend, area:backend, area:blockchain, area:data, area:docs, area:ops]
+- **Risk:** [risk:low | risk:medium | risk:high]
+- **Priority:** [priority:p0 | priority:p1 | priority:p2]
 
 ---
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,132 +1,136 @@
 # GitHub Issue Labels Taxonomy
-# This file defines the canonical label set for the SYNCRO repository.
-# Format: Array of objects with name, color, and description.
+# Canonical label set for the SYNCRO repository.
+# Style: colon-separated prefixes (area:, priority:, type:, risk:, status:)
+# to match the remote GitHub label convention.
+#
+# Sync with GitHub via: node scripts/check-label-drift.js
+# See docs/label-migration.md for slash → colon rename mapping.
 
-# Area Labels: Map to directory ownership boundaries
-- name: "area/client"
-  color: "0072F5"
-  description: "Issues related to the client application (frontend UI/UX)"
+# Area Labels (aligned with remote repository)
+- name: "area:frontend"
+  color: "0052cc"
+  description: "Frontend UX and behavior"
 
-- name: "area/backend"
-  color: "13C18A"
-  description: "Issues related to the Express/Node API backend"
+- name: "area:client-api"
+  color: "006b75"
+  description: "Next.js API routes and API security"
 
-- name: "area/contracts"
-  color: "7828C8"
-  description: "Issues related to Stellar/Soroban smart contracts"
+- name: "area:backend"
+  color: "b60205"
+  description: "Backend services and platform"
 
-- name: "area/supabase"
-  color: "F5A524"
-  description: "Database migrations, RLS policies, schemas, and seeds"
+- name: "area:blockchain"
+  color: "f9d0c4"
+  description: "Contracts and blockchain integrations"
 
-- name: "area/sdk"
-  color: "000000"
-  description: "Stellar reminder SDK and utility logger modules"
+- name: "area:data"
+  color: "bfd4f2"
+  description: "Database and migrations"
 
-- name: "area/shared"
-  color: "71717A"
-  description: "Shared types and utility code across workspaces"
+- name: "area:docs"
+  color: "c5def5"
+  description: "Documentation quality"
 
-- name: "area/docs"
-  color: "0284C7"
-  description: "Technical documentation, markdown guides, API references"
+- name: "area:governance"
+  color: "e4e669"
+  description: "Process and governance"
 
-- name: "area/scripts"
-  color: "E11D48"
-  description: "Automation, devops tooling, local environment helpers"
+- name: "area:integrations"
+  color: "c2e0c6"
+  description: "Payments and external integrations"
 
-- name: "area/governance"
-  color: "F43F5E"
-  description: "Repository workflows, triage policies, backlog management"
+- name: "area:ops"
+  color: "d4c5f9"
+  description: "Operations and observability"
 
-- name: "area/ops"
-  color: "10B981"
-  description: "CI/CD pipelines, deployment workflows, staging/production environments"
+- name: "area:architecture"
+  color: "5319e7"
+  description: "Architecture and structure"
 
-# Priority Labels
-- name: "priority/P0"
-  color: "E11D48"
-  description: "Critical blocker. Immediate action required. Outages or hotfixes."
+- name: "area:quality"
+  color: "fef2c0"
+  description: "Testing and reliability"
 
-- name: "priority/P1"
-  color: "F97316"
+# Priority Labels (aligned with remote repository)
+- name: "priority:p0"
+  color: "d73a4a"
+  description: "Highest priority. Immediate action required."
+
+- name: "priority:p1"
+  color: "d93f0b"
   description: "High priority. Core backlog items for current milestone."
 
-- name: "priority/P2"
-  color: "EAB308"
-  description: "Medium priority. Standard features and fixes for next milestone."
+- name: "priority:p2"
+  color: "0e8a16"
+  description: "Medium priority. Standard features and fixes."
 
-- name: "priority/P3"
-  color: "3B82F6"
-  description: "Low priority. Non-urgent requests, minor polish, or nice-to-haves."
-
-# Type Labels
-- name: "type/bug"
+# Type Labels (local taxonomy; sync to GitHub via label drift check)
+- name: "type:bug"
   color: "D946EF"
   description: "An unexpected error, failure, or incorrect behavior"
 
-- name: "type/feature"
+- name: "type:feature"
   color: "06B6D4"
   description: "A new feature request or enhancements to existing capabilities"
 
-- name: "type/refactor"
+- name: "type:refactor"
   color: "8B5CF6"
   description: "Structural code changes that improve maintainability without adding features"
 
-- name: "type/chore"
+- name: "type:chore"
   color: "64748B"
   description: "Tooling updates, dependency bumps, or repository maintenance"
 
-- name: "type/security"
+- name: "type:security"
   color: "EF4444"
   description: "Security auditing, vulnerability patching, or access control fixes"
 
-- name: "type/documentation"
+- name: "type:documentation"
   color: "0EA5E9"
   description: "Additions, corrections, or updates to documentation"
 
-- name: "type/performance"
+- name: "type:performance"
   color: "10B981"
   description: "Changes targeting bundle size, response time, or SQL optimization"
 
 # Risk Labels
-- name: "risk/low"
+- name: "risk:low"
   color: "10B981"
   description: "Isolated impact, zero DB migrations, simple validation path"
 
-- name: "risk/medium"
+- name: "risk:medium"
   color: "F59E0B"
   description: "Moderate impact, touches multiple components, API/SDK interface updates"
 
-- name: "risk/high"
+- name: "risk:high"
   color: "EF4444"
   description: "Major impact, database migrations, breaking changes, auth/RLS updates"
 
 # Status Labels
-- name: "status/triage"
+- name: "status:triage"
   color: "EC4899"
   description: "New issue. Awaiting triage and verification."
 
-- name: "status/backlog"
+- name: "status:backlog"
   color: "6366F1"
   description: "Triaged and scheduled. Ready for assignment."
 
-- name: "status/in-progress"
+- name: "status:in-progress"
   color: "0EA5E9"
   description: "Active development currently underway"
 
-- name: "status/in-review"
+- name: "status:in-review"
   color: "8B5CF6"
   description: "Development complete. Pull request awaiting approval."
 
-- name: "status/blocked"
+- name: "status:blocked"
   color: "F43F5E"
   description: "Development stalled due to external dependency or dependency task"
 
-- name: "status/wontfix"
+- name: "status:wontfix"
   color: "94A3B8"
   description: "Rejected, duplicate, out-of-scope, or resolved by other means"
 
-- name: "status/done"
+- name: "status:done"
   color: "10B981"
   description: "Fully completed and merged"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,12 @@ jobs:
       - name: Run governance unit tests
         run: node --test scripts/check-issue-governance.test.js
 
+      - name: Check label drift against GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/check-label-drift.js
+
       - name: Validate CONTRIBUTING.md onboarding guide
         run: node scripts/check-contributing.js
 

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,9 +3,13 @@ name: Validate Documentation Samples
 on:
   pull_request:
     paths:
+      - 'README.md'
+      - 'docs/**'
       - 'sdk/README.md'
       - 'backend/README.md'
       - 'backend/SUBSCRIPTION_API.md'
+      - 'scripts/validate-docs.js'
+      - 'scripts/validate-docs.test.js'
       - '.github/workflows/validate-docs.yml'
   workflow_dispatch:
 
@@ -28,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Reject absolute file:// documentation links
+        run: node --test scripts/validate-docs.test.js
+
       - name: Run doc validation
         run: node scripts/validate-docs.js
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ See [contracts/README.md](./contracts/README.md) for Stellar CLI setup.
 node scripts/check-env-docs.js
 node scripts/check-contributing.js
 node scripts/check-issue-governance.js
+node scripts/check-label-drift.js
 ```
 
 ## Database and migrations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Synchro is a decentralized, self-custodial subscription management platform that
 - **Smart Contracts**: Functional Soroban contracts for subscription renewal, escrow, and virtual card interaction on Stellar Testnet.
 - **Overall**: Core MVP functionality is **90% complete** and undergoing final production hardening.
 
-For detailed status, see [./docs/archive/CurrentState.md](file:///c:/Users/HP/Desktop/SYNCRO/./docs/archive/CurrentState.md).
+For detailed status, see [docs/archive/CurrentState.md](./docs/archive/CurrentState.md).
 
 ## Phase 1 (MVP) Workflow
 Supported Payment Method

--- a/client/app/api/payments/refund/__tests__/route.test.ts
+++ b/client/app/api/payments/refund/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { POST } from "../route"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/api/auth"
+import { NextRequest } from "next/server"
+import { mockSupabaseClient } from "@/lib/test-utils/mocks"
+import { PaymentService } from "@/lib/payment-service"
+import { resetRateLimitStore } from "@/lib/api/rate-limit"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock("@/lib/api/auth", () => ({
+  requireAuth: vi.fn(),
+  createRequestContext: vi.fn().mockReturnValue({ requestId: "test-id" }),
+}))
+
+vi.mock("@/lib/payment-service", () => ({
+  PaymentService: vi.fn(),
+}))
+
+vi.mock("@/lib/api/audit", () => ({
+  emitAuditEvent: vi.fn(),
+}))
+
+describe("POST /api/payments/refund", () => {
+  let supabase: ReturnType<typeof mockSupabaseClient>
+  let mockPaymentService: { refundPayment: ReturnType<typeof vi.fn> }
+  const mockUser = { id: "user_123", email: "test@example.com" }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRateLimitStore()
+    supabase = mockSupabaseClient()
+    vi.mocked(createClient).mockResolvedValue(supabase as never)
+    vi.mocked(requireAuth).mockResolvedValue(mockUser as never)
+
+    // Idempotency check: no cached response
+    supabase.single.mockResolvedValue({
+      data: null,
+      error: { code: "PGRST116", message: "No rows found" },
+    })
+
+    mockPaymentService = {
+      refundPayment: vi.fn().mockResolvedValue({
+        success: true,
+        transactionId: "re_123",
+      }),
+    }
+    vi.mocked(PaymentService).mockImplementation(function (this: unknown) {
+      return mockPaymentService
+    } as never)
+  })
+
+  function refundRequest(transactionId: string) {
+    return new NextRequest("http://localhost/api/payments/refund", {
+      method: "POST",
+      body: JSON.stringify({ transactionId }),
+    })
+  }
+
+  function mockPaymentRecord(overrides: {
+    user_id?: string
+    status?: string
+    provider?: string
+  } = {}) {
+    // First single(): idempotency miss; second: payment lookup
+    supabase.single
+      .mockResolvedValueOnce({
+        data: null,
+        error: { code: "PGRST116", message: "No rows found" },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          user_id: overrides.user_id ?? "user_123",
+          status: overrides.status ?? "succeeded",
+          provider: overrides.provider ?? "stripe",
+        },
+        error: null,
+      })
+  }
+
+  it("refunds a Stripe payment using the provider from the payment record", async () => {
+    mockPaymentRecord({ provider: "stripe" })
+
+    const response = await POST(refundRequest("pi_stripe_1"))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.refundId).toBe("re_123")
+    expect(PaymentService).toHaveBeenCalledWith({ provider: "stripe" })
+    expect(mockPaymentService.refundPayment).toHaveBeenCalledWith("pi_stripe_1")
+  })
+
+  it("refunds a PayPal payment using the provider from the payment record", async () => {
+    mockPaymentRecord({ provider: "paypal" })
+    mockPaymentService.refundPayment.mockResolvedValue({
+      success: true,
+      transactionId: "paypal_refund_1",
+    })
+
+    const response = await POST(refundRequest("CAPTURE_1"))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.refundId).toBe("paypal_refund_1")
+    expect(PaymentService).toHaveBeenCalledWith({ provider: "paypal" })
+    expect(mockPaymentService.refundPayment).toHaveBeenCalledWith("CAPTURE_1")
+  })
+
+  it("rejects Paystack payments that require manual refunds", async () => {
+    mockPaymentRecord({ provider: "paystack" })
+
+    const response = await POST(refundRequest("psk_txn_1"))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+    expect(body.error.message).toMatch(/Paystack refunds must be processed manually/i)
+    expect(PaymentService).not.toHaveBeenCalled()
+  })
+
+  it("rejects unknown payment providers with a validation error", async () => {
+    mockPaymentRecord({ provider: "crypto-wallet" })
+
+    const response = await POST(refundRequest("txn_unknown"))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.code).toBe("VALIDATION_ERROR")
+    expect(body.error.message).toMatch(/not supported for payment provider/i)
+    expect(PaymentService).not.toHaveBeenCalled()
+  })
+
+  it("rejects refunds for payments owned by another user", async () => {
+    mockPaymentRecord({ user_id: "other_user", provider: "stripe" })
+
+    const response = await POST(refundRequest("pi_other"))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(PaymentService).not.toHaveBeenCalled()
+    expect(body.error).toBeDefined()
+  })
+
+  it("rejects already-refunded payments", async () => {
+    mockPaymentRecord({ status: "refunded", provider: "stripe" })
+
+    const response = await POST(refundRequest("pi_refunded"))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error.message).toMatch(/already been refunded/i)
+    expect(PaymentService).not.toHaveBeenCalled()
+  })
+})

--- a/client/app/api/payments/refund/route.ts
+++ b/client/app/api/payments/refund/route.ts
@@ -5,14 +5,33 @@ import { z } from "zod"
 import { PaymentService } from "@/lib/payment-service"
 import { createClient } from "@/lib/supabase/server"
 
-// Validation schema
 const refundSchema = z.object({
   transactionId: z.string().min(1, "Transaction ID is required"),
 })
 
+/** Providers that support programmatic refunds via PaymentService. */
+const REFUNDABLE_PROVIDERS = new Set(["stripe", "paypal", "mock"] as const)
+
+type RefundableProvider = "stripe" | "paypal" | "mock"
+
+function assertRefundableProvider(provider: string): asserts provider is RefundableProvider {
+  if (provider === "paystack") {
+    throw ApiErrors.validationError(
+      "Paystack refunds must be processed manually via the Paystack dashboard",
+      "provider",
+    )
+  }
+
+  if (!REFUNDABLE_PROVIDERS.has(provider as RefundableProvider)) {
+    throw ApiErrors.validationError(
+      `Refunds are not supported for payment provider '${provider}'`,
+      "provider",
+    )
+  }
+}
+
 export const POST = createAuthenticatedApiRoute(
   async (request: NextRequest, context, user) => {
-    // Validate request body
     const body = await validateRequestBody(request, refundSchema)
 
     const supabase = await createClient()
@@ -20,7 +39,7 @@ export const POST = createAuthenticatedApiRoute(
     // Verify payment ownership before refunding
     const { data: payment, error: paymentError } = await supabase
       .from("payments")
-      .select("user_id, status")
+      .select("user_id, status, provider")
       .eq("transaction_id", body.transactionId)
       .single()
 
@@ -36,9 +55,10 @@ export const POST = createAuthenticatedApiRoute(
       throw ApiErrors.validationError("Payment has already been refunded")
     }
 
-    const paymentService = new PaymentService({
-      provider: "stripe", // For now, assume Stripe
-    })
+    const provider = typeof payment.provider === "string" ? payment.provider : ""
+    assertRefundableProvider(provider)
+
+    const paymentService = new PaymentService({ provider })
 
     const result = await paymentService.refundPayment(body.transactionId)
 

--- a/client/app/api/subscriptions/[id]/tags/[tagId]/route.ts
+++ b/client/app/api/subscriptions/[id]/tags/[tagId]/route.ts
@@ -1,8 +1,7 @@
 import { type NextRequest } from "next/server"
-import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { removeTagFromSubscription } from "@/lib/supabase/tags"
-import { createClient } from "@/lib/supabase/server"
 
 export async function DELETE(
   request: NextRequest,
@@ -12,23 +11,18 @@ export async function DELETE(
 
   return createAuthenticatedApiRoute(
     async (_req, context, user) => {
-      const supabase = await createClient()
-
-      // Verify subscription ownership
-      const { data: subscription, error: subError } = await supabase
-        .from("subscriptions")
-        .select("user_id")
-        .eq("id", id)
-        .single()
-
-      if (subError || !subscription) {
-        throw ApiErrors.notFound("Subscription")
+      try {
+        await removeTagFromSubscription(user.id, id, tagId)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to remove tag"
+        if (message.includes("not found")) {
+          throw ApiErrors.notFound(message.includes("Tag") ? "Tag" : "Subscription")
+        }
+        if (message.includes("does not belong")) {
+          throw ApiErrors.forbidden(message)
+        }
+        throw err
       }
-
-      checkOwnership(user.id, subscription.user_id)
-
-      // Proceed with tag removal
-      await removeTagFromSubscription(id, tagId)
 
       return createSuccessResponse({ removed: true }, HttpStatus.OK, context.requestId)
     },

--- a/client/app/api/subscriptions/[id]/tags/route.ts
+++ b/client/app/api/subscriptions/[id]/tags/route.ts
@@ -1,9 +1,8 @@
 import { type NextRequest } from "next/server"
-import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors, checkOwnership } from "@/lib/api/index"
+import { createAuthenticatedApiRoute, createSuccessResponse, validateRequestBody, RateLimiters, ApiErrors } from "@/lib/api/index"
 import { HttpStatus } from "@/lib/api/types"
 import { z } from "zod"
 import { addTagToSubscription } from "@/lib/supabase/tags"
-import { createClient } from "@/lib/supabase/server"
 
 const bodySchema = z.object({
   tag_id: z.string().uuid(),
@@ -19,36 +18,18 @@ export async function POST(
     async (_req, context, user) => {
       const { tag_id } = await validateRequestBody(request, bodySchema)
 
-      const supabase = await createClient()
-
-      // Verify subscription ownership
-      const { data: subscription, error: subError } = await supabase
-        .from("subscriptions")
-        .select("user_id")
-        .eq("id", id)
-        .single()
-
-      if (subError || !subscription) {
-        throw ApiErrors.notFound("Subscription")
+      try {
+        await addTagToSubscription(user.id, id, tag_id)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to assign tag"
+        if (message.includes("not found")) {
+          throw ApiErrors.notFound(message.includes("Tag") ? "Tag" : "Subscription")
+        }
+        if (message.includes("does not belong")) {
+          throw ApiErrors.forbidden(message)
+        }
+        throw err
       }
-
-      checkOwnership(user.id, subscription.user_id)
-
-      // Verify tag ownership
-      const { data: tag, error: tagError } = await supabase
-        .from("subscription_tags")
-        .select("user_id")
-        .eq("id", tag_id)
-        .single()
-
-      if (tagError || !tag) {
-        throw ApiErrors.notFound("Tag")
-      }
-
-      checkOwnership(user.id, tag.user_id)
-
-      // Proceed with assignment
-      await addTagToSubscription(id, tag_id)
 
       return createSuccessResponse({ assigned: true }, HttpStatus.OK, context.requestId)
     },

--- a/client/lib/supabase/__tests__/tags.test.ts
+++ b/client/lib/supabase/__tests__/tags.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  addTagToSubscription,
+  removeTagFromSubscription,
+} from "../tags"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+import { createClient } from "@/lib/supabase/server"
+
+describe("subscription tag helpers (user-scoped)", () => {
+  const userId = "user-owner"
+  const otherUserId = "user-other"
+  const subscriptionId = "sub-1"
+  const tagId = "tag-1"
+
+  let fromMock: ReturnType<typeof vi.fn>
+  let upsertMock: ReturnType<typeof vi.fn>
+  let deleteMock: ReturnType<typeof vi.fn>
+
+  function chainFor(result: { data: unknown; error: unknown }) {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    const methods = ["select", "eq", "upsert", "delete", "insert", "update", "order"]
+    for (const m of methods) {
+      chain[m] = vi.fn().mockReturnValue(chain)
+    }
+    chain.single = vi.fn().mockResolvedValue(result)
+    chain.upsert = upsertMock.mockResolvedValue({ error: null })
+    chain.delete = deleteMock.mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    })
+    return chain
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    upsertMock = vi.fn().mockResolvedValue({ error: null })
+    deleteMock = vi.fn()
+    fromMock = vi.fn()
+
+    vi.mocked(createClient).mockResolvedValue({
+      from: fromMock,
+    } as never)
+  })
+
+  function mockOwnedResources() {
+    // First from: subscriptions, second: subscription_tags, third: assignments
+    const subChain = chainFor({ data: { user_id: userId }, error: null })
+    const tagChain = chainFor({ data: { user_id: userId }, error: null })
+    const assignChain = chainFor({ data: null, error: null })
+    assignChain.upsert = upsertMock
+    assignChain.delete = deleteMock.mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    })
+
+    fromMock
+      .mockReturnValueOnce(subChain)
+      .mockReturnValueOnce(tagChain)
+      .mockReturnValueOnce(assignChain)
+
+    return { subChain, tagChain, assignChain }
+  }
+
+  it("addTagToSubscription assigns when subscription and tag belong to user", async () => {
+    mockOwnedResources()
+
+    await expect(
+      addTagToSubscription(userId, subscriptionId, tagId),
+    ).resolves.toBeUndefined()
+
+    expect(upsertMock).toHaveBeenCalledWith({
+      subscription_id: subscriptionId,
+      tag_id: tagId,
+    })
+  })
+
+  it("addTagToSubscription rejects cross-user subscription", async () => {
+    const subChain = chainFor({ data: { user_id: otherUserId }, error: null })
+    fromMock.mockReturnValueOnce(subChain)
+
+    await expect(
+      addTagToSubscription(userId, subscriptionId, tagId),
+    ).rejects.toThrow(/Subscription does not belong to user/)
+
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+
+  it("addTagToSubscription rejects cross-user tag", async () => {
+    const subChain = chainFor({ data: { user_id: userId }, error: null })
+    const tagChain = chainFor({ data: { user_id: otherUserId }, error: null })
+    fromMock.mockReturnValueOnce(subChain).mockReturnValueOnce(tagChain)
+
+    await expect(
+      addTagToSubscription(userId, subscriptionId, tagId),
+    ).rejects.toThrow(/Tag does not belong to user/)
+
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+
+  it("removeTagFromSubscription removes when subscription and tag belong to user", async () => {
+    mockOwnedResources()
+
+    await expect(
+      removeTagFromSubscription(userId, subscriptionId, tagId),
+    ).resolves.toBeUndefined()
+
+    expect(deleteMock).toHaveBeenCalled()
+  })
+
+  it("removeTagFromSubscription rejects cross-user subscription", async () => {
+    const subChain = chainFor({ data: { user_id: otherUserId }, error: null })
+    fromMock.mockReturnValueOnce(subChain)
+
+    await expect(
+      removeTagFromSubscription(userId, subscriptionId, tagId),
+    ).rejects.toThrow(/Subscription does not belong to user/)
+
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+
+  it("removeTagFromSubscription rejects cross-user tag", async () => {
+    const subChain = chainFor({ data: { user_id: userId }, error: null })
+    const tagChain = chainFor({ data: { user_id: otherUserId }, error: null })
+    fromMock.mockReturnValueOnce(subChain).mockReturnValueOnce(tagChain)
+
+    await expect(
+      removeTagFromSubscription(userId, subscriptionId, tagId),
+    ).rejects.toThrow(/Tag does not belong to user/)
+
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+})

--- a/client/lib/supabase/tags.ts
+++ b/client/lib/supabase/tags.ts
@@ -69,11 +69,57 @@ export async function getSubscriptionTagIds(
   return (data ?? []).map((r: { tag_id: string }) => r.tag_id)
 }
 
-/** Assign a tag to a subscription. Idempotent (upsert). */
-export async function addTagToSubscription(
+/**
+ * Verify the subscription and tag both belong to userId.
+ * Throws if either resource is missing or owned by another user.
+ */
+async function assertSubscriptionAndTagOwnership(
+  userId: string,
   subscriptionId: string,
   tagId: string,
 ): Promise<void> {
+  const supabase = await createClient()
+
+  const { data: subscription, error: subError } = await supabase
+    .from("subscriptions")
+    .select("user_id")
+    .eq("id", subscriptionId)
+    .single()
+
+  if (subError || !subscription) {
+    throw new Error("Subscription not found")
+  }
+
+  if (subscription.user_id !== userId) {
+    throw new Error("Subscription does not belong to user")
+  }
+
+  const { data: tag, error: tagError } = await supabase
+    .from("subscription_tags")
+    .select("user_id")
+    .eq("id", tagId)
+    .single()
+
+  if (tagError || !tag) {
+    throw new Error("Tag not found")
+  }
+
+  if (tag.user_id !== userId) {
+    throw new Error("Tag does not belong to user")
+  }
+}
+
+/**
+ * Assign a tag to a subscription. Idempotent (upsert).
+ * Requires userId and verifies both subscription and tag ownership.
+ */
+export async function addTagToSubscription(
+  userId: string,
+  subscriptionId: string,
+  tagId: string,
+): Promise<void> {
+  await assertSubscriptionAndTagOwnership(userId, subscriptionId, tagId)
+
   const supabase = await createClient()
   const { error } = await supabase
     .from("subscription_tag_assignments")
@@ -82,11 +128,17 @@ export async function addTagToSubscription(
   if (error) throw new Error(`Failed to assign tag: ${error.message}`)
 }
 
-/** Remove a tag from a subscription. */
+/**
+ * Remove a tag from a subscription.
+ * Requires userId and verifies both subscription and tag ownership.
+ */
 export async function removeTagFromSubscription(
+  userId: string,
   subscriptionId: string,
   tagId: string,
 ): Promise<void> {
+  await assertSubscriptionAndTagOwnership(userId, subscriptionId, tagId)
+
   const supabase = await createClient()
   const { error } = await supabase
     .from("subscription_tag_assignments")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,10 +44,10 @@ Hardening threads required before public MVP launch.
 
 | Cluster | Representative issues | Area labels | Target |
 |---------|----------------------|-------------|--------|
-| **Payments & webhooks** | #496 (PayPal stub), Stripe/Paystack webhook hardening | `area/client`, `area/backend` | E3 |
-| **Bundle & performance** | [#697](https://github.com/Calebux/SYNCRO/issues/697) bundle budgets, #698 Redis API latency storage | `area/client`, `area/backend` | E4 |
-| **Integrations** | #494 (DB-backed suggestions), Telegram bot enrichment, email parsing | `area/backend`, `area/client` | E2 |
-| **Tech debt governance** | [#120](https://github.com/Calebux/SYNCRO/issues/120) roadmap, DEBT.md policy | `area/governance` | E5 |
+| **Payments & webhooks** | #496 (PayPal stub), Stripe/Paystack webhook hardening | `area:frontend`, `area:backend` | E3 |
+| **Bundle & performance** | [#697](https://github.com/Calebux/SYNCRO/issues/697) bundle budgets, #698 Redis API latency storage | `area:frontend`, `area:backend` | E4 |
+| **Integrations** | #494 (DB-backed suggestions), Telegram bot enrichment, email parsing | `area:backend`, `area:frontend` | E2 |
+| **Tech debt governance** | [#120](https://github.com/Calebux/SYNCRO/issues/120) roadmap, DEBT.md policy | `area:governance` | E5 |
 
 ### M3 — MVP launch 🎯
 
@@ -83,7 +83,7 @@ Use these for context when grooming new work — patterns and resolutions are do
 ## How to use this roadmap
 
 1. **Weekly grooming** — Pull the next open item from M2/M3 into sprint; confirm it maps to an exit criterion (E1–E7).
-2. **New issues** — Tag with `area/`, `priority/`, and link the milestone (M2/M3) in the issue body.
+2. **New issues** — Tag with `area:`, `priority:`, and link the milestone (M2/M3) in the issue body. See [label-migration.md](./label-migration.md).
 3. **Closing MVP** — When E1–E7 are all green, open a release issue, run smoke tests, and update [CurrentState.md](./archive/CurrentState.md).
 
 **Related docs:** [DEBT.md](../DEBT.md) · [issue-triage-policy.md](./issue-triage-policy.md) · [branch-protection.md](./branch-protection.md)

--- a/docs/issue-triage-policy.md
+++ b/docs/issue-triage-policy.md
@@ -6,36 +6,36 @@ This document defines the policy, workflows, and responsibilities for managing t
 
 ## 1. Issue Taxonomy Reference
 
-All issues must be labeled according to the categories defined in [.github/labels.yml](file:///C:/Users/fuhad/SYNCRO/.github/labels.yml):
+All issues must be labeled according to the categories defined in [`.github/labels.yml`](../.github/labels.yml):
 
 | Category | Label Prefix | Purpose |
 | :--- | :--- | :--- |
-| **Area** | `area/` | Maps the issue to code ownership boundaries (e.g., `client`, `backend`, `contracts`). |
-| **Priority** | `priority/` | Defines the urgency and scheduling target (`P0` to `P3`). |
-| **Type** | `type/` | Indicates the kind of work (e.g., `bug`, `feature`, `refactor`, `security`). |
-| **Risk** | `risk/` | Evaluates the blast radius and testing complexity (`low`, `medium`, `high`). |
-| **Status** | `status/` | Tracks the lifecycle of the issue (`triage`, `backlog`, `in-progress`, etc.). |
+| **Area** | `area:` | Maps the issue to ownership boundaries (e.g., `area:frontend`, `area:backend`). |
+| **Priority** | `priority:` | Defines urgency (`priority:p0` to `priority:p2`). |
+| **Type** | `type:` | Kind of work (e.g., `type:bug`, `type:feature`). |
+| **Risk** | `risk:` | Blast radius (`risk:low`, `risk:medium`, `risk:high`). |
+| **Status** | `status:` | Lifecycle (`status:triage`, `status:backlog`, `status:in-progress`, etc.). |
 
 ---
 
 ## 2. Intake expectations
 
 ### Submission
-- All new issues must use the official issue templates defined in [.github/ISSUE_TEMPLATE/](file:///C:/Users/fuhad/SYNCRO/.github/ISSUE_TEMPLATE/).
-- New issues are automatically assigned the `status/triage` label upon creation.
+- All new issues must use the official issue templates defined in [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/).
+- New issues are automatically assigned the `status:triage` label upon creation.
 
 ### Initial Triage Workflow
 - **Frequency:** The triage team reviews new issues daily.
-- **Verification:** For bug reports, the triager must verify the reproduction steps. If the issue is incomplete, they should request clarification and mark the issue as `status/blocked`.
+- **Verification:** For bug reports, the triager must verify the reproduction steps. If the issue is incomplete, they should request clarification and mark the issue as `status:blocked`.
 - **Classification:** Every triaged issue must have at least one label from each of the following groups before entering the backlog:
-  - `area/` (matching the code ownership boundaries)
-  - `priority/` (based on urgency)
-  - `type/` (based on classification)
-  - `risk/` (based on blast radius)
+  - `area:` (matching the code ownership boundaries)
+  - `priority:` (based on urgency)
+  - `type:` (based on classification)
+  - `risk:` (based on blast radius)
 - **Response Targets (SLAs):**
-  - **Priority P0:** Must be triaged within **2 hours** of submission.
-  - **Priority P1:** Must be triaged within **12 hours** of submission.
-  - **Other Priorities:** Must be triaged within **48 hours** of submission.
+  - **priority:p0:** Must be triaged within **2 hours** of submission.
+  - **priority:p1:** Must be triaged within **12 hours** of submission.
+  - **Other priorities:** Must be triaged within **48 hours** of submission.
 
 ---
 
@@ -45,17 +45,17 @@ Backlog grooming ensures that the backlog remains relevant, prioritized, and act
 
 ### Grooming Cadence
 - **Weekly Grooming Session:** The product owners, tech leads, and maintainers meet weekly to groom the backlog.
-- **Bi-weekly Sprint Planning:** Prioritized tasks are pulled from `status/backlog` into active sprints.
+- **Bi-weekly Sprint Planning:** Prioritized tasks are pulled from `status:backlog` into active sprints.
 
 ### Definition of Ready (DoR)
-Before an issue is moved from `status/backlog` to `status/in-progress` (ready for assignment), it must satisfy the following criteria:
+Before an issue is moved from `status:backlog` to `status:in-progress` (ready for assignment), it must satisfy the following criteria:
 1. **Clear Scope:** The description clearly details the problem and expected behavior.
 2. **Acceptance Criteria:** A checklist of functional and non-functional requirements.
 3. **Labels Applied:** Complete taxonomy categorization.
 4. **No Blockers:** The issue is not blocked by other unresolved issues.
 
 ### Re-evaluation and Risk Management
-- If an issue is classified as `risk/high`, it requires:
+- If an issue is classified as `risk:high`, it requires:
   - Architectural review by the primary owner before development starts.
   - A designated test plan in the acceptance criteria.
 - If an issue spans multiple code ownership areas, co-owners must be tagged in the description to coordinate review requirements.
@@ -69,18 +69,18 @@ Issues must follow a formal closure process to guarantee quality control and mai
 ### Criteria for Closure
 An issue can be closed under the following conditions:
 1. **PR Merged:** A pull request addressing the issue has been successfully reviewed, approved, and merged to the main branch. The PR description must link back to the issue using standard keywords (e.g., `Closes #114`).
-2. **Duplicate:** The issue is a duplicate of an existing issue. It must be linked, labeled `status/wontfix`, and closed.
-3. **Out of Scope/Wontfix:** The issue is rejected by maintainers. A comment explaining the reasoning must be posted, the issue labeled `status/wontfix`, and closed.
+2. **Duplicate:** The issue is a duplicate of an existing issue. It must be linked, labeled `status:wontfix`, and closed.
+3. **Out of Scope/Wontfix:** The issue is rejected by maintainers. A comment explaining the reasoning must be posted, the issue labeled `status:wontfix`, and closed.
 
 ### Stale Issue Management
 - Issues with no activity (comments, edits, or assignments) for **60 days** will be marked as stale with a warning comment.
-- If no activity occurs for another **14 days**, the issue will be closed with `status/wontfix`.
+- If no activity occurs for another **14 days**, the issue will be closed with `status:wontfix`.
 
 ### Long-form Implementation Artifacts
-- As outlined in [CONTRIBUTING.md](file:///C:/Users/fuhad/SYNCRO/CONTRIBUTING.md#L195-L197), all long-form implementation artifacts, summaries, or delivery notes must be stored in the `docs/archive/` directory rather than the repository root. This ensures that active project entrypoints remain clean.
+- As outlined in [CONTRIBUTING.md](../CONTRIBUTING.md), all long-form implementation artifacts, summaries, or delivery notes must be stored in the `docs/archive/` directory rather than the repository root. This ensures that active project entrypoints remain clean.
 
 ---
 
 ## 5. Contact and Escalation
 
-For questions about this policy or to request expedited triage of a blocker, contact the DevOps team or ping the maintainers (see [.github/CODEOWNERS](file:///C:/Users/fuhad/SYNCRO/.github/CODEOWNERS)).
+For questions about this policy or to request expedited triage of a blocker, contact the DevOps team or ping the maintainers (see [`.github/CODEOWNERS`](../.github/CODEOWNERS)).

--- a/docs/label-migration.md
+++ b/docs/label-migration.md
@@ -1,0 +1,64 @@
+# Label Taxonomy Migration (slash → colon)
+
+## Decision
+
+**Colon-style labels are canonical** (e.g. `area:frontend`, `priority:p1`).
+
+This matches the labels already present on the GitHub remote. Local
+`.github/labels.yml`, triage docs, and issue templates previously used
+slash-style names (`area/client`, `priority/P1`) and are updated to colon-style.
+
+## Mapping
+
+| Old (slash) | New (colon) | Notes |
+| :--- | :--- | :--- |
+| `area/client` | `area:frontend` | UI work; API routes use `area:client-api` |
+| `area/backend` | `area:backend` | |
+| `area/contracts` | `area:blockchain` | |
+| `area/supabase` | `area:data` | |
+| `area/sdk` | `area:integrations` | Shared SDK / external tooling |
+| `area/shared` | `area:architecture` | Cross-cutting shared code |
+| `area/docs` | `area:docs` | |
+| `area/scripts` | `area:ops` | |
+| `area/governance` | `area:governance` | |
+| `area/ops` | `area:ops` | |
+| `priority/P0` | `priority:p0` | |
+| `priority/P1` | `priority:p1` | |
+| `priority/P2` | `priority:p2` | |
+| `priority/P3` | `priority:p2` | No remote `p3`; treat as medium |
+| `type/bug` | `type:bug` | Create on GitHub if missing |
+| `type/feature` | `type:feature` | |
+| `type/refactor` | `type:refactor` | |
+| `type/chore` | `type:chore` | |
+| `type/security` | `type:security` | |
+| `type/documentation` | `type:documentation` | |
+| `type/performance` | `type:performance` | |
+| `risk/low` | `risk:low` | |
+| `risk/medium` | `risk:medium` | |
+| `risk/high` | `risk:high` | |
+| `status/triage` | `status:triage` | |
+| `status/backlog` | `status:backlog` | |
+| `status/in-progress` | `status:in-progress` | |
+| `status/in-review` | `status:in-review` | |
+| `status/blocked` | `status:blocked` | |
+| `status/wontfix` | `status:wontfix` | |
+| `status/done` | `status:done` | |
+
+## Migrating existing issues
+
+1. Create any missing colon-style labels from `.github/labels.yml` (GitHub UI, or a sync action).
+2. For open issues still on slash-style labels, retag using the mapping above.
+3. Optionally delete obsolete slash-style labels after all open issues are migrated.
+4. Run drift check:
+
+```bash
+node scripts/check-label-drift.js
+# Fail CI when local labels are missing remotely:
+GITHUB_TOKEN=... node scripts/check-label-drift.js --strict
+```
+
+5. Confirm governance still passes:
+
+```bash
+node scripts/check-issue-governance.js
+```

--- a/scripts/check-issue-governance.js
+++ b/scripts/check-issue-governance.js
@@ -7,49 +7,49 @@
  * Usage: node scripts/check-issue-governance.js
  * Exit code: 0 if valid, 1 if invalid
  */
-
 const fs = require('fs');
 const path = require('path');
 
 const REPO_ROOT = path.join(__dirname, '..');
 
+/** Canonical colon-style labels (must match .github/labels.yml). */
 const EXPECTED_LABELS = [
-  // Areas
-  'area/client',
-  'area/backend',
-  'area/contracts',
-  'area/supabase',
-  'area/sdk',
-  'area/shared',
-  'area/docs',
-  'area/scripts',
-  'area/governance',
-  'area/ops',
+  // Areas (aligned with remote GitHub)
+  'area:frontend',
+  'area:client-api',
+  'area:backend',
+  'area:blockchain',
+  'area:data',
+  'area:docs',
+  'area:governance',
+  'area:integrations',
+  'area:ops',
+  'area:architecture',
+  'area:quality',
   // Priorities
-  'priority/P0',
-  'priority/P1',
-  'priority/P2',
-  'priority/P3',
+  'priority:p0',
+  'priority:p1',
+  'priority:p2',
   // Types
-  'type/bug',
-  'type/feature',
-  'type/refactor',
-  'type/chore',
-  'type/security',
-  'type/documentation',
-  'type/performance',
+  'type:bug',
+  'type:feature',
+  'type:refactor',
+  'type:chore',
+  'type:security',
+  'type:documentation',
+  'type:performance',
   // Risks
-  'risk/low',
-  'risk/medium',
-  'risk/high',
+  'risk:low',
+  'risk:medium',
+  'risk:high',
   // Statuses
-  'status/triage',
-  'status/backlog',
-  'status/in-progress',
-  'status/in-review',
-  'status/blocked',
-  'status/wontfix',
-  'status/done'
+  'status:triage',
+  'status:backlog',
+  'status:in-progress',
+  'status:in-review',
+  'status:blocked',
+  'status:wontfix',
+  'status:done'
 ];
 
 function parseLabelsYaml(content) {
@@ -61,7 +61,6 @@ function parseLabelsYaml(content) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
 
-    // Handle YAML sequence item
     if (trimmed.startsWith('- name:')) {
       if (currentLabel) {
         labels.push(currentLabel);
@@ -116,6 +115,11 @@ function checkLabels() {
         errors.push('Found label entry with invalid or empty name');
         continue;
       }
+      if (parsedLabel.name.includes('/')) {
+        errors.push(
+          `Label "${parsedLabel.name}" uses slash-style; canonical style is colon (e.g. area:frontend)`
+        );
+      }
       if (!parsedLabel.color) {
         errors.push(`Label "${parsedLabel.name}" is missing a color definition`);
       }
@@ -141,7 +145,6 @@ function checkTriagePolicy() {
   try {
     const content = fs.readFileSync(policyPath, 'utf8');
 
-    // Check key requirements
     const requiredPhrases = [
       'intake',
       'grooming',
@@ -154,6 +157,14 @@ function checkTriagePolicy() {
       if (!content.toLowerCase().includes(phrase.toLowerCase())) {
         errors.push(`Triage policy lacks mention of "${phrase}"`);
       }
+    }
+
+    if (content.includes('file://')) {
+      errors.push('Triage policy must not contain absolute file:// links');
+    }
+
+    if (content.includes('area/') || content.includes('priority/P')) {
+      errors.push('Triage policy still references slash-style labels; use colon-style (area:, priority:)');
     }
   } catch (err) {
     errors.push(`Failed to read triage policy: ${err.message}`);
@@ -177,18 +188,20 @@ function checkTemplates() {
     try {
       const content = fs.readFileSync(templatePath, 'utf8');
 
-      // Verify template frontmatter contains status/triage label
-      if (!content.includes('status/triage')) {
-        errors.push(`Template ${template} must specify default status/triage label in frontmatter`);
+      if (!content.includes('status:triage')) {
+        errors.push(`Template ${template} must specify default status:triage label in frontmatter`);
       }
 
-      // Verify references to taxonomy in body
       if (!content.includes('Taxonomy (For Triagers)')) {
         errors.push(`Template ${template} should include the "Taxonomy (For Triagers)" checklist section`);
       }
 
       if (!content.includes('Area:') || !content.includes('Priority:') || !content.includes('Risk:')) {
         errors.push(`Template ${template} must prompt for Area, Priority, and Risk`);
+      }
+
+      if (content.includes('area/') || content.includes('priority/P') || content.includes('status/triage')) {
+        errors.push(`Template ${template} still references slash-style labels; use colon-style`);
       }
     } catch (err) {
       errors.push(`Failed to read template ${template}: ${err.message}`);

--- a/scripts/check-issue-governance.test.js
+++ b/scripts/check-issue-governance.test.js
@@ -2,8 +2,6 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
 
 const {
   EXPECTED_LABELS,
@@ -18,23 +16,23 @@ describe('check-issue-governance', () => {
     it('correctly parses a formatted list of labels', () => {
       const yaml = `
 # Some comments
-- name: "area/test"
+- name: "area:frontend"
   color: "123456"
   description: "Test description"
 
-- name: "priority/P1"
+- name: "priority:p1"
   color: "ffffff"
   description: "High priority"
 `;
       const parsed = parseLabelsYaml(yaml);
       assert.equal(parsed.length, 2);
       assert.deepEqual(parsed[0], {
-        name: 'area/test',
+        name: 'area:frontend',
         color: '123456',
         description: 'Test description'
       });
       assert.deepEqual(parsed[1], {
-        name: 'priority/P1',
+        name: 'priority:p1',
         color: 'ffffff',
         description: 'High priority'
       });
@@ -44,7 +42,7 @@ describe('check-issue-governance', () => {
       const yaml = `
 # Comment at top
 
-- name: "status/test"
+- name: "status:triage"
   # inline comment
   color: "000000"
   description: "Status test description"
@@ -52,7 +50,7 @@ describe('check-issue-governance', () => {
       const parsed = parseLabelsYaml(yaml);
       assert.equal(parsed.length, 1);
       assert.deepEqual(parsed[0], {
-        name: 'status/test',
+        name: 'status:triage',
         color: '000000',
         description: 'Status test description'
       });
@@ -73,6 +71,13 @@ describe('check-issue-governance', () => {
     it('issue templates have correct default labels and taxonomy references', () => {
       const errors = checkTemplates();
       assert.deepEqual(errors, [], `Expected no errors in issue templates, but got: ${errors.join(', ')}`);
+    });
+
+    it('expected labels use colon-style names only', () => {
+      for (const name of EXPECTED_LABELS) {
+        assert.ok(!name.includes('/'), `Expected colon-style label, got: ${name}`);
+        assert.ok(name.includes(':'), `Expected colon in label name: ${name}`);
+      }
     });
   });
 });

--- a/scripts/check-label-drift.js
+++ b/scripts/check-label-drift.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+/**
+ * Compares .github/labels.yml with labels on the GitHub remote.
+ *
+ * Usage:
+ *   node scripts/check-label-drift.js
+ *   GITHUB_TOKEN=... node scripts/check-label-drift.js --strict
+ *
+ * Without a token, only validates that labels.yml uses colon-style names.
+ * With a token (or gh auth), compares local names against the remote set.
+ * --strict exits 1 when local labels are missing on GitHub (or vice versa for
+ * taxonomy prefixes).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { parseLabelsYaml } = require('./check-issue-governance');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const TAXONOMY_PREFIXES = ['area:', 'priority:', 'type:', 'risk:', 'status:'];
+
+function loadLocalLabels() {
+  const content = fs.readFileSync(path.join(REPO_ROOT, '.github', 'labels.yml'), 'utf8');
+  return parseLabelsYaml(content).map((l) => l.name).filter(Boolean);
+}
+
+function fetchRemoteLabels() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY || 'Calebux/SYNCRO';
+
+  if (token) {
+    const labels = [];
+    let page = 1;
+    while (true) {
+      const url = `https://api.github.com/repos/${repo}/labels?per_page=100&page=${page}`;
+      const res = execSync(
+        `curl -sS -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.github+json" "${url}"`,
+        { encoding: 'utf8' },
+      );
+      const batch = JSON.parse(res);
+      if (!Array.isArray(batch) || batch.length === 0) break;
+      if (batch.message) {
+        throw new Error(`GitHub API error: ${batch.message}`);
+      }
+      labels.push(...batch.map((l) => l.name));
+      if (batch.length < 100) break;
+      page += 1;
+    }
+    return labels;
+  }
+
+  try {
+    const out = execSync('gh label list --limit 200 --json name', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return JSON.parse(out).map((l) => l.name);
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const strict = process.argv.includes('--strict');
+  const local = loadLocalLabels();
+  const errors = [];
+  const warnings = [];
+
+  console.log('🔍 Checking label drift (local ↔ GitHub)...\n');
+
+  for (const name of local) {
+    if (name.includes('/')) {
+      errors.push(`Local label "${name}" uses slash-style; rename to colon-style`);
+    }
+  }
+
+  const remote = fetchRemoteLabels();
+  if (!remote) {
+    warnings.push(
+      'Could not fetch remote labels (set GITHUB_TOKEN or authenticate gh). Skipped remote comparison.',
+    );
+  } else {
+    const remoteSet = new Set(remote);
+    const localSet = new Set(local);
+
+    const missingOnRemote = local.filter((n) => !remoteSet.has(n));
+    const remoteTaxonomy = remote.filter((n) =>
+      TAXONOMY_PREFIXES.some((p) => n.startsWith(p)),
+    );
+    const extraOnRemote = remoteTaxonomy.filter((n) => !localSet.has(n));
+
+    if (missingOnRemote.length > 0) {
+      const msg = `Local labels missing on GitHub (${missingOnRemote.length}): ${missingOnRemote.join(', ')}`;
+      if (strict) errors.push(msg);
+      else warnings.push(msg);
+    }
+
+    if (extraOnRemote.length > 0) {
+      warnings.push(
+        `Remote taxonomy labels not in labels.yml (${extraOnRemote.length}): ${extraOnRemote.join(', ')}`,
+      );
+    }
+
+    console.log(`Local taxonomy labels: ${local.length}`);
+    console.log(`Remote labels: ${remote.length} (taxonomy-prefixed: ${remoteTaxonomy.length})`);
+  }
+
+  for (const w of warnings) {
+    console.warn(`⚠️  ${w}`);
+  }
+
+  if (errors.length > 0) {
+    console.error('\n❌ Label drift check failed:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  console.log('\n✅ Label drift check passed' + (warnings.length ? ' (with warnings)' : '') + '!');
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { loadLocalLabels, fetchRemoteLabels, TAXONOMY_PREFIXES };

--- a/scripts/validate-docs.js
+++ b/scripts/validate-docs.js
@@ -17,12 +17,6 @@ const VALIDATED_DOCS = [
 
 const SDK_SAMPLES_PATH = ".validated-samples";
 
-interface ValidationResult {
-  file: string;
-  success: boolean;
-  samples: { language: string; code: string; error?: string }[];
-}
-
 function extractCodeBlocks(markdown) {
   const blocks = [];
   const codeBlockRegex = /```(\w+)\n([\s\S]*?)```/g;
@@ -120,6 +114,47 @@ function validateFile(filePath) {
   };
 }
 
+/**
+ * Reject absolute local file:// markdown links (broken on GitHub / non-Windows).
+ * Scans README and docs/*.md (excluding archive unless linked from active nav).
+ */
+function findAbsoluteFileLinks(repoRoot = process.cwd()) {
+  const targets = [
+    path.join(repoRoot, "README.md"),
+    path.join(repoRoot, "docs", "issue-triage-policy.md"),
+    path.join(repoRoot, "docs", "label-migration.md"),
+    path.join(repoRoot, "CONTRIBUTING.md"),
+  ];
+
+  const docsDir = path.join(repoRoot, "docs");
+  if (fs.existsSync(docsDir)) {
+    for (const name of fs.readdirSync(docsDir)) {
+      if (name.endsWith(".md")) {
+        targets.push(path.join(docsDir, name));
+      }
+    }
+  }
+
+  const fileLinkRegex = /\]\(file:\/\/[^)]+\)|file:\/\/[^\s)]+/gi;
+  const findings = [];
+  const seen = new Set();
+
+  for (const filePath of targets) {
+    if (!fs.existsSync(filePath) || seen.has(filePath)) continue;
+    seen.add(filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    const matches = content.match(fileLinkRegex);
+    if (matches && matches.length > 0) {
+      findings.push({
+        file: path.relative(repoRoot, filePath),
+        matches: [...new Set(matches)],
+      });
+    }
+  }
+
+  return findings;
+}
+
 function main() {
   console.log("🔍 Validating documentation code samples...\n");
 
@@ -139,6 +174,17 @@ function main() {
 
   console.log(`\n📊 Results: ${results.length - failed.length}/${results.length} files valid\n`);
 
+  console.log("🔍 Checking for absolute file:// links...\n");
+  const fileLinks = findAbsoluteFileLinks();
+  if (fileLinks.length > 0) {
+    console.error("❌ Absolute file:// links are not allowed (use repo-relative Markdown links):");
+    for (const finding of fileLinks) {
+      console.error(`  - ${finding.file}: ${finding.matches.join(", ")}`);
+    }
+    process.exit(1);
+  }
+  console.log("✅ No absolute file:// links found\n");
+
   if (failed.length > 0) {
     console.error("❌ Documentation validation failed!");
     process.exit(1);
@@ -148,4 +194,8 @@ function main() {
   process.exit(0);
 }
 
-main();
+module.exports = { findAbsoluteFileLinks, extractCodeBlocks, validateFile };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/validate-docs.test.js
+++ b/scripts/validate-docs.test.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { findAbsoluteFileLinks } = require('./validate-docs');
+
+describe('validate-docs file:// guard', () => {
+  it('finds absolute file:// markdown links', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'syncro-docs-'));
+    fs.mkdirSync(path.join(dir, 'docs'));
+    fs.writeFileSync(
+      path.join(dir, 'README.md'),
+      'See [doc](file:///C:/Users/x/SYNCRO/docs/a.md).\n',
+    );
+    fs.writeFileSync(path.join(dir, 'docs', 'issue-triage-policy.md'), '# ok\n');
+
+    const findings = findAbsoluteFileLinks(dir);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].file, 'README.md');
+    assert.ok(findings[0].matches.some((m) => m.includes('file://')));
+  });
+
+  it('passes the real repository (no file:// links)', () => {
+    const findings = findAbsoluteFileLinks(path.join(__dirname, '..'));
+    assert.deepEqual(findings, [], `Unexpected file:// links: ${JSON.stringify(findings)}`);
+  });
+});


### PR DESCRIPTION
closes #1144 
closes #1151 
closes #1154 
closes #1155

### Commit title
```
fix: refund provider selection, scoped tags, docs links, colon labels
```

### PR description

## Summary
- **Refund API:** Select payment provider from the verified payment record instead of hardcoding Stripe; reject Paystack/manual and unknown providers with validation errors; keep ownership and already-refunded checks; add route tests for Stripe, PayPal, Paystack, and unknown providers.
- **Tag helpers:** Require `userId` on `addTagToSubscription` / `removeTagFromSubscription`, verify subscription and tag ownership inside the helpers, update API callers, and add helper-level cross-user tests.
- **Docs links:** Replace Windows `file://` links in `README.md` and `docs/issue-triage-policy.md` with repo-relative Markdown links; extend `scripts/validate-docs.js` (+ tests) to reject absolute local file links.
- **Label taxonomy:** Adopt colon-style as canonical to match GitHub (`area:frontend`, `priority:p1`, etc.); update `.github/labels.yml`, triage docs, templates, and governance scripts; add `scripts/check-label-drift.js` and `docs/label-migration.md` for slash→colon migration.

## Test plan
- [ ] `node scripts/check-issue-governance.js`
- [ ] `node --test scripts/check-issue-governance.test.js`
- [ ] `node scripts/check-label-drift.js` (with `GITHUB_TOKEN` for remote compare)
- [ ] `node --test scripts/validate-docs.test.js`
- [ ] `npm test -w client -- app/api/payments/refund/__tests__/route.test.ts lib/supabase/__tests__/tags.test.ts`
- [ ] Confirm README / triage policy links render on GitHub (no `file://`)
