### PR TITLE
feat: escrow refund, initialize, RBAC, SAC integration (#1189, #1191, #1192, #1193)

### DIFF
--- a/contracts/contracts/src/lib.rs
+++ b/contracts/contracts/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 mod subscription_registry;
 
 pub use subscription_registry::*;

--- a/contracts/contracts/src/subscription_registry.rs
+++ b/contracts/contracts/src/subscription_registry.rs
@@ -51,6 +51,8 @@ pub struct Subscription {
     pub status: SubscriptionStatus,
     /// Optional linked escrow id used for pending funds cleanup on cancel.
     pub escrow_id: Option<u64>,
+    /// Timestamp after which escrowed funds can be refunded to the payer.
+    pub escrow_expires_at: Option<u64>,
 }
 
 #[contracttype]
@@ -68,6 +70,12 @@ pub enum DataKey {
     Admin,
     /// Tracks whether a pending token allowance remains for a subscription.
     PendingAllowance(BytesN<32>),
+    /// Platform fee percentage (basis points, e.g. 250 = 2.5%).
+    PlatformFeeBps,
+    /// Whether the contract is paused.
+    Paused,
+    /// Escrow expiration timestamp per subscription.
+    EscrowExpiresAt(BytesN<32>),
 }
 
 #[contractevent]
@@ -123,6 +131,27 @@ pub struct SubscriptionRenewedEvent {
     pub next_renewal_date: u64,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRefundedEvent {
+    pub subscription_id: BytesN<32>,
+    pub user: Address,
+    pub amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeUpdatedEvent {
+    pub old_fee_bps: u32,
+    pub new_fee_bps: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractPausedEvent {
+    pub paused: bool,
+}
+
 #[contract]
 pub struct SubscriptionRegistry;
 
@@ -137,12 +166,176 @@ impl SubscriptionRegistry {
         env.storage().instance().set(&DataKey::Admin, &admin);
     }
 
+    /// Initialize contract with admin and platform fee. Callable once.
+    pub fn initialize(env: Env, admin: Address, fee_bps: u32) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        assert!(fee_bps <= 10_000, "fee_bps must be <= 10000");
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::PlatformFeeBps, &fee_bps);
+        env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
     fn is_admin(env: &Env, caller: &Address) -> bool {
         env.storage()
             .instance()
             .get::<_, Address>(&DataKey::Admin)
             .map(|admin| &admin == caller)
             .unwrap_or(false)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) {
+        if !Self::is_admin(env, caller) {
+            panic!("not admin");
+        }
+    }
+
+    fn require_not_paused(env: &Env) {
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+        if paused {
+            panic!("contract is paused");
+        }
+    }
+
+    /// Update platform fee (admin only). Fee in basis points (e.g. 250 = 2.5%).
+    pub fn set_fee(env: Env, caller: Address, new_fee_bps: u32) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+        assert!(new_fee_bps <= 10_000, "fee_bps must be <= 10000");
+        let old_fee: u32 = env.storage().instance().get(&DataKey::PlatformFeeBps).unwrap_or(0);
+        env.storage().instance().set(&DataKey::PlatformFeeBps, &new_fee_bps);
+        FeeUpdatedEvent { old_fee_bps: old_fee, new_fee_bps }.publish(&env);
+    }
+
+    /// Pause or unpause the contract (admin only).
+    pub fn pause_contract(env: Env, caller: Address, paused: bool) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        ContractPausedEvent { paused }.publish(&env);
+    }
+
+    /// Check if contract is paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    /// Get current platform fee in basis points.
+    pub fn get_platform_fee(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::PlatformFeeBps).unwrap_or(0)
+    }
+
+    /// Refund escrowed funds if the merchant did not claim before expiry.
+    /// Only the original payer (user) or admin can trigger.
+    pub fn refund_expired_escrow(env: Env, subscription_id: BytesN<32>, caller: Address) {
+        caller.require_auth();
+
+        let mut subscription: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CoreSubscription(subscription_id.clone()))
+            .unwrap_or_else(|| panic!("subscription not found"));
+
+        let authorized = caller == subscription.user || Self::is_admin(&env, &caller);
+        if !authorized {
+            panic!("unauthorized refund");
+        }
+
+        let expires_at = subscription.escrow_expires_at.unwrap_or(0);
+        let now = env.ledger().timestamp();
+        if now < expires_at {
+            panic!("escrow has not expired");
+        }
+
+        let escrow_id = subscription.escrow_id.unwrap_or_else(|| panic!("no escrow linked"));
+        let _ = escrow_id; // escrow_id tracked for cross-contract integration
+
+        // Transfer funds back to user.
+        let token_client = token::Client::new(&env, &subscription.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &subscription.user,
+            &subscription.amount,
+        );
+
+        // Clear escrow linkage and mark refunded by setting status to Canceled.
+        subscription.escrow_id = None;
+        subscription.escrow_expires_at = None;
+        subscription.status = SubscriptionStatus::Canceled;
+        env.storage().persistent().set(
+            &DataKey::CoreSubscription(subscription_id.clone()),
+            &subscription,
+        );
+
+        // Clean up stored expiration.
+        env.storage()
+            .persistent()
+            .remove(&DataKey::EscrowExpiresAt(subscription_id.clone()));
+
+        EscrowRefundedEvent {
+            subscription_id,
+            user: subscription.user,
+            amount: subscription.amount,
+        }
+        .publish(&env);
+    }
+
+    /// Set escrow expiration for a subscription (admin only).
+    pub fn set_escrow_expiration(
+        env: Env,
+        caller: Address,
+        subscription_id: BytesN<32>,
+        expires_at: u64,
+    ) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        let mut subscription: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CoreSubscription(subscription_id.clone()))
+            .unwrap_or_else(|| panic!("subscription not found"));
+
+        subscription.escrow_expires_at = Some(expires_at);
+        env.storage().persistent().set(
+            &DataKey::CoreSubscription(subscription_id.clone()),
+            &subscription,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowExpiresAt(subscription_id), &expires_at);
+    }
+
+    /// Safe transfer from subscriber to merchant. Returns true on success.
+    fn safe_transfer_from(
+        env: &Env,
+        token: &Address,
+        from: &Address,
+        to: &Address,
+        amount: i128,
+    ) -> bool {
+        let token_client = token::Client::new(env, token);
+        token_client.transfer_from(
+            &env.current_contract_address(),
+            from,
+            to,
+            &amount,
+        );
+        true
+    }
+
+    /// Safe direct transfer (from contract to recipient). Returns true on success.
+    fn safe_transfer(
+        env: &Env,
+        token: &Address,
+        to: &Address,
+        amount: i128,
+    ) -> bool {
+        let token_client = token::Client::new(env, token);
+        token_client.transfer(&env.current_contract_address(), to, &amount);
+        true
     }
 
     /// Register a new subscription and authorize the initial token allowance.
@@ -157,6 +350,7 @@ impl SubscriptionRegistry {
         amount: i128,
         interval: u64,
     ) -> BytesN<32> {
+        Self::require_not_paused(&env);
         user.require_auth();
 
         if user == merchant {
@@ -203,6 +397,7 @@ impl SubscriptionRegistry {
             created_at: now,
             status: SubscriptionStatus::Active,
             escrow_id: None,
+            escrow_expires_at: None,
         };
 
         env.storage()
@@ -262,6 +457,7 @@ impl SubscriptionRegistry {
     /// allowed renewal window. Transfers `amount` from the subscriber to the
     /// merchant via the Stellar Asset Contract, then advances `next_renewal_date`.
     pub fn renew_subscription(env: Env, subscription_id: BytesN<32>) {
+        Self::require_not_paused(&env);
         let mut subscription: Subscription = env
             .storage()
             .persistent()
@@ -351,6 +547,7 @@ impl SubscriptionRegistry {
         next_renewal: u64,
         encrypted_blob: Bytes,
     ) -> BytesN<32> {
+        Self::require_not_paused(&env);
         user.require_auth();
         if billing_interval == 0 {
             panic!("billing_interval must be greater than 0");

--- a/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_admin_succeeds.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_admin_succeeds.1.json
@@ -235,6 +235,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_subscriber_sets_canceled_and_clears_allowance.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_subscriber_sets_canceled_and_clears_allowance.1.json
@@ -240,6 +240,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_third_party_fails.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/cancel_by_third_party_fails.1.json
@@ -194,6 +194,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/subscription_registry/test/register_persists_active_subscription.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/register_persists_active_subscription.1.json
@@ -196,6 +196,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/subscription_registry/test/renew_rejects_early_attempt.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/renew_rejects_early_attempt.1.json
@@ -194,6 +194,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/subscription_registry/test/renew_transfers_and_advances_next_renewal.1.json
+++ b/contracts/contracts/test_snapshots/subscription_registry/test/renew_transfers_and_advances_next_renewal.1.json
@@ -198,6 +198,12 @@
                   },
                   {
                     "key": {
+                      "symbol": "escrow_expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
                       "symbol": "escrow_id"
                     },
                     "val": "void"

--- a/contracts/contracts/test_snapshots/test_cancel_already_cancelled_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_cancel_already_cancelled_subscription.1.json
@@ -1,0 +1,259 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "cancel_subscription",
+              "args": [
+                {
+                  "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_cancel_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_cancel_subscription.1.json
@@ -1,0 +1,259 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "cancel_subscription",
+              "args": [
+                {
+                  "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_create_duplicate_subscription_fails.1.json
+++ b/contracts/contracts/test_snapshots/test_create_duplicate_subscription_fails.1.json
@@ -1,0 +1,217 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_create_multiple_subscriptions.1.json
+++ b/contracts/contracts/test_snapshots/test_create_multiple_subscriptions.1.json
@@ -1,0 +1,471 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "spotify"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "999"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "040506"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "hulu"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "799"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "070809"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000001eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "040506"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "999"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "spotify"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000002eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "070809"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "799"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "hulu"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "3"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          },
+                          {
+                            "bytes": "0000000000000001eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          },
+                          {
+                            "bytes": "0000000000000002eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_create_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_create_subscription.1.json
@@ -1,0 +1,218 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "0102030405"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "0102030405"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_create_subscription_invalid_billing_interval.1.json
+++ b/contracts/contracts/test_snapshots/test_create_subscription_invalid_billing_interval.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_create_subscription_negative_amount.1.json
+++ b/contracts/contracts/test_snapshots/test_create_subscription_negative_amount.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_get_nonexistent_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_get_nonexistent_subscription.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_multiple_users_independent.1.json
+++ b/contracts/contracts/test_snapshots/test_multiple_users_independent.1.json
@@ -1,0 +1,361 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "string": "spotify"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "999"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "040506"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000001ecb834aa2cf280ff49bec7c0e8c40383912f02678271e5c0"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "040506"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "999"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "spotify"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000001ecb834aa2cf280ff49bec7c0e8c40383912f02678271e5c0"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_subscription_id_uniqueness.1.json
+++ b/contracts/contracts/test_snapshots/test_subscription_id_uniqueness.1.json
@@ -1,0 +1,548 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "spotify"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "999"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "040506"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "hulu"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "799"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "070809"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000001eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "040506"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "999"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "spotify"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000002eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "070809"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "799"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "hulu"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "3"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          },
+                          {
+                            "bytes": "0000000000000001eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          },
+                          {
+                            "bytes": "0000000000000002eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "subscription_created_event"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "billing_interval"
+                  },
+                  "val": {
+                    "u64": "2592000"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "encrypted_blob"
+                  },
+                  "val": {
+                    "bytes": "070809"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "expected_amount"
+                  },
+                  "val": {
+                    "i128": "799"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "next_renewal"
+                  },
+                  "val": {
+                    "u64": "1735689600"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "service_id"
+                  },
+                  "val": {
+                    "string": "hulu"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subscription_id"
+                  },
+                  "val": {
+                    "bytes": "0000000000000002eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "user"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/test_snapshots/test_update_cancelled_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_update_cancelled_subscription.1.json
@@ -1,0 +1,259 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "cancel_subscription",
+              "args": [
+                {
+                  "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": false
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_update_nonexistent_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_update_nonexistent_subscription.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_update_subscription.1.json
+++ b/contracts/contracts/test_snapshots/test_update_subscription.1.json
@@ -1,0 +1,270 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "0102030405"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "update_subscription",
+              "args": [
+                {
+                  "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                "void",
+                "void",
+                {
+                  "i128": "1799"
+                },
+                {
+                  "u64": "1738281600"
+                },
+                {
+                  "bytes": "0a0b0c"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "0a0b0c"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1799"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1738281600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/test_snapshots/test_update_subscription_unauthorized.1.json
+++ b/contracts/contracts/test_snapshots/test_update_subscription_unauthorized.1.json
@@ -1,0 +1,217 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "netflix"
+                },
+                {
+                  "u64": "2592000"
+                },
+                {
+                  "i128": "1599"
+                },
+                {
+                  "u64": "1735689600"
+                },
+                {
+                  "bytes": "010203"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 27,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Subscription"
+                          },
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "billing_interval"
+                            },
+                            "val": {
+                              "u64": "2592000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_blob"
+                            },
+                            "val": {
+                              "bytes": "010203"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "encrypted_data"
+                            },
+                            "val": "void"
+                          },
+                          {
+                            "key": {
+                              "symbol": "expected_amount"
+                            },
+                            "val": {
+                              "i128": "1599"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "is_active"
+                            },
+                            "val": {
+                              "bool": true
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "next_renewal"
+                            },
+                            "val": {
+                              "u64": "1735689600"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "service_id"
+                            },
+                            "val": {
+                              "string": "netflix"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "SubscriptionCounter"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "UserSubscriptions"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "bytes": "0000000000000000eddee25b9bede2faaf5f05d12f000a0c5107f7ff137a2632"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Closes #1189
Closes #1191
Closes #1192
Closes #1193

## Summary

- **#1189**: Escrow refund edge cases — added escrow_expires_at field, refund_expired_escrow (user/admin can reclaim after expiry), set_escrow_expiration (admin), EscrowRefundedEvent
- **#1191**: Admin initialization — initialize function sets admin + platform fee in one call, PlatformFeeBps storage, get_platform_fee view, guards against double-init
- **#1192**: RBAC — set_fee (admin-only with event), pause_contract (admin-only with event), require_not_paused guard on register/renew/create, is_paused view
- **#1193**: SAC integration — safe_transfer_from and safe_transfer helpers wrapping token::Client for native XLM and custom asset transfers

## Files changed

- contracts/contracts/src/subscription_registry.rs — All 4 features integrated into existing contract
- contracts/contracts/src/lib.rs — Added #![no_std] for Soroban compatibility