### PR TITLE
fix: scope PayPal webhook processed update by provider

### DIFF
--- a/client/app/api/webhooks/paypal/route.ts
+++ b/client/app/api/webhooks/paypal/route.ts
@@ -232,7 +232,11 @@ export async function POST(request: NextRequest) {
         await supabase
             .from('webhook_events')
             .update({ processed: true, processed_at: new Date().toISOString() })
-            .eq('id', newRecord.id)
+            // Keep the state transition in the same provider/event namespace as
+            // the idempotency check. This prevents an identical event ID from a
+            // different provider ever being updated by this handler.
+            .eq('provider', 'paypal')
+            .eq('event_id', event.id)
 
         return NextResponse.json({ received: true })
     } catch (error) {


### PR DESCRIPTION
## Summary
Scopes the PayPal processed-state update by both `provider` and `event_id`, matching the idempotency lookup namespace and preventing cross-provider event-ID updates.

The existing `webhook_events_provider_event_id_unique` constraint already enforces the provider/event invariant; no backfill is needed because the stored schema already contains this constraint.

Closes #1149.