### PR TITLE
fix: handle DST transitions in quiet hours and reminder scheduling (#1033)

### DIFF
--- a/backend/src/services/quiet-hours-service.ts
+++ b/backend/src/services/quiet-hours-service.ts
@@ -1,3 +1,4 @@
+import { addDays } from 'date-fns';
 import { toZonedTime, fromZonedTime } from 'date-fns-tz';
 import { UserPreferences, NotificationPriority, NotificationPayload } from '../types/reminder';
 import logger from '../config/logger';
@@ -95,16 +96,15 @@ export class QuietHoursService {
       const mm    = String(endMinute).padStart(2, '0');
       const localDateStr = `${year}-${month}-${day}T${hh}:${mm}:00`;
 
-      // fromZonedTime interprets the string as a wall-clock time in `tz`
-      // and returns the corresponding UTC instant.
       let candidate = fromZonedTime(localDateStr, tz);
 
-      // If the candidate is not strictly after currentTime, advance by 24 hours.
-      // Adding exactly 24 h is safe here: DST shifts only affect the wall-clock
-      // representation, not the UTC arithmetic, and we only need "tomorrow's
-      // end time" — not a precise local-midnight boundary.
       if (candidate <= currentTime) {
-        candidate = new Date(candidate.getTime() + 24 * 60 * 60 * 1000);
+        const nextZoned = addDays(zonedNow, 1);
+        const nextYear = nextZoned.getFullYear();
+        const nextMonth = String(nextZoned.getMonth() + 1).padStart(2, '0');
+        const nextDay = String(nextZoned.getDate()).padStart(2, '0');
+        const nextLocalDateStr = `${nextYear}-${nextMonth}-${nextDay}T${hh}:${mm}:00`;
+        candidate = fromZonedTime(nextLocalDateStr, tz);
       }
 
       return candidate;

--- a/backend/tests/timestamp-timezone.test.ts
+++ b/backend/tests/timestamp-timezone.test.ts
@@ -230,6 +230,49 @@ describe('QuietHoursService — timezone-aware behaviour (Issue #71)', () => {
       const endTime = service.getQuietHoursEndTime(prefs, utcNow);
       expect(endTime.getTime()).toBeGreaterThan(utcNow.getTime());
     });
+
+    /**
+     * DST Spring Forward: 2026-03-08 in America/New_York (clocks jump 02:00 EST -> 03:00 EDT).
+     * Quiet hours: 22:00–08:00.
+     * At 2026-03-08 03:00 UTC (2026-03-07 22:00 EST), next end time is 08:00 EDT on Mar 8 = 12:00 UTC.
+     */
+    it('calculates exact 08:00 EDT wall-clock end time across Spring Forward (23h day)', () => {
+      const prefs = makePrefs({ quiet_hours_timezone: 'America/New_York' });
+      const utcNow = new Date('2026-03-08T03:00:00Z'); // 22:00 EST on Mar 7
+      const endTime = service.getQuietHoursEndTime(prefs, utcNow);
+
+      expect(endTime.toISOString()).toBe('2026-03-08T12:00:00.000Z');
+      expect(service.isInQuietHours(prefs, endTime)).toBe(false);
+    });
+
+    /**
+     * DST Fall Back: 2026-11-01 in America/New_York (clocks fall back 02:00 EDT -> 01:00 EST).
+     * Quiet hours: 22:00–08:00.
+     * At 2026-11-01 03:00 UTC (2026-10-31 23:00 EDT), next end time is 08:00 EST on Nov 1 = 13:00 UTC.
+     * Must NOT yield 12:00 UTC (07:00 EST), which would be inside quiet hours.
+     */
+    it('calculates exact 08:00 EST wall-clock end time across Fall Back (25h day)', () => {
+      const prefs = makePrefs({ quiet_hours_timezone: 'America/New_York' });
+      const utcNow = new Date('2026-11-01T03:00:00Z'); // 23:00 EDT on Oct 31
+      const endTime = service.getQuietHoursEndTime(prefs, utcNow);
+
+      expect(endTime.toISOString()).toBe('2026-11-01T13:00:00.000Z');
+      expect(service.isInQuietHours(prefs, endTime)).toBe(false);
+    });
+
+    /**
+     * DST Fall Back: 2026-10-25 in Europe/London (BST UTC+1 -> GMT UTC+0).
+     * Quiet hours: 22:00–08:00.
+     * At 2026-10-24 22:00 UTC (23:00 BST), next end time is 08:00 GMT on Oct 25 = 08:00 UTC.
+     */
+    it('calculates exact 08:00 GMT end time across European Fall Back', () => {
+      const prefs = makePrefs({ quiet_hours_timezone: 'Europe/London' });
+      const utcNow = new Date('2026-10-24T22:00:00Z'); // 23:00 BST on Oct 24
+      const endTime = service.getQuietHoursEndTime(prefs, utcNow);
+
+      expect(endTime.toISOString()).toBe('2026-10-25T08:00:00.000Z');
+      expect(service.isInQuietHours(prefs, endTime)).toBe(false);
+    });
   });
 
   // ── isAppropriateTimeForDelayedNotifications ───────────────────────────────


### PR DESCRIPTION
### Fix: Quiet-hours & reminder scheduling across DST boundaries (#1033)

#### Summary
Closes #1033  where calculating quiet hours end time across DST transition boundaries (Spring Forward / Fall Back) relied on adding raw 24 UTC hours (`+ 24 * 60 * 60 * 1000` ms). On Fall Back (25-hour days), this caused `getQuietHoursEndTime` to calculate a wall-clock time of 07:00 instead of 08:00, leading to delayed notifications firing inside the user quiet hours window.

#### Key Changes
- **QuietHoursService**: Refactored `getQuietHoursEndTime` to use timezone-aware calendar arithmetic (`addDays(zonedNow, 1)` and `fromZonedTime`) to advance the local calendar date when calculating the next quiet hours end boundary.
- **DST Boundary Tests**: Added comprehensive test cases in `timestamp-timezone.test.ts` for US Eastern Spring Forward (23h day), US Eastern Fall Back (25h day), and UK GMT/BST transitions.

#### Verification
- `quiet-hours-service.test.ts`: 20/20 PASSED
- `quiet-hours-integration.test.ts`: 6/6 PASSED
- `timestamp-timezone.test.ts`: 30/30 PASSED
- Total: 56/56 tests passing