### PR TITLE
test: add webhook route integration tests for Stripe, Paystack, PayPa…

### DIFF
--- a/backend/tests/paypal-webhook-integration.test.ts
+++ b/backend/tests/paypal-webhook-integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for PayPal webhook route (POST /api/webhooks/paypal)
+ * Covers: success, idempotent-replay, rejected-forgery (#1084)
+ */
+import request from 'supertest';
+import express, { type Express } from 'express';
+
+jest.mock('../src/config/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+}));
+
+import paypalWebhookRoutes from '../src/routes/paypal-webhook';
+
+function buildApp(): Express {
+  const app = express();
+  app.use('/api/webhooks/paypal', express.raw({ type: 'application/json' }), paypalWebhookRoutes);
+  return app;
+}
+
+const app = buildApp();
+
+describe('PayPal webhook route integration', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+  const PAYPAL_WEBHOOK_ID = 'WH-TEST-12345';
+  const PAYPAL_CLIENT_ID = 'test_client_id';
+  const PAYPAL_CLIENT_SECRET = 'test_client_secret';
+
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    originalEnv.PAYPAL_WEBHOOK_ID = process.env.PAYPAL_WEBHOOK_ID;
+    originalEnv.PAYPAL_CLIENT_ID = process.env.PAYPAL_CLIENT_ID;
+    originalEnv.PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET;
+    originalEnv.PAYPAL_MODE = process.env.PAYPAL_MODE;
+
+    process.env.PAYPAL_WEBHOOK_ID = PAYPAL_WEBHOOK_ID;
+    process.env.PAYPAL_CLIENT_ID = PAYPAL_CLIENT_ID;
+    process.env.PAYPAL_CLIENT_SECRET = PAYPAL_CLIENT_SECRET;
+    process.env.PAYPAL_MODE = 'sandbox';
+  });
+
+  afterEach(() => {
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    });
+    global.fetch = originalFetch;
+  });
+
+  const validPayload = JSON.stringify({
+    id: 'WH-58D07950BU892453L',
+    event_type: 'PAYMENT.CAPTURE.COMPLETED',
+    resource: { id: 'CAP-123', amount: { total: '29.99', currency: 'USD' } },
+  });
+
+  const validHeaders = {
+    'paypal-transmission-id': 'tx-abc-123',
+    'paypal-transmission-time': '2026-07-01T12:00:00Z',
+    'paypal-cert-url': 'https://api.sandbox.paypal.com/v1/notifications/certs/CERT-ID',
+    'paypal-auth-algo': 'SHA256withRSA',
+    'paypal-transmission-sig': 'mock-signature-value',
+  };
+
+  function mockPayPalSuccess() {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test_access_token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'SUCCESS' }),
+      }) as jest.Mock;
+  }
+
+  function mockPayPalFailure() {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test_access_token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'FAILURE' }),
+      }) as jest.Mock;
+  }
+
+  it('accepts a valid PayPal webhook (success)', async () => {
+    mockPayPalSuccess();
+
+    const res = await request(app)
+      .post('/api/webhooks/paypal')
+      .set(validHeaders)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  });
+
+  it('accepts the same webhook twice (idempotent-replay)', async () => {
+    // Use a single mock that returns success for all fetch calls
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test_access_token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'SUCCESS' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test_access_token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ verification_status: 'SUCCESS' }),
+      }) as jest.Mock;
+
+    const res1 = await request(app)
+      .post('/api/webhooks/paypal')
+      .set(validHeaders)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    const res2 = await request(app)
+      .post('/api/webhooks/paypal')
+      .set(validHeaders)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+
+  it('rejects a webhook with PayPal verification FAILURE (rejected-forgery)', async () => {
+    mockPayPalFailure();
+
+    const res = await request(app)
+      .post('/api/webhooks/paypal')
+      .set(validHeaders)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid signature');
+  });
+
+  it('rejects a webhook when transmission headers are missing (rejected-forgery)', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/paypal')
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid signature');
+  });
+
+  it('rejects a webhook when some transmission headers are missing (rejected-forgery)', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/paypal')
+      .set('paypal-transmission-id', 'tx-partial')
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(401);
+  });
+
+  describe('malformed-payload handling (#1084)', () => {
+    it('rejects a non-JSON malformed payload', async () => {
+      const res = await request(app)
+        .post('/api/webhooks/paypal')
+        .set(validHeaders)
+        .set('content-type', 'application/json')
+        .send('not valid json');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects an empty body', async () => {
+      const res = await request(app)
+        .post('/api/webhooks/paypal')
+        .set(validHeaders)
+        .set('content-type', 'application/json')
+        .send('');
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/backend/tests/paystack-webhook-integration.test.ts
+++ b/backend/tests/paystack-webhook-integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests for Paystack webhook route (POST /api/webhooks/paystack)
+ * Covers: success, idempotent-replay, rejected-forgery (#1084)
+ *
+ * Note: The Paystack route sends res.sendStatus(200) before signature
+ * verification, so even forged signatures receive HTTP 200. The forgery
+ * test verifies that the warning logger is called with the rejection reason.
+ */
+import request from 'supertest';
+import express, { type Express } from 'express';
+import crypto from 'crypto';
+
+const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+jest.mock('../src/config/logger', () => ({
+  __esModule: true,
+  default: mockLogger,
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+}));
+
+import paystackWebhookRoutes from '../src/routes/paystack-webhook';
+
+const PAYSTACK_SECRET_KEY = 'sk_test_secret_key_for_integration_testing';
+
+function buildApp(): Express {
+  const app = express();
+  app.use('/api/webhooks/paystack', express.raw({ type: 'application/json' }), paystackWebhookRoutes);
+  return app;
+}
+
+const app = buildApp();
+
+describe('Paystack webhook route integration', () => {
+  const originalPaystackSecretKey = process.env.PAYSTACK_SECRET_KEY;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.PAYSTACK_SECRET_KEY = PAYSTACK_SECRET_KEY;
+    process.env.NODE_ENV = 'production';
+    mockLogger.warn.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalPaystackSecretKey === undefined) {
+      delete process.env.PAYSTACK_SECRET_KEY;
+    } else {
+      process.env.PAYSTACK_SECRET_KEY = originalPaystackSecretKey;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  const validPayload = JSON.stringify({
+    event: 'charge.success',
+    data: { reference: 'ref_test_123', amount: 5000, status: 'success' },
+  });
+
+  function generateValidSignature(payload: string): string {
+    return crypto.createHmac('sha512', PAYSTACK_SECRET_KEY).update(payload).digest('hex');
+  }
+
+  it('accepts a valid Paystack webhook (success)', async () => {
+    const signature = generateValidSignature(validPayload);
+
+    const res = await request(app)
+      .post('/api/webhooks/paystack')
+      .set('x-paystack-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    // Paystack route always responds 200 immediately
+    expect(res.status).toBe(200);
+    // No warning should be logged on valid signature
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      '[PaystackWebhook] Rejected — invalid signature',
+      expect.anything(),
+    );
+  });
+
+  it('accepts the same webhook twice (idempotent-replay)', async () => {
+    const signature = generateValidSignature(validPayload);
+
+    const res1 = await request(app)
+      .post('/api/webhooks/paystack')
+      .set('x-paystack-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    const res2 = await request(app)
+      .post('/api/webhooks/paystack')
+      .set('x-paystack-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+
+  it('logs a warning on forged signature (rejected-forgery)', async () => {
+    const forgedPayload = JSON.stringify({
+      event: 'charge.success',
+      data: { reference: 'ref_forged', amount: 99999 },
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks/paystack')
+      .set('x-paystack-signature', 'deadbeef' + '0'.repeat(120))
+      .set('content-type', 'application/json')
+      .send(forgedPayload);
+
+    // Paystack always returns 200 (response sent before verification)
+    expect(res.status).toBe(200);
+    // But it should log the forgery warning
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[PaystackWebhook] Rejected — invalid signature',
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  it('rejects (logs warning) when Paystack signature header is missing', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/paystack')
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(200);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[PaystackWebhook] Rejected — invalid signature',
+      expect.anything(),
+    );
+  });
+
+  describe('malformed-payload handling (#1084)', () => {
+    it('returns 200 for a non-JSON malformed payload (body always accepted)', async () => {
+      const res = await request(app)
+        .post('/api/webhooks/paystack')
+        .set('x-paystack-signature', 'deadbeef' + '0'.repeat(120))
+        .set('content-type', 'application/json')
+        .send('not valid json');
+
+      // Paystack always responds 200 first, regardless of payload validity
+      expect(res.status).toBe(200);
+      // Should log the forgery warning
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '[PaystackWebhook] Rejected — invalid signature',
+        expect.anything(),
+      );
+    });
+
+    it('returns 200 for an empty body', async () => {
+      const res = await request(app)
+        .post('/api/webhooks/paystack')
+        .set('content-type', 'application/json')
+        .send('');
+
+      expect(res.status).toBe(200);
+      // Missing signature should trigger warning in production
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '[PaystackWebhook] Rejected — invalid signature',
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/backend/tests/stripe-webhook-integration.test.ts
+++ b/backend/tests/stripe-webhook-integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for Stripe webhook route (POST /api/webhooks/stripe)
+ * Covers: success, idempotent-replay, rejected-forgery (#1084)
+ */
+import request from 'supertest';
+import express, { type Express } from 'express';
+import Stripe from 'stripe';
+
+jest.mock('../src/config/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+}));
+
+import stripeWebhookRoutes from '../src/routes/stripe-webhook';
+
+const STRIPE_WEBHOOK_SECRET = 'whsec_test_secret_for_integration_tests';
+const STRIPE_SECRET_KEY = 'sk_test_placeholder';
+
+function buildApp(): Express {
+  const app = express();
+  // Must use raw body parser like in index.ts for signature verification
+  app.use('/api/webhooks/stripe', express.raw({ type: 'application/json' }), stripeWebhookRoutes);
+  return app;
+}
+
+const app = buildApp();
+
+describe('Stripe webhook route integration', () => {
+  const originalStripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = STRIPE_WEBHOOK_SECRET;
+    process.env.STRIPE_SECRET_KEY = STRIPE_SECRET_KEY;
+  });
+
+  afterEach(() => {
+    if (originalStripeWebhookSecret === undefined) {
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+    } else {
+      process.env.STRIPE_WEBHOOK_SECRET = originalStripeWebhookSecret;
+    }
+    if (originalStripeSecretKey === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+    }
+  });
+
+  const validPayload = JSON.stringify({
+    id: 'evt_test_123',
+    type: 'payment_intent.succeeded',
+    data: { object: { id: 'pi_test' } },
+  });
+
+  function generateValidSignature(payload: string): string {
+    const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2025-02-24.acacia' });
+    return stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: STRIPE_WEBHOOK_SECRET,
+    });
+  }
+
+  it('accepts a valid Stripe webhook (success)', async () => {
+    const signature = generateValidSignature(validPayload);
+
+    const res = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('stripe-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+  });
+
+  it('accepts the same webhook twice (idempotent-replay)', async () => {
+    const signature = generateValidSignature(validPayload);
+
+    const res1 = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('stripe-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    const res2 = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('stripe-signature', signature)
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+
+  it('rejects a webhook with forged signature (rejected-forgery)', async () => {
+    const forgedPayload = JSON.stringify({
+      id: 'evt_forged',
+      type: 'payment_intent.created',
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('stripe-signature', 't=9999999999,v1=deadbeefcafebabe0123456789abcdef')
+      .set('content-type', 'application/json')
+      .send(forgedPayload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Webhook signature verification failed');
+  });
+
+  it('rejects a webhook when Stripe signature header is missing (rejected-forgery)', async () => {
+    const res = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('content-type', 'application/json')
+      .send(validPayload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Webhook signature verification failed');
+  });
+
+  it('rejects a webhook with mismatched payload signature (rejected-forgery)', async () => {
+    const signature = generateValidSignature(validPayload);
+    const differentPayload = JSON.stringify({ id: 'evt_different', type: 'charge.failed' });
+
+    const res = await request(app)
+      .post('/api/webhooks/stripe')
+      .set('stripe-signature', signature)
+      .set('content-type', 'application/json')
+      .send(differentPayload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Webhook signature verification failed');
+  });
+
+  describe('malformed-payload handling (#1084)', () => {
+    it('rejects a non-JSON malformed payload', async () => {
+      const malformedBody = 'not valid json at all';
+      const signature = generateValidSignature(malformedBody);
+
+      const res = await request(app)
+        .post('/api/webhooks/stripe')
+        .set('stripe-signature', signature)
+        .set('content-type', 'application/json')
+        .send(malformedBody);
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an empty body', async () => {
+      const emptyBody = '{}';
+      const signature = generateValidSignature(emptyBody);
+
+      const res = await request(app)
+        .post('/api/webhooks/stripe')
+        .set('stripe-signature', signature)
+        .set('content-type', 'application/json')
+        .send(emptyBody);
+
+      // Empty body passes signature but may not match expected event shape
+      // The route accepts it since Stripe verifies the signature only
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ received: true });
+    });
+  });
+});

--- a/backend/tests/telegram-webhook-secret.test.ts
+++ b/backend/tests/telegram-webhook-secret.test.ts
@@ -91,4 +91,76 @@ describe('Telegram webhook secret validation', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
   });
+
+  describe('Success and idempotent-replay (#1084)', () => {
+    beforeEach(() => {
+      delete process.env.TELEGRAM_WEBHOOK_SECRET;
+    });
+
+    it('processes a valid /help command update (success)', async () => {
+      const helpUpdate = {
+        update_id: 12345,
+        message: {
+          message_id: 1,
+          from: { id: 111, is_bot: false, first_name: 'TestUser' },
+          chat: { id: 111, first_name: 'TestUser', type: 'private' },
+          date: Math.floor(Date.now() / 1000),
+          text: '/help',
+        },
+      };
+
+      const res = await request(app)
+        .post('/api/telegram/webhook')
+        .send(helpUpdate);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+    });
+
+    it('processes a /start command without deep link (success)', async () => {
+      const startUpdate = {
+        update_id: 12346,
+        message: {
+          message_id: 2,
+          from: { id: 222, is_bot: false, first_name: 'NewUser' },
+          chat: { id: 222, first_name: 'NewUser', type: 'private' },
+          date: Math.floor(Date.now() / 1000),
+          text: '/start',
+        },
+      };
+
+      const res = await request(app)
+        .post('/api/telegram/webhook')
+        .send(startUpdate);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+    });
+
+    it('accepts the same update_id twice (idempotent-replay)', async () => {
+      const statusUpdate = {
+        update_id: 99999,
+        message: {
+          message_id: 10,
+          from: { id: 333, is_bot: false, first_name: 'ReplayUser' },
+          chat: { id: 333, first_name: 'ReplayUser', type: 'private' },
+          date: Math.floor(Date.now() / 1000),
+          text: '/help',
+        },
+      };
+
+      const res1 = await request(app)
+        .post('/api/telegram/webhook')
+        .send(statusUpdate);
+
+      const res2 = await request(app)
+        .post('/api/telegram/webhook')
+        .send(statusUpdate);
+
+      expect(res1.status).toBe(200);
+      expect(res1.body).toEqual({ ok: true });
+      expect(res2.status).toBe(200);
+      expect(res2.body).toEqual({ ok: true });
+    });
+  });
 });


### PR DESCRIPTION
…l, and Telegram (#1084)

Add success, idempotent-replay, rejected-forgery, and malformed-payload integration tests for all four backend webhook routes:
- Stripe (POST /api/webhooks/stripe): signature verification via stripe.webhooks.constructEvent
- Paystack (POST /api/webhooks/paystack): HMAC-SHA512 verification
- PayPal (POST /api/webhooks/paypal): PayPal verify-webhook-signature API
- Telegram (POST /api/telegram/webhook): secret-token validation + command processing

Each route has:
- Success test (valid signature/token)
- Idempotent-replay test (same payload twice)
- Rejected-forgery test (invalid signature/token)
- Malformed-payload test (non-JSON or empty body)


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #1084 

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
