### PR TITLE
retain PaymentIntent metadata needed by webhooks

### DIFF
--- a/client/lib/payment-service.ts
+++ b/client/lib/payment-service.ts
@@ -4,6 +4,7 @@ import { getStripeInstance } from "./stripe-config"
 import { getPayPalService } from "./paypal-service"
 import { getPaystackService } from "./paystack-service"
 import { isPaymentProviderEnabled } from "./feature-flags"
+import { randomUUID } from "crypto"
 
 export interface PaymentConfig {
   provider: "stripe" | "paypal" | "mock" | "paystack"
@@ -48,7 +49,7 @@ export class PaymentService {
 
     try {
       if (this.provider === "stripe") {
-        result = await this.processStripePayment(amount, currency, paymentMethodId)
+        result = await this.processStripePayment(amount, currency, paymentMethodId, metadata)
       } else if (this.provider === "paypal") {
         result = await this.processPayPalPayment(amount, currency, paymentMethodId, metadata)
       } else if (this.provider === "paystack") {
@@ -102,13 +103,22 @@ export class PaymentService {
   private async processStripePayment(
     amount: number,
     currency: string,
-    paymentMethodId: string
+    paymentMethodId: string,
+    metadata: any = {}
   ): Promise<PaymentResult> {
     if (!this.stripe) {
       return { success: false, transactionId: "", error: "Stripe not configured" }
     }
 
     try {
+      // Sanitize metadata to only allowed non-sensitive fields
+      const allowedKeys = ["userId", "planName", "requestId"]
+      const sanitized: any = {}
+      for (const key of allowedKeys) {
+        if (metadata[key]) sanitized[key] = metadata[key]
+      }
+      // Ensure a correlation requestId exists
+      if (!sanitized.requestId) sanitized.requestId = randomUUID()
       const paymentIntent = await this.stripe.paymentIntents.create({
         amount: Math.round(amount * 100), // Convert to cents
         currency,
@@ -119,6 +129,7 @@ export class PaymentService {
           enabled: true,
           allow_redirects: "never",
         },
+        metadata: sanitized,
       })
 
       return {

--- a/tests/payment-service.test.ts
+++ b/tests/payment-service.test.ts
@@ -1,0 +1,62 @@
+// tests/payment-service.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PaymentService, PaymentConfig } from '../client/lib/payment-service'
+
+// Mock Stripe instance
+vi.mock('../client/lib/stripe-config', () => ({
+  getStripeInstance: vi.fn(),
+}))
+
+// Mock randomUUID for deterministic requestId
+vi.mock('crypto', () => ({
+  randomUUID: vi.fn(() => 'test-request-id'),
+}))
+
+// Mock supabase client to avoid DB calls
+vi.mock('../client/lib/supabase/server', () => ({
+  createClient: vi.fn(() => ({
+    from: () => ({
+      select: () => ({ single: () => ({ data: null }) }),
+      insert: () => ({}),
+      update: () => ({}),
+    }),
+  })),
+}))
+
+describe('PaymentService Stripe metadata handling', () => {
+  let service: PaymentService
+  const mockCreate = vi.fn()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    const { getStripeInstance } = require('../client/lib/stripe-config')
+    getStripeInstance.mockReturnValue({
+      paymentIntents: { create: mockCreate },
+    })
+    const config: PaymentConfig = { provider: 'stripe' }
+    service = new PaymentService(config)
+  })
+
+  it('passes allowed metadata and generates requestId', async () => {
+    mockCreate.mockResolvedValue({ status: 'succeeded', id: 'pi_123' })
+    const metadata = { userId: 'user-1', planName: 'gold', extra: 'secret' }
+    const result = await service.processPayment(10, 'usd', 'pm_abc', metadata)
+    expect(result.success).toBe(true)
+    expect(mockCreate).toHaveBeenCalledOnce()
+    const payload = mockCreate.mock.calls[0][0]
+    expect(payload.metadata).toEqual({
+      userId: 'user-1',
+      planName: 'gold',
+      requestId: 'test-request-id',
+    })
+    expect(payload.metadata).not.toHaveProperty('extra')
+  })
+
+  it('uses existing requestId if provided', async () => {
+    mockCreate.mockResolvedValue({ status: 'succeeded', id: 'pi_456' })
+    const metadata = { userId: 'u2', planName: 'silver', requestId: 'existing-id' }
+    await service.processPayment(20, 'usd', 'pm_def', metadata)
+    const payload = mockCreate.mock.calls[0][0]
+    expect(payload.metadata?.requestId).toBe('existing-id')
+  })
+})


### PR DESCRIPTION
I implemented retain PaymentIntent metadata needed by webhooks.



This PR closes #1145 