### PR TITLE
hardening(subscription_renewal): replace panic!/unwrap/expect with ty…

### DIFF
--- a/contracts/contracts/subscription_renewal/src/fuzz.rs
+++ b/contracts/contracts/subscription_renewal/src/fuzz.rs
@@ -6,10 +6,9 @@ use soroban_sdk::{
     testutils::{Address as _, EnvTestConfig},
     Address, Env,
 };
-use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use super::{
-    SubscriptionRenewalContract, SubscriptionRenewalContractClient, SubscriptionState,
+    ContractError, SubscriptionRenewalContract, SubscriptionRenewalContractClient, SubscriptionState,
 };
 
 fn fuzz_env() -> Env {
@@ -25,7 +24,7 @@ fn fuzz_setup() -> (Env, Address, Address) {
     let id = env.register_contract(None, SubscriptionRenewalContract);
     let admin = Address::generate(&env);
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    client.init(&admin);
+    client.init(&admin).unwrap();
     (env, id, admin)
 }
 
@@ -47,7 +46,7 @@ proptest! {
 
         client.init_sub(&user, &merchant, &amount, &frequency, &spending_cap, &sub_id);
 
-        let data = client.get_sub(&sub_id);
+        let data = client.get_sub(&sub_id).unwrap();
         prop_assert_eq!(data.amount, amount);
         prop_assert_eq!(data.frequency, frequency);
         prop_assert_eq!(data.spending_cap, spending_cap);
@@ -68,18 +67,24 @@ proptest! {
         let sub_id = 42u64;
 
         client.init_sub(&user, &merchant, &amount, &86400u64, &spending_cap, &sub_id);
-        client.approve_renewal(&sub_id, &1u64, &renew_amount, &10_000u32);
-        client.acquire_renewal_lock(&sub_id, &200u32);
+        client.approve_renewal(&sub_id, &1u64, &renew_amount, &10_000u32).unwrap();
+        client.acquire_renewal_lock(&sub_id, &200u32).unwrap();
 
         let exceeds_cap = spending_cap > 0 && renew_amount > spending_cap;
 
         if exceeds_cap {
-            let result = catch_unwind(AssertUnwindSafe(|| {
-                client.renew(&sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260101u64, &true);
-            }));
-            prop_assert!(result.is_err(), "renewal exceeding cap must panic");
+            let result = client.try_renew(
+                &sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260101u64, &true,
+            );
+            prop_assert_eq!(
+                result.unwrap_err().unwrap(),
+                ContractError::SpendingCapExceeded,
+                "renewal exceeding cap must return SpendingCapExceeded"
+            );
         } else {
-            let ok = client.renew(&sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260101u64, &true);
+            let ok = client
+                .renew(&sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260101u64, &true)
+                .unwrap();
             prop_assert!(ok);
             let spent = client.get_user_spent(&user);
             prop_assert_eq!(spent, renew_amount);
@@ -98,15 +103,15 @@ proptest! {
         let user = Address::generate(&env);
         let merchant = Address::generate(&env);
 
-        client.set_user_cap(&user, &cap);
+        client.set_user_cap(&user, &cap).unwrap();
 
         let sub_a = 1u64;
         let sub_b = 2u64;
         client.init_sub(&user, &merchant, &100i128, &86400u64, &0i128, &sub_a);
         client.init_sub(&user, &merchant, &100i128, &86400u64, &0i128, &sub_b);
 
-        client.approve_renewal(&sub_a, &1u64, &first_amount, &10_000u32);
-        client.acquire_renewal_lock(&sub_a, &200u32);
+        client.approve_renewal(&sub_a, &1u64, &first_amount, &10_000u32).unwrap();
+        client.acquire_renewal_lock(&sub_a, &200u32).unwrap();
         if first_amount <= cap {
             let _ = client.renew(&sub_a, &1u64, &first_amount, &3u32, &10u32, &20260101u64, &true);
         }
@@ -114,19 +119,22 @@ proptest! {
         let spent = client.get_user_spent(&user);
         let remaining = cap.saturating_sub(spent);
 
-        client.approve_renewal(&sub_b, &1u64, &second_amount, &10_000u32);
-        client.acquire_renewal_lock(&sub_b, &200u32);
+        client.approve_renewal(&sub_b, &1u64, &second_amount, &10_000u32).unwrap();
+        client.acquire_renewal_lock(&sub_b, &200u32).unwrap();
 
         if second_amount > remaining {
-            let result = catch_unwind(AssertUnwindSafe(|| {
-                client.renew(&sub_b, &1u64, &second_amount, &3u32, &10u32, &20260201u64, &true);
-            }));
-            prop_assert!(result.is_err(), "global cap overflow must panic");
+            let result = client.try_renew(
+                &sub_b, &1u64, &second_amount, &3u32, &10u32, &20260201u64, &true,
+            );
+            prop_assert_eq!(
+                result.unwrap_err().unwrap(),
+                ContractError::GlobalCapExceeded,
+                "global cap overflow must return GlobalCapExceeded"
+            );
         }
     }
 
-    /// Admin-only set_paused must reject when contract is not initialized for random callers
-    /// (uninitialized contract panics on missing admin storage).
+    /// Admin-only set_paused must return NotInitialized when contract is not initialized.
     #[test]
     fn fuzz_uninitialized_contract_rejects_admin_ops(_seed in 0u64..=1000u64) {
         let env = fuzz_env();
@@ -134,13 +142,15 @@ proptest! {
         let id = env.register_contract(None, SubscriptionRenewalContract);
         let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            client.set_paused(&true);
-        }));
-        prop_assert!(result.is_err(), "admin ops on uninitialized contract must panic");
+        let result = client.try_set_paused(&true);
+        prop_assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::NotInitialized,
+            "admin ops on uninitialized contract must return NotInitialized"
+        );
     }
 
-    /// Approval single-use: consuming an approval twice must fail.
+    /// Approval single-use: consuming an approval twice must return InvalidApproval.
     #[test]
     fn fuzz_approval_single_use(
         amount in 1i128..=100_000i128,
@@ -154,15 +164,19 @@ proptest! {
         let renew_amount = amount.min(approval_max);
 
         client.init_sub(&user, &merchant, &amount, &86400u64, &0i128, &sub_id);
-        client.approve_renewal(&sub_id, &1u64, &approval_max, &10_000u32);
+        client.approve_renewal(&sub_id, &1u64, &approval_max, &10_000u32).unwrap();
 
-        client.acquire_renewal_lock(&sub_id, &200u32);
+        client.acquire_renewal_lock(&sub_id, &200u32).unwrap();
         let _ = client.renew(&sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260101u64, &true);
 
-        client.acquire_renewal_lock(&sub_id, &200u32);
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            client.renew(&sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260201u64, &true);
-        }));
-        prop_assert!(result.is_err(), "reused approval must panic");
+        client.acquire_renewal_lock(&sub_id, &200u32).unwrap();
+        let result = client.try_renew(
+            &sub_id, &1u64, &renew_amount, &3u32, &10u32, &20260201u64, &true,
+        );
+        prop_assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::InvalidApproval,
+            "reused approval must return InvalidApproval"
+        );
     }
 }

--- a/contracts/contracts/subscription_renewal/src/lib.rs
+++ b/contracts/contracts/subscription_renewal/src/lib.rs
@@ -1,7 +1,38 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, Env, IntoVal,
+    contract, contractevent, contractimpl, contracterror, contracttype, xdr::ToXdr,
+    Address, Bytes, Env, IntoVal,
 };
+
+// ── Error enum ────────────────────────────────────────────────────
+
+/// All typed errors returned by this contract.
+/// Discriminants must be u32 1..=N for Soroban ABI compatibility.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    AlreadyInitialized    = 1,
+    NotInitialized        = 2,
+    ProtocolPaused        = 3,
+    RenewalLockActive     = 4,
+    NoRenewalLock         = 5,
+    SubscriptionNotFound  = 6,
+    AlreadyCancelled      = 7,
+    LifecycleNotFound     = 8,
+    SubscriptionFailed    = 9,
+    RenewalLockRequired   = 10,
+    RenewalLockExpired    = 11,
+    DuplicateCycle        = 12,
+    CooldownActive        = 13,
+    InvalidApproval       = 14,
+    OutsideRenewalWindow  = 15,
+    IntegrityViolation    = 16,
+    SpendingCapExceeded   = 17,
+    GlobalCapExceeded     = 18,
+    InvalidWindow         = 19,
+}
+
+// ── Storage key types ─────────────────────────────────────────────
 
 /// Storage keys for contract-level state (admin, pause flag).
 #[contracttype]
@@ -40,6 +71,8 @@ struct RenewalLockKey {
 struct LifecycleKey {
     lifecycle_sub_id: u64,
 }
+
+// ── Data types ────────────────────────────────────────────────────
 
 /// Data stored for an active renewal lock
 #[contracttype]
@@ -95,7 +128,31 @@ pub struct LifecycleTimestamps {
     pub canceled_at: u64,
 }
 
-/// Events for subscription renewal tracking
+/// Storage key for renewal window per subscription
+#[contracttype]
+#[derive(Clone)]
+struct WindowKey {
+    sub_id: u64,
+}
+
+/// Billing window for a subscription renewal
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenewalWindow {
+    pub billing_start: u64,
+    pub billing_end: u64,
+}
+
+/// Storage key for global user spending caps
+#[contracttype]
+#[derive(Clone)]
+pub enum UserCapKey {
+    UserCap(Address),
+    UserSpent(Address),
+}
+
+// ── Events ────────────────────────────────────────────────────────
+
 #[contractevent]
 pub struct RenewalSuccess {
     pub sub_id: u64,
@@ -142,7 +199,7 @@ pub struct DuplicateRenewalRejected {
 }
 
 #[contractevent]
-pub struct IntegrityViolation {
+pub struct IntegrityViolationEvent {
     pub sub_id: u64,
 }
 
@@ -160,7 +217,7 @@ pub struct RenewalLockReleased {
 }
 
 #[contractevent]
-pub struct RenewalLockExpired {
+pub struct RenewalLockExpiredEvent {
     pub sub_id: u64,
     pub original_locked_at: u32,
     pub expired_at: u32,
@@ -200,29 +257,6 @@ pub struct UserCapUpdated {
     pub cap: i128,
 }
 
-/// Storage key for renewal window per subscription
-#[contracttype]
-#[derive(Clone)]
-struct WindowKey {
-    sub_id: u64,
-}
-
-/// Billing window for a subscription renewal
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RenewalWindow {
-    pub billing_start: u64,
-    pub billing_end: u64,
-}
-
-/// Storage key for global user spending caps
-#[contracttype]
-#[derive(Clone)]
-pub enum UserCapKey {
-    UserCap(Address),
-    UserSpent(Address),
-}
-
 #[contract]
 pub struct SubscriptionRenewalContract;
 
@@ -231,29 +265,32 @@ impl SubscriptionRenewalContract {
     // ── Admin / Pause management ──────────────────────────────────
 
     /// Initialize the contract admin. Can only be called once.
-    pub fn init(env: Env, admin: Address) {
+    pub fn init(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().instance().has(&ContractKey::Admin) {
-            panic!("Already initialized");
+            return Err(ContractError::AlreadyInitialized);
         }
         env.storage().instance().set(&ContractKey::Admin, &admin);
         env.storage().instance().set(&ContractKey::Paused, &false);
+        Ok(())
     }
 
     /// Internal helper – loads admin and calls `require_auth`.
-    fn require_admin(env: &Env) {
+    fn require_admin(env: &Env) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&ContractKey::Admin)
-            .expect("Contract not initialized");
+            .ok_or(ContractError::NotInitialized)?;
         admin.require_auth();
+        Ok(())
     }
 
     /// Pause or unpause all renewal execution. Admin only.
-    pub fn set_paused(env: Env, paused: bool) {
-        Self::require_admin(&env);
+    pub fn set_paused(env: Env, paused: bool) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         env.storage().instance().set(&ContractKey::Paused, &paused);
         PauseToggled { paused }.publish(&env);
+        Ok(())
     }
 
     /// Query the current pause state.
@@ -265,25 +302,23 @@ impl SubscriptionRenewalContract {
     }
 
     /// Set the logging contract address. Admin only.
-    pub fn set_logging_contract(env: Env, address: Address) {
-        Self::require_admin(&env);
+    pub fn set_logging_contract(env: Env, address: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         env.storage()
             .instance()
             .set(&ContractKey::LoggingContract, &address);
+        Ok(())
     }
 
     // ── Renewal lock management ────────────────────────────────────
 
     /// Acquire a processing lock for a subscription renewal.
-    /// Prevents concurrent renewal execution by multiple workers.
-    pub fn acquire_renewal_lock(env: Env, sub_id: u64, lock_timeout: u32) {
+    pub fn acquire_renewal_lock(env: Env, sub_id: u64, lock_timeout: u32) -> Result<(), ContractError> {
         if Self::is_paused(env.clone()) {
-            panic!("Protocol is paused");
+            return Err(ContractError::ProtocolPaused);
         }
 
-        let lock_key = RenewalLockKey {
-            lock_sub_id: sub_id,
-        };
+        let lock_key = RenewalLockKey { lock_sub_id: sub_id };
         let current_ledger = env.ledger().sequence();
 
         if let Some(existing) = env
@@ -291,12 +326,11 @@ impl SubscriptionRenewalContract {
             .persistent()
             .get::<RenewalLockKey, RenewalLockData>(&lock_key)
         {
-            // Check if existing lock has expired
             if current_ledger < existing.locked_at + existing.lock_timeout {
-                panic!("Renewal lock active");
+                return Err(ContractError::RenewalLockActive);
             }
             // Lock expired — emit expiry event and allow re-acquisition
-            RenewalLockExpired {
+            RenewalLockExpiredEvent {
                 sub_id,
                 original_locked_at: existing.locked_at,
                 expired_at: current_ledger,
@@ -304,44 +338,28 @@ impl SubscriptionRenewalContract {
             .publish(&env);
         }
 
-        let lock_data = RenewalLockData {
-            locked_at: current_ledger,
-            lock_timeout,
-        };
+        let lock_data = RenewalLockData { locked_at: current_ledger, lock_timeout };
         env.storage().persistent().set(&lock_key, &lock_data);
 
-        RenewalLockAcquired {
-            sub_id,
-            locked_at: current_ledger,
-            lock_timeout,
-        }
-        .publish(&env);
+        RenewalLockAcquired { sub_id, locked_at: current_ledger, lock_timeout }.publish(&env);
+        Ok(())
     }
 
     /// Release a processing lock for a subscription renewal.
-    pub fn release_renewal_lock(env: Env, sub_id: u64) {
-        let lock_key = RenewalLockKey {
-            lock_sub_id: sub_id,
-        };
+    pub fn release_renewal_lock(env: Env, sub_id: u64) -> Result<(), ContractError> {
+        let lock_key = RenewalLockKey { lock_sub_id: sub_id };
         if !env.storage().persistent().has(&lock_key) {
-            panic!("No renewal lock to release");
+            return Err(ContractError::NoRenewalLock);
         }
-
         let current_ledger = env.ledger().sequence();
         env.storage().persistent().remove(&lock_key);
-
-        RenewalLockReleased {
-            sub_id,
-            released_at: current_ledger,
-        }
-        .publish(&env);
+        RenewalLockReleased { sub_id, released_at: current_ledger }.publish(&env);
+        Ok(())
     }
 
     /// Query the current renewal lock for a subscription.
     pub fn get_renewal_lock(env: Env, sub_id: u64) -> Option<RenewalLockData> {
-        let lock_key = RenewalLockKey {
-            lock_sub_id: sub_id,
-        };
+        let lock_key = RenewalLockKey { lock_sub_id: sub_id };
         env.storage().persistent().get(&lock_key)
     }
 
@@ -363,7 +381,6 @@ impl SubscriptionRenewalContract {
         integrity_data.push_back(frequency.into_val(&env));
         integrity_data.push_back(spending_cap.into_val(&env));
 
-        // Use a simple hash of the vector of values
         let integrity_hash = env.crypto().sha256(&integrity_data.to_xdr(&env));
 
         let key = sub_id;
@@ -380,7 +397,6 @@ impl SubscriptionRenewalContract {
         };
         env.storage().persistent().set(&key, &data);
 
-        // Initialize lifecycle timestamps
         let now = env.ledger().timestamp();
         let lifecycle = LifecycleTimestamps {
             created_at: now,
@@ -388,25 +404,12 @@ impl SubscriptionRenewalContract {
             last_renewed_at: 0,
             canceled_at: 0,
         };
-        let lc_key = LifecycleKey {
-            lifecycle_sub_id: sub_id,
-        };
+        let lc_key = LifecycleKey { lifecycle_sub_id: sub_id };
         env.storage().persistent().set(&lc_key, &lifecycle);
 
-        LifecycleTimestampUpdated {
-            sub_id,
-            event_kind: 1,
-            timestamp: now,
-        }
-        .publish(&env);
-        LifecycleTimestampUpdated {
-            sub_id,
-            event_kind: 2,
-            timestamp: now,
-        }
-        .publish(&env);
+        LifecycleTimestampUpdated { sub_id, event_kind: 1, timestamp: now }.publish(&env);
+        LifecycleTimestampUpdated { sub_id, event_kind: 2, timestamp: now }.publish(&env);
 
-        // Record initialization log
         Self::record_log(
             &env,
             sub_id,
@@ -421,10 +424,6 @@ impl SubscriptionRenewalContract {
             .instance()
             .get::<_, Address>(&ContractKey::LoggingContract)
         {
-            // Here we would call the logging contract.
-            // Since we are in a multi-contract setup, we'd use a client.
-            // For now, we'll emit an event as a placeholder or assume the client is available.
-            // (In a real implementation, we'd use a cross-contract call).
             env.events().publish(
                 (soroban_sdk::symbol_short!("log"), sub_id),
                 (event_type, data_str),
@@ -433,44 +432,35 @@ impl SubscriptionRenewalContract {
     }
 
     /// Explicitly cancel a subscription
-    pub fn cancel_sub(env: Env, sub_id: u64) {
+    pub fn cancel_sub(env: Env, sub_id: u64) -> Result<(), ContractError> {
         let key = sub_id;
         let mut data: SubscriptionData = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("Subscription not found");
+            .ok_or(ContractError::SubscriptionNotFound)?;
 
         data.owner.require_auth();
 
         if data.state == SubscriptionState::Cancelled {
-            panic!("Subscription already cancelled");
+            return Err(ContractError::AlreadyCancelled);
         }
 
         data.state = SubscriptionState::Cancelled;
         env.storage().persistent().set(&key, &data);
 
-        // Update lifecycle timestamps
-        let lc_key = LifecycleKey {
-            lifecycle_sub_id: sub_id,
-        };
+        let lc_key = LifecycleKey { lifecycle_sub_id: sub_id };
         let mut lifecycle: LifecycleTimestamps = env
             .storage()
             .persistent()
             .get(&lc_key)
-            .expect("Lifecycle data not found");
+            .ok_or(ContractError::LifecycleNotFound)?;
         let now = env.ledger().timestamp();
         lifecycle.canceled_at = now;
         env.storage().persistent().set(&lc_key, &lifecycle);
 
-        LifecycleTimestampUpdated {
-            sub_id,
-            event_kind: 4,
-            timestamp: now,
-        }
-        .publish(&env);
+        LifecycleTimestampUpdated { sub_id, event_kind: 4, timestamp: now }.publish(&env);
 
-        // Record cancellation log
         Self::record_log(
             &env,
             sub_id,
@@ -478,12 +468,8 @@ impl SubscriptionRenewalContract {
             soroban_sdk::String::from_str(&env, "Subscription cancelled"),
         );
 
-        // Emit state transition event
-        StateTransition {
-            sub_id,
-            new_state: SubscriptionState::Cancelled,
-        }
-        .publish(&env);
+        StateTransition { sub_id, new_state: SubscriptionState::Cancelled }.publish(&env);
+        Ok(())
     }
 
     // ── Approval management ───────────────────────────────────────
@@ -495,101 +481,71 @@ impl SubscriptionRenewalContract {
         approval_id: u64,
         max_spend: i128,
         expires_at: u32,
-    ) {
+    ) -> Result<(), ContractError> {
         let sub_key = sub_id;
         let data: SubscriptionData = env
             .storage()
             .persistent()
             .get(&sub_key)
-            .expect("Subscription not found");
+            .ok_or(ContractError::SubscriptionNotFound)?;
 
         data.owner.require_auth();
 
-        let approval = RenewalApproval {
-            sub_id,
-            max_spend,
-            expires_at,
-            used: false,
-        };
-
-        let key = ApprovalKey {
-            sub_id,
-            approval_id,
-        };
+        let approval = RenewalApproval { sub_id, max_spend, expires_at, used: false };
+        let key = ApprovalKey { sub_id, approval_id };
         env.storage().persistent().set(&key, &approval);
 
-        ApprovalCreated {
-            sub_id,
-            approval_id,
-            max_spend,
-            expires_at,
-        }
-        .publish(&env);
+        ApprovalCreated { sub_id, approval_id, max_spend, expires_at }.publish(&env);
+        Ok(())
     }
 
-    /// Validate and consume an approval
-    fn consume_approval(env: &Env, sub_id: u64, approval_id: u64, amount: i128) -> bool {
-        let key = ApprovalKey {
-            sub_id,
-            approval_id,
-        };
-
+    /// Validate and consume an approval. Returns Ok(true) on success,
+    /// Ok(false) is never produced — failures return Err(ContractError::InvalidApproval).
+    fn consume_approval(
+        env: &Env,
+        sub_id: u64,
+        approval_id: u64,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        let key = ApprovalKey { sub_id, approval_id };
         let approval_opt: Option<RenewalApproval> = env.storage().persistent().get(&key);
 
         if approval_opt.is_none() {
-            ApprovalRejected {
-                sub_id,
-                approval_id,
-                reason: 4,
-            }
-            .publish(env);
-            return false;
+            ApprovalRejected { sub_id, approval_id, reason: 4 }.publish(env);
+            return Err(ContractError::InvalidApproval);
         }
 
-        let mut approval = approval_opt.unwrap();
+        // Safety: guarded by is_none() check above
+        let mut approval = match approval_opt {
+            Some(a) => a,
+            None => return Err(ContractError::InvalidApproval),
+        };
 
         if approval.used {
-            ApprovalRejected {
-                sub_id,
-                approval_id,
-                reason: 2,
-            }
-            .publish(env);
-            return false;
+            ApprovalRejected { sub_id, approval_id, reason: 2 }.publish(env);
+            return Err(ContractError::InvalidApproval);
         }
 
         let current_ledger = env.ledger().sequence();
         if current_ledger > approval.expires_at {
-            ApprovalRejected {
-                sub_id,
-                approval_id,
-                reason: 1,
-            }
-            .publish(env);
-            return false;
+            ApprovalRejected { sub_id, approval_id, reason: 1 }.publish(env);
+            return Err(ContractError::InvalidApproval);
         }
 
         if amount > approval.max_spend {
-            ApprovalRejected {
-                sub_id,
-                approval_id,
-                reason: 3,
-            }
-            .publish(env);
-            return false;
+            ApprovalRejected { sub_id, approval_id, reason: 3 }.publish(env);
+            return Err(ContractError::InvalidApproval);
         }
 
         approval.used = true;
         env.storage().persistent().set(&key, &approval);
-        true
+        Ok(())
     }
 
     // ── Renewal logic ─────────────────────────────────────────────
 
     /// Attempt to renew the subscription.
-    /// Returns true if renewal is successful (simulated), false if it failed and retry logic was triggered.
-    /// limits: max retries allowed.
-    /// cooldown: min ledgers between retries.
+    /// Returns Ok(true) on success, Ok(false) on simulated payment failure (retry path).
     pub fn renew(
         env: Env,
         sub_id: u64,
@@ -599,13 +555,12 @@ impl SubscriptionRenewalContract {
         cooldown_ledgers: u32,
         cycle_id: u64,
         succeed: bool,
-    ) -> bool {
+    ) -> Result<bool, ContractError> {
         // 1. Check global pause
         if Self::is_paused(env.clone()) {
-            panic!("Protocol is paused");
+            return Err(ContractError::ProtocolPaused);
         }
 
-        // Get current ledger early (needed for lock verification)
         let current_ledger = env.ledger().sequence();
 
         // 2. Load subscription data
@@ -614,57 +569,59 @@ impl SubscriptionRenewalContract {
             .storage()
             .persistent()
             .get(&key)
-            .expect("Subscription not found");
+            .ok_or(ContractError::SubscriptionNotFound)?;
 
         // 3. Check failed state
         if data.state == SubscriptionState::Failed {
-            panic!("Subscription is in FAILED state");
+            return Err(ContractError::SubscriptionFailed);
         }
 
         // 4. Verify renewal lock exists and is not expired
-        let lock_key = RenewalLockKey {
-            lock_sub_id: sub_id,
-        };
+        let lock_key = RenewalLockKey { lock_sub_id: sub_id };
         let lock_data: Option<RenewalLockData> = env.storage().persistent().get(&lock_key);
         match lock_data {
-            None => panic!("Renewal lock required"),
+            None => return Err(ContractError::RenewalLockRequired),
             Some(ref ld) => {
                 if current_ledger >= ld.locked_at + ld.lock_timeout {
-                    panic!("Renewal lock expired");
+                    return Err(ContractError::RenewalLockExpired);
                 }
             }
         }
 
-        // 5. Cycle guard: reject duplicate renewal for the same billing cycle
+        // 5. Cycle guard
         let cycle_key = CycleKey { sub_id };
         let last_cycle: Option<u64> = env.storage().persistent().get(&cycle_key);
         if let Some(last) = last_cycle {
             if cycle_id == last {
                 DuplicateRenewalRejected { sub_id, cycle_id }.publish(&env);
-                panic!("Duplicate renewal for cycle");
+                return Err(ContractError::DuplicateCycle);
             }
         }
 
         // 6. Check cooldown
-        if data.failure_count > 0 && current_ledger < data.last_attempt_ledger + cooldown_ledgers {
-            panic!("Cooldown period active");
+        if data.failure_count > 0
+            && current_ledger < data.last_attempt_ledger + cooldown_ledgers
+        {
+            return Err(ContractError::CooldownActive);
         }
 
-        // 7. Validate and consume approval (also checks renewal window if set)
-        if !Self::consume_approval(&env, sub_id, approval_id, amount) {
-            panic!("Invalid or expired approval");
-        }
+        // 7. Validate and consume approval
+        Self::consume_approval(&env, sub_id, approval_id, amount)?;
 
         // 7b. Enforce renewal window if configured
         let window_key = WindowKey { sub_id };
-        if let Some(window) = env.storage().persistent().get::<WindowKey, RenewalWindow>(&window_key) {
+        if let Some(window) = env
+            .storage()
+            .persistent()
+            .get::<WindowKey, RenewalWindow>(&window_key)
+        {
             let current_time = env.ledger().timestamp();
             if current_time < window.billing_start || current_time > window.billing_end {
-                panic!("Outside renewal window");
+                return Err(ContractError::OutsideRenewalWindow);
             }
         }
 
-        // 8. Validate Integrity Hash
+        // 8. Validate integrity hash
         let mut integrity_data = soroban_sdk::Vec::<soroban_sdk::Val>::new(&env);
         integrity_data.push_back(data.merchant.into_val(&env));
         integrity_data.push_back(data.amount.into_val(&env));
@@ -675,19 +632,14 @@ impl SubscriptionRenewalContract {
         let current_hash_bytes: soroban_sdk::BytesN<32> = current_hash.into();
 
         if current_hash_bytes.as_ref() != data.integrity_hash.as_ref() {
-            IntegrityViolation { sub_id }.publish(&env);
-            panic!("Subscription integrity violation: parameters tampered");
+            IntegrityViolationEvent { sub_id }.publish(&env);
+            return Err(ContractError::IntegrityViolation);
         }
 
         // 9. Enforce per-subscription spending cap
         if data.spending_cap > 0 && amount > data.spending_cap {
-            SpendingCapViolated {
-                sub_id,
-                amount,
-                cap: data.spending_cap,
-            }
-            .publish(&env);
-            panic!("Per-subscription spending cap exceeded");
+            SpendingCapViolated { sub_id, amount, cap: data.spending_cap }.publish(&env);
+            return Err(ContractError::SpendingCapExceeded);
         }
 
         // 10. Enforce global user spending cap
@@ -709,15 +661,13 @@ impl SubscriptionRenewalContract {
                     cap: global_cap,
                 }
                 .publish(&env);
-                panic!("Global user spending cap exceeded");
+                return Err(ContractError::GlobalCapExceeded);
             }
         }
 
         if succeed {
-            // Capture previous state before changing it
             let previous_state = data.state;
 
-            // Simulated success - renewal successful
             data.state = SubscriptionState::Active;
             data.failure_count = 0;
             data.last_attempt_ledger = current_ledger;
@@ -736,53 +686,30 @@ impl SubscriptionRenewalContract {
             // Store cycle_id on success only
             env.storage().persistent().set(&cycle_key, &cycle_id);
 
-            // Emit renewal success event
-            RenewalSuccess {
-                sub_id,
-                owner: data.owner.clone(),
-            }
-            .publish(&env);
+            RenewalSuccess { sub_id, owner: data.owner.clone() }.publish(&env);
 
             // Update lifecycle timestamps
-            let lc_key = LifecycleKey {
-                lifecycle_sub_id: sub_id,
-            };
+            let lc_key = LifecycleKey { lifecycle_sub_id: sub_id };
             let mut lifecycle: LifecycleTimestamps = env
                 .storage()
                 .persistent()
                 .get(&lc_key)
-                .expect("Lifecycle data not found");
+                .ok_or(ContractError::LifecycleNotFound)?;
             let now = env.ledger().timestamp();
             lifecycle.last_renewed_at = now;
 
-            LifecycleTimestampUpdated {
-                sub_id,
-                event_kind: 3,
-                timestamp: now,
-            }
-            .publish(&env);
+            LifecycleTimestampUpdated { sub_id, event_kind: 3, timestamp: now }.publish(&env);
 
-            // If recovering from Retrying, also update activated_at
             if previous_state == SubscriptionState::Retrying {
                 lifecycle.activated_at = now;
-                LifecycleTimestampUpdated {
-                    sub_id,
-                    event_kind: 2,
-                    timestamp: now,
-                }
-                .publish(&env);
+                LifecycleTimestampUpdated { sub_id, event_kind: 2, timestamp: now }.publish(&env);
             }
             env.storage().persistent().set(&lc_key, &lifecycle);
 
             // Auto-release lock
             env.storage().persistent().remove(&lock_key);
-            RenewalLockReleased {
-                sub_id,
-                released_at: current_ledger,
-            }
-            .publish(&env);
+            RenewalLockReleased { sub_id, released_at: current_ledger }.publish(&env);
 
-            // Record renewal success log
             Self::record_log(
                 &env,
                 sub_id,
@@ -790,14 +717,11 @@ impl SubscriptionRenewalContract {
                 soroban_sdk::String::from_str(&env, "Renewal successful"),
             );
 
-            true
+            Ok(true)
         } else {
-            // Simulated failure - renewal failed, apply retry logic
-            // Do NOT store cycle_id on failure — retries with same cycle_id remain allowed
             data.failure_count += 1;
             data.last_attempt_ledger = current_ledger;
 
-            // Emit renewal failure event
             RenewalFailed {
                 sub_id,
                 failure_count: data.failure_count,
@@ -805,16 +729,9 @@ impl SubscriptionRenewalContract {
             }
             .publish(&env);
 
-            // Determine new state based on retry count
             if data.failure_count > max_retries {
                 data.state = SubscriptionState::Failed;
-                StateTransition {
-                    sub_id,
-                    new_state: SubscriptionState::Failed,
-                }
-                .publish(&env);
-
-                // Record failure log
+                StateTransition { sub_id, new_state: SubscriptionState::Failed }.publish(&env);
                 Self::record_log(
                     &env,
                     sub_id,
@@ -823,13 +740,7 @@ impl SubscriptionRenewalContract {
                 );
             } else {
                 data.state = SubscriptionState::Retrying;
-                StateTransition {
-                    sub_id,
-                    new_state: SubscriptionState::Retrying,
-                }
-                .publish(&env);
-
-                // Record retry log
+                StateTransition { sub_id, new_state: SubscriptionState::Retrying }.publish(&env);
                 Self::record_log(
                     &env,
                     sub_id,
@@ -842,51 +753,43 @@ impl SubscriptionRenewalContract {
 
             // Auto-release lock
             env.storage().persistent().remove(&lock_key);
-            RenewalLockReleased {
-                sub_id,
-                released_at: current_ledger,
-            }
-            .publish(&env);
+            RenewalLockReleased { sub_id, released_at: current_ledger }.publish(&env);
 
-            false
+            Ok(false)
         }
     }
 
-    pub fn get_sub(env: Env, sub_id: u64) -> SubscriptionData {
+    pub fn get_sub(env: Env, sub_id: u64) -> Result<SubscriptionData, ContractError> {
         env.storage()
             .persistent()
             .get(&sub_id)
-            .expect("Subscription not found")
+            .ok_or(ContractError::SubscriptionNotFound)
     }
 
-    pub fn get_lifecycle(env: Env, sub_id: u64) -> LifecycleTimestamps {
-        let lc_key = LifecycleKey {
-            lifecycle_sub_id: sub_id,
-        };
+    pub fn get_lifecycle(env: Env, sub_id: u64) -> Result<LifecycleTimestamps, ContractError> {
+        let lc_key = LifecycleKey { lifecycle_sub_id: sub_id };
         env.storage()
             .persistent()
             .get(&lc_key)
-            .expect("Lifecycle data not found")
+            .ok_or(ContractError::LifecycleNotFound)
     }
 
     /// Set a billing window for a subscription. Admin only.
-    pub fn set_window(env: Env, sub_id: u64, billing_start: u64, billing_end: u64) {
-        Self::require_admin(&env);
+    pub fn set_window(
+        env: Env,
+        sub_id: u64,
+        billing_start: u64,
+        billing_end: u64,
+    ) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         if billing_start >= billing_end {
-            panic!("Invalid window: start must be before end");
+            return Err(ContractError::InvalidWindow);
         }
         let key = WindowKey { sub_id };
-        let window = RenewalWindow {
-            billing_start,
-            billing_end,
-        };
+        let window = RenewalWindow { billing_start, billing_end };
         env.storage().persistent().set(&key, &window);
-        WindowUpdated {
-            sub_id,
-            billing_start,
-            billing_end,
-        }
-        .publish(&env);
+        WindowUpdated { sub_id, billing_start, billing_end }.publish(&env);
+        Ok(())
     }
 
     /// Get the billing window for a subscription.
@@ -896,12 +799,13 @@ impl SubscriptionRenewalContract {
     }
 
     /// Set global spending cap for a user. Admin only.
-    pub fn set_user_cap(env: Env, user: Address, cap: i128) {
-        Self::require_admin(&env);
+    pub fn set_user_cap(env: Env, user: Address, cap: i128) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
         env.storage()
             .persistent()
             .set(&UserCapKey::UserCap(user.clone()), &cap);
         UserCapUpdated { user, cap }.publish(&env);
+        Ok(())
     }
 
     /// Get global spending cap for a user.

--- a/contracts/contracts/subscription_renewal/src/test.rs
+++ b/contracts/contracts/subscription_renewal/src/test.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
 
 use super::{
-    SubscriptionRenewalContract, SubscriptionRenewalContractClient, SubscriptionState,
+    ContractError, SubscriptionRenewalContract, SubscriptionRenewalContractClient, SubscriptionState,
 };
 
 fn setup() -> (Env, Address, Address) {
@@ -12,9 +12,22 @@ fn setup() -> (Env, Address, Address) {
     let id = env.register_contract(None, SubscriptionRenewalContract);
     let admin = Address::generate(&env);
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    client.init(&admin);
+    client.init(&admin).unwrap();
     (env, id, admin)
 }
+
+// ── Init tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_cannot_init_twice() {
+    let (env, id, _admin) = setup();
+    let client = SubscriptionRenewalContractClient::new(&env, &id);
+    let another = Address::generate(&env);
+    let err = client.try_init(&another).unwrap_err().unwrap();
+    assert_eq!(err, ContractError::AlreadyInitialized);
+}
+
+// ── Renewal success / failure ─────────────────────────────────────
 
 #[test]
 fn test_renew_works_after_unpause() {
@@ -22,32 +35,18 @@ fn test_renew_works_after_unpause() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 101;
-
+    let sub_id = 101u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    // Pause then unpause
-    client.set_paused(&true);
-    client.set_paused(&false);
+    client.set_paused(&true).unwrap();
+    client.set_paused(&false).unwrap();
 
-    // Should succeed now
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true).unwrap();
     assert!(result);
 }
-
-#[test]
-#[should_panic(expected = "Already initialized")]
-fn test_cannot_init_twice() {
-    let (env, id, _admin) = setup();
-    let client = SubscriptionRenewalContractClient::new(&env, &id);
-    let another = Address::generate(&env);
-    client.init(&another);
-}
-
-// ── Original tests (updated to use setup helper) ─────────────────
 
 #[test]
 fn test_renewal_success() {
@@ -55,17 +54,16 @@ fn test_renewal_success() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 123;
-
+    let sub_id = 123u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260115, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260115, &true).unwrap();
     assert!(result);
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Active);
     assert_eq!(data.failure_count, 0);
 }
@@ -76,93 +74,59 @@ fn test_retry_logic() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 456;
-    let max_retries = 2;
-    let cooldown = 10;
-
+    let sub_id = 456u64;
+    let max_retries = 2u32;
+    let cooldown = 10u32;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First failure (cycle_id same for retries — allowed because failure doesn't store cycle)
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(
-        &sub_id,
-        &1,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260201,
-        &false,
-    );
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &max_retries, &cooldown, &20260201, &false).unwrap();
     assert!(!result);
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Retrying);
     assert_eq!(data.failure_count, 1);
 
-    // Advance ledger to pass cooldown
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 100;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 100; });
 
-    // renewal attempt but fail again (ledger 100)
-    client.approve_renewal(&sub_id, &2, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &2,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260201,
-        &false,
-    );
+    client.approve_renewal(&sub_id, &2, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &max_retries, &cooldown, &20260201, &false).unwrap();
 
-    // Advance past cooldown
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 120;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 120; });
 
-    // Third failure (count becomes 3 > max_retries 2) -> Should fail
-    client.approve_renewal(&sub_id, &3, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &3,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260201,
-        &false,
-    );
+    client.approve_renewal(&sub_id, &3, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &3, &500, &max_retries, &cooldown, &20260201, &false).unwrap();
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Failed);
     assert_eq!(data.failure_count, 3);
 }
 
 #[test]
-#[should_panic(expected = "Cooldown period active")]
 fn test_cooldown_enforcement() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 789;
-
+    let sub_id = 789u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // Fail once
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260301, &false);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20260301, &false).unwrap();
 
-    // Try again immediately (cooldown not met)
-    client.approve_renewal(&sub_id, &2, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &2, &500, &3, &10, &20260301, &false);
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &2, &500, &3, &10, &20260301, &false)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::CooldownActive);
 }
 
 #[test]
@@ -171,19 +135,16 @@ fn test_event_emission_on_success() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 999;
-
+    let sub_id = 999u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    // Successful renewal should emit RenewalSuccess event
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260315, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260315, &true).unwrap();
     assert!(result);
 
-    // Verify event was emitted by checking subscription data
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Active);
     assert_eq!(data.failure_count, 0);
 }
@@ -194,19 +155,16 @@ fn test_zero_max_retries() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 111;
-    let max_retries = 0;
-
+    let sub_id = 111u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    // First failure with max_retries = 0 should immediately fail
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &max_retries, &10, &20260401, &false);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &0, &10, &20260401, &false).unwrap();
     assert!(!result);
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Failed);
     assert_eq!(data.failure_count, 1);
 }
@@ -217,124 +175,70 @@ fn test_multiple_failures_then_success() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 222;
-    let max_retries = 3;
-    let cooldown = 10;
-
+    let sub_id = 222u64;
+    let max_retries = 3u32;
+    let cooldown = 10u32;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First failure
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &1,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260501,
-        &false,
-    );
-    let data = client.get_sub(&sub_id);
-    assert_eq!(data.state, SubscriptionState::Retrying);
-    assert_eq!(data.failure_count, 1);
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &max_retries, &cooldown, &20260501, &false).unwrap();
+    assert_eq!(client.get_sub(&sub_id).unwrap().state, SubscriptionState::Retrying);
 
-    // Advance ledger
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 20; });
 
-    // Second failure
-    client.approve_renewal(&sub_id, &2, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &2,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260501,
-        &false,
-    );
-    let data = client.get_sub(&sub_id);
-    assert_eq!(data.state, SubscriptionState::Retrying);
-    assert_eq!(data.failure_count, 2);
+    client.approve_renewal(&sub_id, &2, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &max_retries, &cooldown, &20260501, &false).unwrap();
+    assert_eq!(client.get_sub(&sub_id).unwrap().state, SubscriptionState::Retrying);
 
-    // Advance ledger
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 40;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 40; });
 
-    // Now succeed - should reset failure count and return to Active
-    client.approve_renewal(&sub_id, &3, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &3, &500, &max_retries, &cooldown, &20260501, &true);
+    client.approve_renewal(&sub_id, &3, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &3, &500, &max_retries, &cooldown, &20260501, &true).unwrap();
     assert!(result);
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Active);
     assert_eq!(data.failure_count, 0);
 }
 
 #[test]
-#[should_panic(expected = "Subscription is in FAILED state")]
 fn test_cannot_renew_failed_subscription() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 333;
-    let max_retries = 1;
-    let cooldown = 10;
-
+    let sub_id = 333u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // Fail twice to reach Failed state
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &1,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260601,
-        &false,
-    );
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &1, &10, &20260601, &false).unwrap();
 
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 20; });
 
-    client.approve_renewal(&sub_id, &2, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(
-        &sub_id,
-        &2,
-        &500,
-        &max_retries,
-        &cooldown,
-        &20260601,
-        &false,
-    );
+    client.approve_renewal(&sub_id, &2, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &1, &10, &20260601, &false).unwrap();
 
-    let data = client.get_sub(&sub_id);
-    assert_eq!(data.state, SubscriptionState::Failed);
+    assert_eq!(client.get_sub(&sub_id).unwrap().state, SubscriptionState::Failed);
 
-    // Advance ledger
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 40;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 40; });
 
-    // Try to renew a FAILED subscription - should panic
-    client.approve_renewal(&sub_id, &3, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &3, &500, &max_retries, &cooldown, &20260701, &true);
+    client.approve_renewal(&sub_id, &3, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &3, &500, &1, &10, &20260701, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::SubscriptionFailed);
 }
 
-// ── Approval system tests ────────────────────────────────────────
+// ── Approval system tests ─────────────────────────────────────────
 
 #[test]
 fn test_approval_required_for_renewal() {
@@ -342,110 +246,96 @@ fn test_approval_required_for_renewal() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 500;
-    let approval_id = 1;
-
+    let sub_id = 500u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    // Create approval
-    client.approve_renewal(&sub_id, &approval_id, &1000, &100);
-
-    // Renew with valid approval
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &approval_id, &500, &3, &10, &20260801, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260801, &true).unwrap();
     assert!(result);
 }
 
 #[test]
-#[should_panic(expected = "Invalid or expired approval")]
 fn test_renewal_without_approval_fails() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 501;
-
+    let sub_id = 501u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // Try to renew without creating approval
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &999, &500, &3, &10, &20260901, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &999, &500, &3, &10, &20260901, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidApproval);
 }
 
 #[test]
-#[should_panic(expected = "Invalid or expired approval")]
 fn test_approval_cannot_be_reused() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 502;
-    let approval_id = 2;
-
+    let sub_id = 502u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &approval_id, &1000, &100);
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
 
-    // First use - should succeed
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &approval_id, &500, &3, &10, &20261001, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &3, &10, &20261001, &true).unwrap();
 
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 20; });
 
-    // Second use - should fail (already used) — use different cycle_id to bypass cycle guard
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &approval_id, &500, &3, &10, &20261101, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &2, &500, &3, &10, &20261101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidApproval);
 }
 
 #[test]
-#[should_panic(expected = "Invalid or expired approval")]
 fn test_expired_approval_rejected() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 503;
-    let approval_id = 3;
-
+    let sub_id = 503u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.approve_renewal(&sub_id, &3, &1000, &50).unwrap();
 
-    // Create approval that expires at ledger 50
-    client.approve_renewal(&sub_id, &approval_id, &1000, &50);
+    env.ledger().with_mut(|li| { li.sequence_number = 51; });
 
-    // Advance past expiration
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 51;
-    });
-
-    // Try to use expired approval
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &approval_id, &500, &3, &10, &20261201, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &3, &500, &3, &10, &20261201, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidApproval);
 }
 
 #[test]
-#[should_panic(expected = "Invalid or expired approval")]
 fn test_amount_exceeds_max_spend() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 504;
-    let approval_id = 4;
-
+    let sub_id = 504u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.approve_renewal(&sub_id, &4, &1000, &100).unwrap();
 
-    // Create approval with max_spend = 1000
-    client.approve_renewal(&sub_id, &approval_id, &1000, &100);
-
-    // Try to renew with amount > max_spend
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &approval_id, &1500, &3, &10, &20270101, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &4, &1500, &3, &10, &20270101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidApproval);
 }
 
 #[test]
@@ -454,54 +344,47 @@ fn test_multiple_approvals_for_same_subscription() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 505;
-
+    let sub_id = 505u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &5000, &sub_id);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.approve_renewal(&sub_id, &2, &2000, &200).unwrap();
 
-    // Create multiple approvals
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.approve_renewal(&sub_id, &2, &2000, &200);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20270201, &true).unwrap();
 
-    // Use first approval
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20270201, &true);
+    env.ledger().with_mut(|li| { li.sequence_number = 20; });
 
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-    });
-
-    // Use second approval — different cycle_id since first succeeded
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &2, &1500, &3, &10, &20270301, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &2, &1500, &3, &10, &20270301, &true).unwrap();
     assert!(result);
 }
 
-// ── Cycle guard tests ────────────────────────────────────────────
+// ── Cycle guard tests ─────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Duplicate renewal for cycle")]
 fn test_duplicate_cycle_rejected_after_success() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 600;
-    let cycle_id = 20260315;
-
+    let sub_id = 600u64;
+    let cycle_id = 20260315u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First renewal succeeds — stores cycle_id
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &cycle_id, &true);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &cycle_id, &true).unwrap();
     assert!(result);
 
-    // Second renewal with same cycle_id — should panic
-    client.approve_renewal(&sub_id, &2, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &2, &500, &3, &10, &cycle_id, &true);
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &2, &500, &3, &10, &cycle_id, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::DuplicateCycle);
 }
 
 #[test]
@@ -510,27 +393,21 @@ fn test_retry_same_cycle_allowed_after_failure() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 601;
-    let cycle_id = 20260315;
-
+    let sub_id = 601u64;
+    let cycle_id = 20260315u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First attempt fails — does NOT store cycle_id
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &cycle_id, &false);
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &cycle_id, &false).unwrap();
     assert!(!result);
 
-    // Advance ledger past cooldown
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 20; });
 
-    // Retry with same cycle_id — should succeed because failure didn't record cycle
-    client.approve_renewal(&sub_id, &2, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &2, &500, &3, &10, &cycle_id, &true);
+    client.approve_renewal(&sub_id, &2, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &2, &500, &3, &10, &cycle_id, &true).unwrap();
     assert!(result);
 }
 
@@ -540,21 +417,18 @@ fn test_different_cycle_allowed_after_success() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 602;
-
+    let sub_id = 602u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First cycle succeeds
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260315, &true);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260315, &true).unwrap();
     assert!(result);
 
-    // Different cycle_id — should succeed
-    client.approve_renewal(&sub_id, &2, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &2, &500, &3, &10, &20260415, &true);
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &2, &500, &3, &10, &20260415, &true).unwrap();
     assert!(result);
 }
 
@@ -564,20 +438,20 @@ fn test_first_renewal_always_allowed() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 603;
-
+    let sub_id = 603u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First renewal ever — no stored cycle, guard passes
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true).unwrap();
     assert!(result);
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Active);
 }
+
+// ── Cancel sub tests ──────────────────────────────────────────────
 
 #[test]
 fn test_cancel_sub() {
@@ -585,118 +459,119 @@ fn test_cancel_sub() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 600;
-
+    let sub_id = 604u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // Cancel subscription
-    client.cancel_sub(&sub_id);
+    client.cancel_sub(&sub_id).unwrap();
 
-    let data = client.get_sub(&sub_id);
+    let data = client.get_sub(&sub_id).unwrap();
     assert_eq!(data.state, SubscriptionState::Cancelled);
 }
 
 #[test]
-#[should_panic(expected = "Subscription already cancelled")]
 fn test_cannot_cancel_twice() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 601;
-
+    let sub_id = 605u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    client.cancel_sub(&sub_id);
-    client.cancel_sub(&sub_id);
+    client.cancel_sub(&sub_id).unwrap();
+    let err = client.try_cancel_sub(&sub_id).unwrap_err().unwrap();
+    assert_eq!(err, ContractError::AlreadyCancelled);
 }
 
 #[test]
-#[should_panic(expected = "Subscription not found")]
 fn test_cancel_non_existent_sub() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    client.cancel_sub(&999);
+
+    let err = client.try_cancel_sub(&999).unwrap_err().unwrap();
+    assert_eq!(err, ContractError::SubscriptionNotFound);
 }
 
+// ── Spending cap tests ────────────────────────────────────────────
+
 #[test]
-#[should_panic(expected = "Per-subscription spending cap exceeded")]
 fn test_per_subscription_spending_cap() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let sub_id = 700;
-
-    // Cap is 1000
+    let sub_id = 700u64;
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &2000, &100);
+    client.approve_renewal(&sub_id, &1, &2000, &100).unwrap();
 
-    // Try to renew with 1500 (exceeds 1000 cap)
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &1500, &3, &10, &20270101, &true);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &1, &1500, &3, &10, &20270101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::SpendingCapExceeded);
 }
 
 #[test]
-#[should_panic(expected = "Global user spending cap exceeded")]
 fn test_global_user_spending_cap() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let merchant = Address::generate(&env);
+    client.set_user_cap(&user, &2000).unwrap();
 
-    // Set global cap for user to 2000
-    client.set_user_cap(&user, &2000);
-
-    let sub_id_1 = 701;
-    let sub_id_2 = 702;
-
+    let sub_id_1 = 701u64;
+    let sub_id_2 = 702u64;
     client.init_sub(&user, &merchant, &1500, &86400, &5000, &sub_id_1);
     client.init_sub(&user, &merchant, &1000, &86400, &5000, &sub_id_2);
 
-    client.approve_renewal(&sub_id_1, &1, &2000, &100);
-    client.approve_renewal(&sub_id_2, &1, &2000, &100);
+    client.approve_renewal(&sub_id_1, &1, &2000, &100).unwrap();
+    client.approve_renewal(&sub_id_2, &1, &2000, &100).unwrap();
 
-    // First renewal: 1500. Total spent: 1500 / 2000
-    client.acquire_renewal_lock(&sub_id_1, &200);
-    client.renew(&sub_id_1, &1, &1500, &3, &10, &20260101, &true);
+    client.acquire_renewal_lock(&sub_id_1, &200).unwrap();
+    client.renew(&sub_id_1, &1, &1500, &3, &10, &20260101, &true).unwrap();
 
-    // Second renewal: 1000. Total would be 2500 / 2000 -> Should panic
-    client.acquire_renewal_lock(&sub_id_2, &200);
-    client.renew(&sub_id_2, &1, &1000, &3, &10, &20260101, &true);
+    client.acquire_renewal_lock(&sub_id_2, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id_2, &1, &1000, &3, &10, &20260101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::GlobalCapExceeded);
 }
 
-// ── Renewal lock tests ──────────────────────────────────────────
+// ── Renewal lock tests ────────────────────────────────────────────
 
 #[test]
 fn test_acquire_renewal_lock() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 700;
-
-    client.acquire_renewal_lock(&sub_id, &200);
+    let sub_id = 710u64;
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
 
     let lock = client.get_renewal_lock(&sub_id);
     assert!(lock.is_some());
     let lock_data = lock.unwrap();
-    assert_eq!(lock_data.locked_at, 0); // default ledger
+    assert_eq!(lock_data.locked_at, 0);
     assert_eq!(lock_data.lock_timeout, 200);
 }
 
 #[test]
-#[should_panic(expected = "Renewal lock active")]
 fn test_lock_prevents_concurrent_acquisition() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 701;
+    let sub_id = 711u64;
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &200);
-    // Second acquire should panic
-    client.acquire_renewal_lock(&sub_id, &200);
+    let err = client
+        .try_acquire_renewal_lock(&sub_id, &200)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::RenewalLockActive);
 }
 
 #[test]
@@ -704,17 +579,12 @@ fn test_lock_auto_expires_and_reacquirable() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 702;
+    let sub_id = 712u64;
+    client.acquire_renewal_lock(&sub_id, &50).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &50);
+    env.ledger().with_mut(|li| { li.sequence_number = 60; });
 
-    // Advance ledger past lock timeout
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 60;
-    });
-
-    // Should succeed — old lock expired
-    client.acquire_renewal_lock(&sub_id, &200);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
 
     let lock = client.get_renewal_lock(&sub_id);
     assert!(lock.is_some());
@@ -728,40 +598,42 @@ fn test_release_renewal_lock() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 703;
-
-    client.acquire_renewal_lock(&sub_id, &200);
+    let sub_id = 713u64;
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
     assert!(client.get_renewal_lock(&sub_id).is_some());
 
-    client.release_renewal_lock(&sub_id);
+    client.release_renewal_lock(&sub_id).unwrap();
     assert!(client.get_renewal_lock(&sub_id).is_none());
 }
 
 #[test]
-#[should_panic(expected = "No renewal lock to release")]
-fn test_release_nonexistent_lock_panics() {
+fn test_release_nonexistent_lock() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 704;
-    client.release_renewal_lock(&sub_id);
+    let err = client
+        .try_release_renewal_lock(&714u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::NoRenewalLock);
 }
 
 #[test]
-#[should_panic(expected = "Renewal lock required")]
-fn test_renew_without_lock_panics() {
+fn test_renew_without_lock_fails() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 705;
-
+    let sub_id = 715u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    // Renew without acquiring lock — should panic
-    client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::RenewalLockRequired);
 }
 
 #[test]
@@ -770,19 +642,16 @@ fn test_renew_with_lock_succeeds_and_auto_releases() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 706;
-
+    let sub_id = 716u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &100);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &200);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
     assert!(client.get_renewal_lock(&sub_id).is_some());
 
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true).unwrap();
     assert!(result);
-
-    // Lock should be auto-released after renew
     assert!(client.get_renewal_lock(&sub_id).is_none());
 }
 
@@ -792,57 +661,73 @@ fn test_renew_failure_also_releases_lock() {
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 707;
-
+    let sub_id = 717u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &200);
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &200);
-    assert!(client.get_renewal_lock(&sub_id).is_some());
-
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &false);
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101, &false).unwrap();
     assert!(!result);
-
-    // Lock should be auto-released even after failure
     assert!(client.get_renewal_lock(&sub_id).is_none());
 }
 
 #[test]
-#[should_panic(expected = "Renewal lock expired")]
-fn test_renew_with_expired_lock_panics() {
+fn test_renew_with_expired_lock_fails() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
     let user = Address::generate(&env);
-    let sub_id = 708;
-
+    let sub_id = 718u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    client.approve_renewal(&sub_id, &1, &1000, &200);
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
 
-    client.acquire_renewal_lock(&sub_id, &50);
+    client.acquire_renewal_lock(&sub_id, &50).unwrap();
 
-    // Advance ledger past lock timeout
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 60;
-    });
+    env.ledger().with_mut(|li| { li.sequence_number = 60; });
 
-    // Renew with expired lock — should panic
-    client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::RenewalLockExpired);
 }
 
 #[test]
-#[should_panic(expected = "Protocol is paused")]
 fn test_acquire_lock_blocked_when_paused() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    let sub_id = 709;
+    let sub_id = 719u64;
+    client.set_paused(&true).unwrap();
 
-    client.set_paused(&true);
-    // Should panic because protocol is paused
-    client.acquire_renewal_lock(&sub_id, &200);
+    let err = client
+        .try_acquire_renewal_lock(&sub_id, &200)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::ProtocolPaused);
+}
+
+#[test]
+fn test_renew_blocked_when_paused() {
+    let (env, id, _admin) = setup();
+    let client = SubscriptionRenewalContractClient::new(&env, &id);
+
+    let user = Address::generate(&env);
+    let sub_id = 720u64;
+    let merchant = Address::generate(&env);
+    client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    // acquire lock before pausing
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.set_paused(&true).unwrap();
+
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::ProtocolPaused);
 }
 
 // ── Lifecycle timestamp tests ─────────────────────────────────────
@@ -852,17 +737,14 @@ fn test_lifecycle_created_on_init() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
 
     let user = Address::generate(&env);
-    let sub_id = 800;
-
+    let sub_id = 800u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    let lc = client.get_lifecycle(&sub_id);
+    let lc = client.get_lifecycle(&sub_id).unwrap();
     assert_eq!(lc.created_at, 1700000000);
     assert_eq!(lc.activated_at, 1700000000);
     assert_eq!(lc.last_renewed_at, 0);
@@ -874,27 +756,20 @@ fn test_lifecycle_renewed_at_updated_on_success() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
-
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
     let user = Address::generate(&env);
-    let sub_id = 801;
-
+    let sub_id = 801u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700100000;
-    });
+    env.ledger().with_mut(|li| { li.timestamp = 1700100000; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true).unwrap();
 
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260101, &true);
-
-    let lc = client.get_lifecycle(&sub_id);
+    let lc = client.get_lifecycle(&sub_id).unwrap();
     assert_eq!(lc.created_at, 1700000000);
-    assert_eq!(lc.activated_at, 1700000000); // unchanged — not recovering
+    assert_eq!(lc.activated_at, 1700000000);
     assert_eq!(lc.last_renewed_at, 1700100000);
     assert_eq!(lc.canceled_at, 0);
 }
@@ -904,23 +779,16 @@ fn test_lifecycle_canceled_at_set_on_cancel() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
-
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
     let user = Address::generate(&env);
-    let sub_id = 802;
-
+    let sub_id = 802u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700200000;
-    });
+    env.ledger().with_mut(|li| { li.timestamp = 1700200000; });
+    client.cancel_sub(&sub_id).unwrap();
 
-    client.cancel_sub(&sub_id);
-
-    let lc = client.get_lifecycle(&sub_id);
+    let lc = client.get_lifecycle(&sub_id).unwrap();
     assert_eq!(lc.created_at, 1700000000);
     assert_eq!(lc.canceled_at, 1700200000);
 }
@@ -930,39 +798,26 @@ fn test_lifecycle_activated_at_updated_on_recovery_from_retrying() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
-
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
     let user = Address::generate(&env);
-    let sub_id = 803;
-
+    let sub_id = 803u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // Fail once to enter Retrying
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700100000;
-    });
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260201, &false);
+    env.ledger().with_mut(|li| { li.timestamp = 1700100000; });
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20260201, &false).unwrap();
+    assert_eq!(client.get_sub(&sub_id).unwrap().state, SubscriptionState::Retrying);
 
-    let data = client.get_sub(&sub_id);
-    assert_eq!(data.state, SubscriptionState::Retrying);
+    env.ledger().with_mut(|li| { li.sequence_number = 20; li.timestamp = 1700200000; });
+    client.approve_renewal(&sub_id, &2, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &3, &10, &20260201, &true).unwrap();
 
-    // Advance past cooldown, succeed
-    env.ledger().with_mut(|li| {
-        li.sequence_number = 20;
-        li.timestamp = 1700200000;
-    });
-    client.approve_renewal(&sub_id, &2, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &2, &500, &3, &10, &20260201, &true);
-
-    let lc = client.get_lifecycle(&sub_id);
+    let lc = client.get_lifecycle(&sub_id).unwrap();
     assert_eq!(lc.created_at, 1700000000);
-    assert_eq!(lc.activated_at, 1700200000); // updated on recovery
+    assert_eq!(lc.activated_at, 1700200000);
     assert_eq!(lc.last_renewed_at, 1700200000);
     assert_eq!(lc.canceled_at, 0);
 }
@@ -972,26 +827,20 @@ fn test_lifecycle_not_updated_on_renewal_failure() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
-
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
     let user = Address::generate(&env);
-    let sub_id = 804;
-
+    let sub_id = 804u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700100000;
-    });
-    client.approve_renewal(&sub_id, &1, &1000, &200);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260301, &false);
+    env.ledger().with_mut(|li| { li.timestamp = 1700100000; });
+    client.approve_renewal(&sub_id, &1, &1000, &200).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20260301, &false).unwrap();
 
-    let lc = client.get_lifecycle(&sub_id);
-    assert_eq!(lc.last_renewed_at, 0); // unchanged on failure
-    assert_eq!(lc.activated_at, 1700000000); // unchanged
+    let lc = client.get_lifecycle(&sub_id).unwrap();
+    assert_eq!(lc.last_renewed_at, 0);
+    assert_eq!(lc.activated_at, 1700000000);
 }
 
 #[test]
@@ -999,221 +848,182 @@ fn test_lifecycle_multiple_renewals_update_last_renewed() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
 
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700000000;
-    });
-
+    env.ledger().with_mut(|li| { li.timestamp = 1700000000; });
     let user = Address::generate(&env);
-    let sub_id = 805;
-
+    let sub_id = 805u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // First renewal
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700100000;
-    });
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260401, &true);
+    env.ledger().with_mut(|li| { li.timestamp = 1700100000; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &1, &500, &3, &10, &20260401, &true).unwrap();
+    assert_eq!(client.get_lifecycle(&sub_id).unwrap().last_renewed_at, 1700100000);
 
-    let lc = client.get_lifecycle(&sub_id);
-    assert_eq!(lc.last_renewed_at, 1700100000);
+    env.ledger().with_mut(|li| { li.timestamp = 1700200000; });
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    client.renew(&sub_id, &2, &500, &3, &10, &20260501, &true).unwrap();
 
-    // Second renewal
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1700200000;
-    });
-    client.approve_renewal(&sub_id, &2, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &2, &500, &3, &10, &20260501, &true);
-
-    let lc = client.get_lifecycle(&sub_id);
+    let lc = client.get_lifecycle(&sub_id).unwrap();
     assert_eq!(lc.last_renewed_at, 1700200000);
-    assert_eq!(lc.created_at, 1700000000); // unchanged
+    assert_eq!(lc.created_at, 1700000000);
 }
 
 #[test]
-#[should_panic(expected = "Lifecycle data not found")]
 fn test_get_lifecycle_nonexistent_sub() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    client.get_lifecycle(&999);
+
+    let err = client.try_get_lifecycle(&999u64).unwrap_err().unwrap();
+    assert_eq!(err, ContractError::LifecycleNotFound);
 }
 
-// ── Renewal window invariant tests (I-W1..I-W5) ──────────────────
+// ── Renewal window tests ──────────────────────────────────────────
 
-/// I-W1: billing_start must be strictly less than billing_end.
 #[test]
-#[should_panic(expected = "Invalid window: start must be before end")]
 fn test_window_start_must_be_before_end() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    let user = Address::generate(&env);
-    let sub_id = 900u64;
-    let merchant = Address::generate(&env);
-    client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    // start == end — should panic
-    client.set_window(&sub_id, &1735689600u64, &1735689600u64);
+
+    let err = client
+        .try_set_window(&900u64, &1735689600u64, &1735689600u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidWindow);
 }
 
-/// I-W1: start > end is also rejected.
 #[test]
-#[should_panic(expected = "Invalid window: start must be before end")]
 fn test_window_start_after_end_rejected() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
-    let user = Address::generate(&env);
-    let sub_id = 901u64;
-    let merchant = Address::generate(&env);
-    client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
-    // start > end — should panic
-    client.set_window(&sub_id, &1735862400u64, &1735689600u64);
+
+    let err = client
+        .try_set_window(&901u64, &1735862400u64, &1735689600u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidWindow);
 }
 
-/// I-W2: renew() succeeds when current timestamp is within the window.
 #[test]
 fn test_renew_within_window_succeeds() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 902u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.set_window(&sub_id, &1000u64, &2000u64).unwrap();
 
-    // Window: [1000, 2000]
-    client.set_window(&sub_id, &1000u64, &2000u64);
-
-    // Set ledger timestamp inside the window
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1500;
-    });
-
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true);
+    env.ledger().with_mut(|li| { li.timestamp = 1500; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true).unwrap();
     assert!(result);
 }
 
-/// I-W2: renew() panics when current timestamp is before billing_start.
 #[test]
-#[should_panic(expected = "Outside renewal window")]
-fn test_renew_before_window_panics() {
+fn test_renew_before_window_fails() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 903u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.set_window(&sub_id, &1000u64, &2000u64).unwrap();
 
-    // Window: [1000, 2000]
-    client.set_window(&sub_id, &1000u64, &2000u64);
-
-    // Set ledger timestamp before the window
-    env.ledger().with_mut(|li| {
-        li.timestamp = 500;
-    });
-
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true);
+    env.ledger().with_mut(|li| { li.timestamp = 500; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::OutsideRenewalWindow);
 }
 
-/// I-W2: renew() panics when current timestamp is after billing_end.
 #[test]
-#[should_panic(expected = "Outside renewal window")]
-fn test_renew_after_window_panics() {
+fn test_renew_after_window_fails() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 904u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.set_window(&sub_id, &1000u64, &2000u64).unwrap();
 
-    // Window: [1000, 2000]
-    client.set_window(&sub_id, &1000u64, &2000u64);
-
-    // Set ledger timestamp after the window
-    env.ledger().with_mut(|li| {
-        li.timestamp = 2500;
-    });
-
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true);
+    env.ledger().with_mut(|li| { li.timestamp = 2500; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::OutsideRenewalWindow);
 }
 
-/// I-W3: renew() succeeds with no time restriction when no window is set.
 #[test]
 fn test_renew_without_window_has_no_time_restriction() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 905u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
 
-    // No set_window call — window is optional
-    env.ledger().with_mut(|li| {
-        li.timestamp = 9999999999;
-    });
-
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true);
+    env.ledger().with_mut(|li| { li.timestamp = 9999999999; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true).unwrap();
     assert!(result);
 }
 
-/// I-W4: Only the subscription owner can set the window.
 #[test]
-fn test_set_window_owner_only() {
+fn test_set_and_get_window() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 906u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.set_window(&sub_id, &1000u64, &2000u64).unwrap();
 
-    // Owner sets window — should succeed
-    client.set_window(&sub_id, &1000u64, &2000u64);
-
-    let window = client.get_window(&sub_id);
-    assert!(window.is_some());
-    let w = window.unwrap();
+    let w = client.get_window(&sub_id).unwrap();
     assert_eq!(w.billing_start, 1000);
     assert_eq!(w.billing_end, 2000);
 }
 
-/// I-W5: renew() fails outside the window and succeeds when moved inside.
 #[test]
 fn test_approval_consumed_before_window_check() {
     let (env, id, _admin) = setup();
     let client = SubscriptionRenewalContractClient::new(&env, &id);
+
     let user = Address::generate(&env);
     let sub_id = 907u64;
     let merchant = Address::generate(&env);
     client.init_sub(&user, &merchant, &500, &86400, &1000, &sub_id);
+    client.set_window(&sub_id, &1000u64, &2000u64).unwrap();
 
-    // Window: [1000, 2000]
-    client.set_window(&sub_id, &1000u64, &2000u64);
+    // outside window — renew should fail with OutsideRenewalWindow
+    env.ledger().with_mut(|li| { li.timestamp = 500; });
+    client.approve_renewal(&sub_id, &1, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let err = client
+        .try_renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::OutsideRenewalWindow);
 
-    // Timestamp outside window — renew should fail
-    env.ledger().with_mut(|li| {
-        li.timestamp = 500;
-    });
-    client.approve_renewal(&sub_id, &1, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result = client.try_renew(&sub_id, &1, &500, &3, &10, &20260101u64, &true);
-    assert!(result.is_err());
-
-    // Release the lock (held from before the failed renew) and move inside the window
-    client.release_renewal_lock(&sub_id);
-    env.ledger().with_mut(|li| {
-        li.timestamp = 1500;
-    });
-    // Renew with a fresh approval inside the window — should succeed
-    client.approve_renewal(&sub_id, &2, &1000, &100);
-    client.acquire_renewal_lock(&sub_id, &200);
-    let result2 = client.renew(&sub_id, &2, &500, &3, &10, &20260102u64, &true);
-    assert!(result2);
+    // release lock, move inside window, use a fresh approval
+    client.release_renewal_lock(&sub_id).unwrap();
+    env.ledger().with_mut(|li| { li.timestamp = 1500; });
+    client.approve_renewal(&sub_id, &2, &1000, &100).unwrap();
+    client.acquire_renewal_lock(&sub_id, &200).unwrap();
+    let result = client.renew(&sub_id, &2, &500, &3, &10, &20260102u64, &true).unwrap();
+    assert!(result);
 }


### PR DESCRIPTION


Closes #1053

- Add ContractError #[contracterror] enum (19 variants, discriminants 1-19)
- Convert init, set_paused, set_logging_contract, acquire_renewal_lock, release_renewal_lock, cancel_sub, approve_renewal, renew, get_sub, get_lifecycle, set_window, set_user_cap to return Result<T, ContractError>
- Replace every panic!/expect()/unwrap() on user-reachable paths with typed Err(ContractError::*) — zero bare panics remain
- Rename IntegrityViolation/RenewalLockExpired event structs to IntegrityViolationEvent/RenewalLockExpiredEvent to avoid clash with enum
- Update all #[should_panic] tests to use try_* client methods and assert_eq!(err, ContractError::Variant) patterns
- Update fuzz tests: remove catch_unwind, assert typed error codes instead
- No logic changes; all invariants and spending caps preserved


## Description

Briefly describe what this PR does.

---

## Related Issue

Closes #

---

## Test Plan

- [ ] Tested locally
- [ ] Verified expected behavior
- [ ] No regressions introduced

---

## Screenshots (if applicable)

---

## Checklist

- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Follows project conventions
- [ ] No sensitive data exposed
