### PR TITLE
fix: scope tag lookups, harden offline sync, real admin user list

### DIFF
--- a/client/__tests__/lib/offline-mutations.test.ts
+++ b/client/__tests__/lib/offline-mutations.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { offlineMutationSchema } from "@/lib/sync/offline-mutations"
+
+describe("offlineMutationSchema", () => {
+  it("accepts a create mutation", () => {
+    const result = offlineMutationSchema.safeParse({
+      type: "create",
+      payload: { name: "Netflix", amount: 15.99 },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts an update mutation carrying a version", () => {
+    const result = offlineMutationSchema.safeParse({
+      type: "update",
+      payload: { id: "sub-1", version: 3, name: "Netflix" },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects an unknown mutation type", () => {
+    const result = offlineMutationSchema.safeParse({
+      type: "upsert",
+      payload: { id: "sub-1" },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a missing payload", () => {
+    const result = offlineMutationSchema.safeParse({ type: "delete" })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an update without an id", () => {
+    const result = offlineMutationSchema.safeParse({
+      type: "update",
+      payload: { name: "Netflix" },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects unknown top-level fields so new offline fields need a schema change", () => {
+    const result = offlineMutationSchema.safeParse({
+      type: "delete",
+      payload: { id: "sub-1" },
+      clientTimestamp: 123,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/client/app/api/admin/users/route.ts
+++ b/client/app/api/admin/users/route.ts
@@ -1,9 +1,43 @@
 import { NextRequest } from 'next/server'
-import { createApiRoute, createSuccessResponse } from '@/lib/api'
+import { createClient } from '@/lib/supabase/server'
+import {
+  ApiErrors,
+  CommonSchemas,
+  createApiRoute,
+  createPaginatedResponse,
+  createSuccessResponse,
+  validateQueryParams,
+} from '@/lib/api/index'
+import { HttpStatus } from '@/lib/api/types'
 
 export const GET = createApiRoute(
-  async (request: NextRequest) => {
-    return createSuccessResponse({ users: [] })
+  async (request: NextRequest, context) => {
+    const { page, limit } = validateQueryParams(request, CommonSchemas.pagination)
+    const from = (page - 1) * limit
+
+    const supabase = await createClient()
+    const { data, error, count } = await supabase
+      .from('profiles')
+      // Only safe fields needed by the admin UI — no tokens, settings, or PII
+      // beyond the basics.
+      .select('id, email, full_name, created_at', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(from, from + limit - 1)
+
+    if (error) {
+      console.error(
+        `[admin/users] user list query failed (requestId=${context.requestId}): ${error.message}`
+      )
+      throw ApiErrors.internalError('Failed to fetch users', {
+        requestId: context.requestId,
+      })
+    }
+
+    return createSuccessResponse(
+      createPaginatedResponse(data ?? [], page, limit, count ?? 0),
+      HttpStatus.OK,
+      context.requestId
+    )
   },
   {
     requireAuth: true,

--- a/client/app/api/sync/offline/route.ts
+++ b/client/app/api/sync/offline/route.ts
@@ -1,131 +1,120 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { type NextRequest } from "next/server"
 import { createClient } from "@/lib/supabase/server"
+import {
+  ApiException,
+  ApiErrors,
+  RateLimiters,
+  createAuthenticatedApiRoute,
+  createSuccessResponse,
+  validateRequestBody,
+} from "@/lib/api/index"
+import { ErrorCode, HttpStatus } from "@/lib/api/types"
+import {
+  offlineMutationSchema,
+  type OfflineMutation,
+  type SyncConflictDetails,
+} from "@/lib/sync/offline-mutations"
 import { trackError } from "@/lib/telemetry"
 
-// Conflict resolution: Last-write-wins strategy with version tracking
-async function resolveConflict(
-  existingSubscription: any,
+// Last-write-wins with version tracking: the newer version becomes the base,
+// and the merged row is offered back to the client inside the 409 details.
+function resolveConflict(
+  existingSubscription: Record<string, unknown>,
   updates: Record<string, unknown>
-): Promise<Record<string, unknown>> {
-  const existingVersion = existingSubscription.version || 0
-  const updateVersion = updates.version || 0
+): SyncConflictDetails {
+  const serverVersion = Number(existingSubscription.version) || 0
+  const clientVersion = Number(updates.version) || 0
 
-  // Last-write-wins: if server version is higher, reject client changes
-  if (existingVersion > updateVersion) {
-    return {
-      ...updates,
-      _conflict: true,
-      _serverData: existingSubscription,
-    }
-  }
-
-  // Merge changes with server data
   return {
-    ...existingSubscription,
-    ...updates,
-    version: Math.max(existingVersion, updateVersion) + 1,
+    conflict: true,
+    serverVersion,
+    clientVersion,
+    serverData: existingSubscription,
+    resolvedData: {
+      ...existingSubscription,
+      ...updates,
+      version: Math.max(serverVersion, clientVersion) + 1,
+    },
   }
 }
 
-export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+export const POST = createAuthenticatedApiRoute(
+  async (request: NextRequest, context, user) => {
+    const mutation: OfflineMutation = await validateRequestBody(
+      request,
+      offlineMutationSchema
+    )
+    const supabase = await createClient()
 
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
+    try {
+      if (mutation.type === "create") {
+        const { data, error } = await supabase
+          .from("subscriptions")
+          .insert({ user_id: user.id, ...mutation.payload })
+          .select()
+          .single()
 
-  const mutation = await request.json()
-
-  const { type, payload } = mutation
-
-  try {
-    if (type === "create") {
-      const { data, error } = await supabase
-        .from("subscriptions")
-        .insert({
-          user_id: user.id,
-          ...payload,
-        })
-        .select()
-        .single()
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
+        if (error) throw ApiErrors.validationError(error.message)
+        return createSuccessResponse(data, HttpStatus.OK, context.requestId)
       }
 
-      return NextResponse.json({ success: true, data })
-    }
+      if (mutation.type === "update") {
+        const { id, version, ...rest } = mutation.payload
 
-    if (type === "update") {
-      const id = payload.id as string
+        const { data: existing, error: fetchError } = await supabase
+          .from("subscriptions")
+          .select("*")
+          .eq("id", id)
+          .eq("user_id", user.id)
+          .single()
 
-      // Check for conflicts
-      const { data: existing, error: fetchError } = await supabase
-        .from("subscriptions")
-        .select("*")
-        .eq("id", id)
-        .eq("user_id", user.id)
-        .single()
+        if (fetchError && fetchError.code === "PGRST116") {
+          throw ApiErrors.notFound("Subscription")
+        }
+        if (fetchError) throw ApiErrors.validationError(fetchError.message)
 
-      if (fetchError && fetchError.code === "PGRST116") {
-        // Subscription not found - may have been deleted
-        return NextResponse.json({ error: "Subscription not found" }, { status: 404 })
+        // Optimistic locking: reject stale client versions with the
+        // documented conflict contract (see lib/sync/offline-mutations.ts).
+        if (version && existing.version && version < existing.version) {
+          throw new ApiException(
+            ErrorCode.CONFLICT,
+            "Conflict detected",
+            HttpStatus.CONFLICT,
+            resolveConflict(existing, mutation.payload)
+          )
+        }
+
+        const { data, error } = await supabase
+          .from("subscriptions")
+          .update({ ...rest, version: (existing.version || 0) + 1 })
+          .eq("id", id)
+          .eq("user_id", user.id)
+          .select()
+          .single()
+
+        if (error) throw ApiErrors.validationError(error.message)
+        return createSuccessResponse(data, HttpStatus.OK, context.requestId)
       }
-
-      if (fetchError) {
-        return NextResponse.json({ error: fetchError.message }, { status: 400 })
-      }
-
-      // Check for conflict (optimistic locking)
-      if (payload.version && existing.version && payload.version < existing.version) {
-        const resolved = await resolveConflict(existing, payload)
-        return NextResponse.json({ 
-          error: "Conflict detected", 
-          conflict: true,
-          resolvedData: resolved,
-        }, { status: 409 })
-      }
-
-      const { data, error } = await supabase
-        .from("subscriptions")
-        .update({
-          ...payload,
-          version: (existing.version || 0) + 1,
-        })
-        .eq("id", id)
-        .eq("user_id", user.id)
-        .select()
-        .single()
-
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
-      }
-
-      return NextResponse.json({ success: true, data })
-    }
-
-    if (type === "delete") {
-      const id = payload.id as string
 
       const { error } = await supabase
         .from("subscriptions")
         .delete()
-        .eq("id", id)
+        .eq("id", mutation.payload.id)
         .eq("user_id", user.id)
 
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 400 })
-      }
-
-      return NextResponse.json({ success: true })
+      if (error) throw ApiErrors.validationError(error.message)
+      return createSuccessResponse({ deleted: true }, HttpStatus.OK, context.requestId)
+    } catch (error) {
+      trackError(error, "database", {
+        component: "sync/offline",
+        userId: user.id,
+        extra: { mutationType: mutation.type, requestId: context.requestId },
+      })
+      throw error
     }
-
-    return NextResponse.json({ error: "Unknown mutation type" }, { status: 400 })
-  } catch (error) {
-    trackError(error, "sync", { type, userId: user.id })
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  },
+  {
+    rateLimit: RateLimiters.standard,
+    idempotent: true,
   }
-}
+)

--- a/client/lib/supabase/tags.ts
+++ b/client/lib/supabase/tags.ts
@@ -55,11 +55,32 @@ export async function deleteTag(tagId: string, userId: string): Promise<void> {
   if (error) throw new Error(`Failed to delete tag: ${error.message}`)
 }
 
-/** Fetch tag IDs assigned to a subscription. */
+/**
+ * Fetch tag IDs assigned to a subscription.
+ *
+ * Requires the authenticated user's id: ownership is validated against
+ * subscriptions.user_id before assignments are fetched, so this helper is
+ * safe to call from routes that have not performed their own ownership check.
+ * Throws if the subscription does not exist or belongs to another user.
+ */
 export async function getSubscriptionTagIds(
   subscriptionId: string,
+  userId: string,
 ): Promise<string[]> {
   const supabase = await createClient()
+
+  const { data: subscription, error: ownershipError } = await supabase
+    .from("subscriptions")
+    .select("id")
+    .eq("id", subscriptionId)
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (ownershipError)
+    throw new Error(`Failed to verify subscription ownership: ${ownershipError.message}`)
+  if (!subscription)
+    throw new Error("Subscription not found for this user")
+
   const { data, error } = await supabase
     .from("subscription_tag_assignments")
     .select("tag_id")

--- a/client/lib/sync/offline-mutations.ts
+++ b/client/lib/sync/offline-mutations.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared contract for offline sync mutations.
+ *
+ * Both the client mutation queue and the /api/sync/offline route validate
+ * against these schemas, so queued mutations can be validated, retried, and
+ * resolved deterministically. The top-level objects are strict: adding a new
+ * offline field requires an explicit schema addition here.
+ */
+
+import { z } from "zod"
+
+const createMutationSchema = z
+  .object({
+    type: z.literal("create"),
+    payload: z.record(z.string(), z.unknown()),
+  })
+  .strict()
+
+const updateMutationSchema = z
+  .object({
+    type: z.literal("update"),
+    payload: z
+      .object({
+        id: z.string().min(1, "id is required"),
+        version: z.number().int().nonnegative().optional(),
+      })
+      .catchall(z.unknown()),
+  })
+  .strict()
+
+const deleteMutationSchema = z
+  .object({
+    type: z.literal("delete"),
+    payload: z.object({ id: z.string().min(1, "id is required") }),
+  })
+  .strict()
+
+export const offlineMutationSchema = z.discriminatedUnion("type", [
+  createMutationSchema,
+  updateMutationSchema,
+  deleteMutationSchema,
+])
+
+export type OfflineMutation = z.infer<typeof offlineMutationSchema>
+
+/**
+ * Conflict contract consumed by the client mutation queue.
+ *
+ * When a queued update loses to a newer server version, the route responds
+ * with HTTP 409 and the standard error envelope; `error.details` carries this
+ * shape. The client should replace its local copy with `serverData` (or apply
+ * `resolvedData` when a merge was possible) and drop or re-queue the mutation.
+ */
+export type SyncConflictDetails = {
+  conflict: true
+  serverVersion: number
+  clientVersion: number
+  serverData: Record<string, unknown>
+  resolvedData: Record<string, unknown>
+}


### PR DESCRIPTION
Closes #1152 : getSubscriptionTagIds now takes the authenticated userId and verifies ownership via subscriptions.user_id before reading assignments, so callers without their own ownership check cannot leak another user's tag IDs.

Closes #1141 : adds a shared Zod contract for offline mutations (client/lib/sync/offline-mutations.ts) covering create/update/delete, with strict top-level objects so new offline fields require an explicit schema addition. Documents the 409 conflict details shape consumed by the client mutation queue, plus unit tests for malformed types, missing payloads and version handling.

Closes #1140 : the offline sync route now goes through createAuthenticatedApiRoute, picking up CSRF validation, rate-limit headers, request IDs, idempotency and standardized error shapes instead of hand-rolled auth and JSON responses. Offline mutation semantics (last-write-wins with version tracking) are preserved.

Closes #1136 : the admin users endpoint returns a real paginated query over profiles restricted to safe fields, instead of a hardcoded empty array, and includes the request ID in error responses and logs.


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
